### PR TITLE
File monitor improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: generic
 
-branches:
-  only:
-    - master
-
 os: linux
 compiler: gcc
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # libfly
 ##fly, a C++ utility library for Linux and Windows.
-[![Build Status](https://travis-ci.org/trflynn89/libfly.svg?branch=master)](https://travis-ci.org/trflynn89/libfly) [![Build status](https://ci.appveyor.com/api/projects/status/j9dncuoismnwcu5r?svg=true)](https://ci.appveyor.com/project/trflynn89/libfly)
- [![codecov](https://codecov.io/gh/trflynn89/libfly/branch/master/graph/badge.svg)](https://codecov.io/gh/trflynn89/libfly)
+[![Build Status](https://travis-ci.org/trflynn89/libfly.svg?branch=file_monitor)](https://travis-ci.org/trflynn89/libfly) [![Build status](https://ci.appveyor.com/api/projects/status/j9dncuoismnwcu5r/branch/file_monitor?svg=true)](https://ci.appveyor.com/project/trflynn89/libfly/branch/file_monitor)
+ [![codecov](https://codecov.io/gh/trflynn89/libfly/branch/file_monitor/graph/badge.svg)](https://codecov.io/gh/trflynn89/libfly)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # libfly
 ##fly, a C++ utility library for Linux and Windows.
-[![Build Status](https://travis-ci.org/trflynn89/libfly.svg?branch=file_monitor)](https://travis-ci.org/trflynn89/libfly) [![Build status](https://ci.appveyor.com/api/projects/status/j9dncuoismnwcu5r/branch/file_monitor?svg=true)](https://ci.appveyor.com/project/trflynn89/libfly/branch/file_monitor)
- [![codecov](https://codecov.io/gh/trflynn89/libfly/branch/file_monitor/graph/badge.svg)](https://codecov.io/gh/trflynn89/libfly)
+[![Build Status](https://travis-ci.org/trflynn89/libfly.svg?branch=master)](https://travis-ci.org/trflynn89/libfly) [![Build status](https://ci.appveyor.com/api/projects/status/j9dncuoismnwcu5r/branch/master?svg=true)](https://ci.appveyor.com/project/trflynn89/libfly/branch/master)
+ [![codecov](https://codecov.io/gh/trflynn89/libfly/branch/master/graph/badge.svg)](https://codecov.io/gh/trflynn89/libfly)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,5 @@
 version: "{build}"
 
-branches:
-  only:
-    - master
-
 os: Visual Studio 2015
 
 init:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,12 +2,6 @@ version: "{build}"
 
 os: Visual Studio 2015
 
-init:
-  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
-
-on_finish:
-  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
-
 install:
   - ps: $env:libfly_version = (Get-Content -Raw -Path VERSION.md)
   - ps: Update-AppveyorBuild -Version "$env:libfly_version-$env:APPVEYOR_BUILD_NUMBER"

--- a/fly/concurrency/concurrent_container.h
+++ b/fly/concurrency/concurrent_container.h
@@ -48,19 +48,6 @@ public:
     bool Pop(T &, std::chrono::duration<R, P>);
 
     /**
-     * Pop an item from the container. If the container is empty, wait (at most)
-     * for the specified amount of time for an item to be available.
-     *
-     * @param T Reference to an object of type T where the item will be stored.
-     * @param duration The amount of time to wait.
-     * @param bool True if the container should be cleared after popping.
-     *
-     * @return True if an object was popped in the given duration.
-     */
-    template <typename R, typename P>
-    bool Pop(T &, std::chrono::duration<R, P>, bool);
-
-    /**
      * @return True if the container is empty, false otherwise.
      */
     bool IsEmpty() const;
@@ -125,17 +112,6 @@ bool ConcurrentContainer<T, Container>::Pop(
     std::chrono::duration<R, P> waitTime
 )
 {
-    return Pop(item, waitTime, false);
-}
-
-//==============================================================================
-template <typename T, typename Container> template <typename R, typename P>
-bool ConcurrentContainer<T, Container>::Pop(
-    T &item,
-    std::chrono::duration<R, P> waitTime,
-    bool clear
-)
-{
     std::unique_lock<std::mutex> lock(m_containerMutex);
 
     auto emptyTest = [&] { return !m_container.empty(); };
@@ -144,11 +120,6 @@ bool ConcurrentContainer<T, Container>::Pop(
     if (itemPopped)
     {
         pop(item);
-
-        if (clear)
-        {
-            Container().swap(m_container);
-        }
     }
 
     return itemPopped;

--- a/fly/config/config_manager.h
+++ b/fly/config/config_manager.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -94,16 +95,13 @@ protected:
     bool DoWork();
 
 private:
-    /**
-     * Handle an update to the configuration file on disk.
-     */
-    void onConfigChange(FileMonitor::FileEvent);
-
     FileMonitorPtr m_spMonitor;
     ParserPtr m_spParser;
 
     const std::string m_path;
     const std::string m_file;
+
+    std::atomic_bool m_aFileChanged;
 
     mutable std::mutex m_configsMutex;
     ConfigMap m_configs;

--- a/fly/file/file_monitor.cpp
+++ b/fly/file/file_monitor.cpp
@@ -6,26 +6,19 @@ namespace fly {
 
 namespace
 {
+    // TODO make configurable
     static const std::chrono::milliseconds s_pollTimeout(1000);
 }
 
 //==============================================================================
-FileMonitor::FileMonitor(
-    FileEventCallback handler,
-    const std::string &path,
-    const std::string &file
-) :
-    Runner("FileMonitor", 1),
-    m_path(path),
-    m_file(file),
-    m_handler(handler),
-    m_interval(0)
+FileMonitor::FileMonitor() : Runner("FileMonitor", 1)
 {
 }
 
 //==============================================================================
 FileMonitor::~FileMonitor()
 {
+    Stop();
 }
 
 //==============================================================================
@@ -37,48 +30,18 @@ bool FileMonitor::StartRunner()
 //==============================================================================
 void FileMonitor::StopRunner()
 {
-    std::lock_guard<std::mutex> lock(m_callbackMutex);
-    m_handler = nullptr;
+    Close();
 }
 
 //==============================================================================
 bool FileMonitor::DoWork()
 {
-    static const std::chrono::seconds noWait(std::chrono::seconds::zero());
-    static const size_t updateInterval(5);
-
     if (IsValid())
     {
         Poll(s_pollTimeout);
-
-        if ((++m_interval % updateInterval) == 0)
-        {
-            FileEvent event = FileMonitor::FILE_NO_CHANGE;
-            m_eventStack.Pop(event, noWait, true);
-
-            if (event != FileMonitor::FILE_NO_CHANGE)
-            {
-                std::lock_guard<std::mutex> lock(m_callbackMutex);
-
-                if (m_handler != nullptr)
-                {
-                    LOGI(-1, "Handling event %d for \"%s\"", event, m_file);
-                    m_handler(event);
-                }
-            }
-        }
     }
 
     return IsValid();
-}
-
-//==============================================================================
-void FileMonitor::HandleEvent(FileEvent event)
-{
-    if (event != FileMonitor::FILE_NO_CHANGE)
-    {
-        m_eventStack.Push(event);
-    }
 }
 
 }

--- a/fly/file/file_monitor.cpp
+++ b/fly/file/file_monitor.cpp
@@ -1,5 +1,6 @@
 #include "file_monitor.h"
 
+#include <fly/file/file_monitor_impl.h>
 #include <fly/logging/logger.h>
 
 namespace fly {
@@ -19,6 +20,81 @@ FileMonitor::FileMonitor() : Runner("FileMonitor", 1)
 FileMonitor::~FileMonitor()
 {
     Stop();
+}
+
+//==============================================================================
+bool FileMonitor::AddFile(
+    const std::string &path,
+    const std::string &file,
+    FileEventCallback callback
+)
+{
+    if (callback == nullptr)
+    {
+        LOGW(-1, "Ignoring NULL callback for \"%s\"", path);
+        return false;
+    }
+
+    PathInfoPtr spInfo;
+
+    std::lock_guard<std::mutex> lock(m_mutex);
+    auto it = m_pathInfo.find(path);
+
+    if (it == m_pathInfo.end())
+    {
+        FileMonitorPtr spMonitor = SharedFromThis<FileMonitor>();
+        spInfo = std::make_shared<FileMonitorImpl::PathInfoImpl>(spMonitor, path);
+
+        if (spInfo->IsValid())
+        {
+            m_pathInfo[path] = spInfo;
+        }
+        else
+        {
+            return false;
+        }
+    }
+    else
+    {
+        spInfo = it->second;
+    }
+
+    LOGD(-1, "Watching for changes to \"%s\" in \"%s\"", file, path);
+    spInfo->m_handlers[file] = callback;
+
+    return true;
+}
+
+//==============================================================================
+bool FileMonitor::RemoveFile(const std::string &path, const std::string &file)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    auto it = m_pathInfo.find(path);
+
+    if (it != m_pathInfo.end())
+    {
+        PathInfoPtr spInfo(it->second);
+
+        auto it2 = spInfo->m_handlers.find(file);
+
+        if (it2 != spInfo->m_handlers.end())
+        {
+            LOGD(-1, "Stopped watching for changes to \"%s\" in \"%s\"", file, path);
+            spInfo->m_handlers.erase(it2);
+
+            if (spInfo->m_handlers.empty())
+            {
+                LOGI(-1, "Removed watcher for \"%s\"", path);
+                m_pathInfo.erase(it);
+            }
+
+            return true;
+        }
+    }
+
+    LOGW(-1, "Not watching for changes to \"%s\" in \"%s\"", file, path);
+    return false;
 }
 
 //==============================================================================

--- a/fly/file/file_monitor.h
+++ b/fly/file/file_monitor.h
@@ -64,6 +64,8 @@ public:
      * @param string Directory containing the file to start monitoring.
      * @param string Name of the file to start monitoring.
      * @param FileEventCallback Callback to trigger when the file changes.
+     *
+     * @return bool True if the file could be added.
      */
     bool AddFile(const std::string &, const std::string &, FileEventCallback);
 
@@ -72,8 +74,24 @@ public:
      *
      * @param string Directory containing the file to stop monitoring.
      * @param string Name of the file to stop monitoring.
+     *
+     * @return bool True if the file was removed.
      */
     bool RemoveFile(const std::string &, const std::string &);
+
+    /**
+     * Stop monitoring all files under the given path.
+     *
+     * @param string Directory containing the files to stop monitoring.
+     *
+     * @return bool True if the path was removed.
+     */
+    bool RemovePath(const std::string &);
+
+    /**
+     * Stop monitoring all files.
+     */
+    void RemoveAllPaths();
 
 protected:
     DEFINE_STRUCT_PTRS(PathInfo);

--- a/fly/file/nix_file_monitor.cpp
+++ b/fly/file/nix_file_monitor.cpp
@@ -28,10 +28,8 @@ namespace
 //==============================================================================
 FileMonitorImpl::FileMonitorImpl() :
     FileMonitor(),
-    m_monitorDescriptor(-1)
+    m_monitorDescriptor(::inotify_init1(s_initFlags))
 {
-    m_monitorDescriptor = ::inotify_init1(s_initFlags);
-
     if (m_monitorDescriptor == -1)
     {
         LOGW(-1, "Could not initialize monitor: %s", fly::System::GetLastError());
@@ -235,7 +233,7 @@ void FileMonitorImpl::handleEvent(const struct inotify_event *pEvent)
         if ((callback != nullptr) && (event != FileMonitor::FILE_NO_CHANGE))
         {
             LOGI(-1, "Handling event %d for \"%s\" in \"%s\"",
-                event, it->first, pEvent->name);
+                event, pEvent->name, it->first);
 
             callback(it->first, pEvent->name, event);
         }

--- a/fly/file/nix_file_monitor.cpp
+++ b/fly/file/nix_file_monitor.cpp
@@ -149,7 +149,7 @@ void FileMonitorImpl::handleEvent(const struct inotify_event *pEvent) const
     {
         PathInfoImplPtr spInfo(DownCast<PathInfoImpl>(it->second));
 
-        FileEventCallback &callback = spInfo->m_handlers[pEvent->name];
+        FileMonitor::FileEventCallback &callback = spInfo->m_handlers[pEvent->name];
         FileMonitor::FileEvent event = convertToEvent(pEvent->mask);
 
         if ((callback != nullptr) && (event != FileMonitor::FILE_NO_CHANGE))

--- a/fly/file/nix_file_monitor.cpp
+++ b/fly/file/nix_file_monitor.cpp
@@ -124,7 +124,6 @@ bool FileMonitorImpl::RemoveFile(const std::string &path, const std::string &fil
 //==============================================================================
 void FileMonitorImpl::Poll(const std::chrono::milliseconds &timeout)
 {
-    std::lock_guard<std::mutex> lock(m_mutex);
     struct pollfd pollFd;
 
     pollFd.fd = m_monitorDescriptor;
@@ -138,6 +137,8 @@ void FileMonitorImpl::Poll(const std::chrono::milliseconds &timeout)
     }
     else if ((numEvents > 0) && (pollFd.revents & POLLIN))
     {
+        std::lock_guard<std::mutex> lock(m_mutex);
+
         while (readEvents())
         {
         }

--- a/fly/file/nix_file_monitor.cpp
+++ b/fly/file/nix_file_monitor.cpp
@@ -228,7 +228,7 @@ void FileMonitorImpl::handleEvent(const struct inotify_event *pEvent)
 
     if (it != m_monitoredPaths.end())
     {
-        FileEventCallback callback = it->second.m_handlers[pEvent->name];
+        FileEventCallback &callback = it->second.m_handlers[pEvent->name];
         FileMonitor::FileEvent event = convertToEvent(pEvent->mask);
 
         if ((callback != nullptr) && (event != FileMonitor::FILE_NO_CHANGE))

--- a/fly/file/nix_file_monitor.h
+++ b/fly/file/nix_file_monitor.h
@@ -6,7 +6,6 @@
 #include <poll.h>
 #include <string>
 #include <sys/inotify.h>
-#include <vector>
 
 #include <fly/file/file_monitor.h>
 
@@ -76,8 +75,8 @@ private:
     FileMonitor::FileEvent convertToEvent(int);
 
     mutable std::mutex m_mutex;
-    int m_monitorDescriptor;
     PathMap m_monitoredPaths;
+    int m_monitorDescriptor;
 };
 
 }

--- a/fly/file/win_file_monitor.cpp
+++ b/fly/file/win_file_monitor.cpp
@@ -73,6 +73,8 @@ void FileMonitorImpl::Poll(const std::chrono::milliseconds &timeout)
     LPOVERLAPPED pOverlapped = NULL;
     DWORD millis = static_cast<DWORD>(timeout.count());
 
+    std::string pathToRemove;
+
     if (::GetQueuedCompletionStatus(m_iocp, &bytes, &pKey, &pOverlapped, millis))
     {
         std::lock_guard<std::mutex> lock(m_mutex);
@@ -92,9 +94,14 @@ void FileMonitorImpl::Poll(const std::chrono::milliseconds &timeout)
 
             if (!spInfo->Refresh(it->first))
             {
-                m_pathInfo.erase(it);
+                pathToRemove = it->first;
             }
         }
+    }
+
+    if (!pathToRemove.empty())
+    {
+        RemovePath(pathToRemove);
     }
 }
 

--- a/fly/file/win_file_monitor.h
+++ b/fly/file/win_file_monitor.h
@@ -66,7 +66,7 @@ private:
 
         /**
          * Call the ReadDirectoryChangesW API for this path. Should be called
-         * after initialization and each time an IOCP completion is occurs for
+         * after initialization and each time an IOCP completion occurs for
          * this path.
          *
          * @param string Name of the monitored path.
@@ -83,6 +83,7 @@ private:
      * Handle a FILE_NOTIFY_INFORMATION event for a path.
      *
      * @param PathInfoMap::value_type The path's entry in the PathInfoMap.
+     * @param string Name of the path.
      */
     void handleEvents(const PathInfoImplPtr &, const std::string &) const;
 

--- a/fly/fly.h
+++ b/fly/fly.h
@@ -30,3 +30,25 @@
     typedef std::shared_ptr<classname> classname##Ptr;  \
     typedef std::unique_ptr<classname> classname##UPtr; \
     typedef std::weak_ptr<classname> classname##WPtr;
+
+// Typedefs for struct name and smart pointers
+#define DEFINE_STRUCT_PTRS(structname)                    \
+    struct structname;                                    \
+    typedef std::shared_ptr<structname> structname##Ptr;  \
+    typedef std::unique_ptr<structname> structname##UPtr; \
+    typedef std::weak_ptr<structname> structname##WPtr;
+
+/**
+ * Wrapper around static_pointer_cast to create a compile error if type of the
+ * given shared_ptr is not a parent of the desired type.
+ *
+ * @param shared_ptr The shared pointer to down cast.
+ *
+ * @return shared_ptr The casted shared pointer.
+ */
+template <typename T, typename U>
+static std::shared_ptr<T> DownCast(const std::shared_ptr<U> &spObject)
+{
+    static_assert(std::is_base_of<U, T>::value, "Type T is not derived from type U");
+    return std::static_pointer_cast<T>(spObject);
+}

--- a/fly/system/nix_system.cpp
+++ b/fly/system/nix_system.cpp
@@ -5,6 +5,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <execinfo.h>
+#include <fts.h>
 #include <signal.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -96,6 +97,65 @@ bool SystemImpl::MakeDirectory(const std::string &path)
     }
 
     return ((::mkdir(path.c_str(), mode) == 0) || (errno == EEXIST));
+}
+
+//==============================================================================
+bool SystemImpl::RemoveDirectory(const std::string &path)
+{
+    static const int mode = FTS_NOCHDIR | FTS_PHYSICAL | FTS_XDEV;
+    struct stat st;
+
+    bool ret = ((::stat(path.c_str(), &st) == 0) && S_ISDIR(st.st_mode));
+
+    if (ret)
+    {
+        char *files[] = { (char *)path.c_str(), NULL };
+
+        FTS *pFts = fts_open(files, mode, NULL);
+        FTSENT *pCurr = NULL;
+
+        while (ret && (pFts != NULL) && ((pCurr = fts_read(pFts)) != NULL))
+        {
+            std::string file(pCurr->fts_path, pCurr->fts_pathlen);
+
+            switch(pCurr->fts_info)
+            {
+            case FTS_NS:
+            case FTS_DNR:
+            case FTS_ERR:
+                LOGW(-1, "Could not read \"%s\": %s", file, strerror(pCurr->fts_errno));
+                ret = false;
+                break;
+
+            case FTS_DP:
+            case FTS_F:
+            case FTS_SL:
+            case FTS_SLNONE:
+            case FTS_DEFAULT:
+                if (::remove(pCurr->fts_accpath) == 0)
+                {
+                    LOGD(-1, "Removed \"%s\"", file);
+                }
+                else
+                {
+                    LOGW(-1, "Could not remove \"%s\": %s", file, GetLastError(NULL));
+                    ret = false;
+                }
+
+                break;
+
+            default:
+                break;
+            }
+        }
+
+        if (pFts != NULL)
+        {
+            fts_close(pFts);
+        }
+    }
+
+    return ret;
 }
 
 //==============================================================================

--- a/fly/system/nix_system.cpp
+++ b/fly/system/nix_system.cpp
@@ -70,7 +70,7 @@ namespace
 }
 
 //==============================================================================
-bool SystemImpl::MakeDirectory(const std::string &path)
+bool SystemImpl::MakePath(const std::string &path)
 {
     static const mode_t mode = S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH;
     struct stat st;
@@ -90,7 +90,7 @@ bool SystemImpl::MakeDirectory(const std::string &path)
 
     if (pos != std::string::npos)
     {
-        if (!MakeDirectory(path.substr(0, pos)))
+        if (!MakePath(path.substr(0, pos)))
         {
             return false;
         }
@@ -100,7 +100,7 @@ bool SystemImpl::MakeDirectory(const std::string &path)
 }
 
 //==============================================================================
-bool SystemImpl::RemoveDirectory(const std::string &path)
+bool SystemImpl::RemovePath(const std::string &path)
 {
     static const int mode = FTS_NOCHDIR | FTS_PHYSICAL | FTS_XDEV;
     struct stat st;

--- a/fly/system/nix_system.h
+++ b/fly/system/nix_system.h
@@ -17,6 +17,7 @@ class SystemImpl
 {
 public:
     static bool MakeDirectory(const std::string &);
+    static bool RemoveDirectory(const std::string &);
     static char GetSeparator();
     static std::string GetTempDirectory();
     static void PrintBacktrace();

--- a/fly/system/nix_system.h
+++ b/fly/system/nix_system.h
@@ -16,8 +16,8 @@ namespace fly {
 class SystemImpl
 {
 public:
-    static bool MakeDirectory(const std::string &);
-    static bool RemoveDirectory(const std::string &);
+    static bool MakePath(const std::string &);
+    static bool RemovePath(const std::string &);
     static char GetSeparator();
     static std::string GetTempDirectory();
     static void PrintBacktrace();

--- a/fly/system/system.cpp
+++ b/fly/system/system.cpp
@@ -15,6 +15,12 @@ bool System::MakeDirectory(const std::string &path)
 }
 
 //==============================================================================
+bool System::RemoveDirectory(const std::string &path)
+{
+    return SystemImpl::RemoveDirectory(path);
+}
+
+//==============================================================================
 char System::GetSeparator()
 {
     return SystemImpl::GetSeparator();

--- a/fly/system/system.cpp
+++ b/fly/system/system.cpp
@@ -9,15 +9,15 @@
 namespace fly {
 
 //==============================================================================
-bool System::MakeDirectory(const std::string &path)
+bool System::MakePath(const std::string &path)
 {
-    return SystemImpl::MakeDirectory(path);
+    return SystemImpl::MakePath(path);
 }
 
 //==============================================================================
-bool System::RemoveDirectory(const std::string &path)
+bool System::RemovePath(const std::string &path)
 {
-    return SystemImpl::RemoveDirectory(path);
+    return SystemImpl::RemovePath(path);
 }
 
 //==============================================================================

--- a/fly/system/system.h
+++ b/fly/system/system.h
@@ -28,6 +28,15 @@ public:
     static bool MakeDirectory(const std::string &);
 
     /**
+     * Remove a directory.
+     *
+     * @param std::string Path to the directory to remove.
+     *
+     * @return True if the directory could be removed.
+     */
+    static bool RemoveDirectory(const std::string &);
+
+    /**
      * @return The system's path separator.
      */
     static char GetSeparator();

--- a/fly/system/system.h
+++ b/fly/system/system.h
@@ -25,7 +25,7 @@ public:
      *
      * @return True if the directory could be created (or already exists).
      */
-    static bool MakeDirectory(const std::string &);
+    static bool MakePath(const std::string &);
 
     /**
      * Remove a directory.
@@ -34,7 +34,7 @@ public:
      *
      * @return True if the directory could be removed.
      */
-    static bool RemoveDirectory(const std::string &);
+    static bool RemovePath(const std::string &);
 
     /**
      * @return The system's path separator.

--- a/fly/system/win_system.h
+++ b/fly/system/win_system.h
@@ -16,7 +16,8 @@ namespace fly {
 class SystemImpl
 {
 public:
-    static bool MakeDirectory(const std::string &);
+    static bool MakePath(const std::string &);
+    static bool RemovePath(const std::string &);
     static char GetSeparator();
     static std::string GetTempDirectory();
     static void PrintBacktrace();

--- a/fly/task/runner.h
+++ b/fly/task/runner.h
@@ -114,10 +114,7 @@ private:
 template <typename T>
 std::shared_ptr<T> Runner::SharedFromThis()
 {
-    static_assert(std::is_base_of<Runner, T>::value,
-        "Given type is not a runnable type");
-
-    return std::static_pointer_cast<T>(shared_from_this());
+    return DownCast<T>(shared_from_this());
 }
 
 }

--- a/test/concurrency/main.cpp
+++ b/test/concurrency/main.cpp
@@ -41,19 +41,6 @@ namespace
     }
 
     //==========================================================================
-    void DoQueuePopAndClear(
-        ObjectQueue &objectQueue,
-        const Object &expectedObject
-    )
-    {
-        Object object;
-
-        ASSERT_TRUE(objectQueue.Pop(object, std::chrono::milliseconds(0), true));
-        ASSERT_EQ(objectQueue.Size(), 0);
-        ASSERT_EQ(object, expectedObject);
-    }
-
-    //==========================================================================
     unsigned int WriterThread(ObjectQueue &objectQueue)
     {
         unsigned int numWrites = 100;
@@ -181,11 +168,6 @@ TEST(ConcurrencyTest, SingleThreadedTest)
     DoQueuePop(objectQueue, obj1, --size);
     DoQueuePop(objectQueue, obj2, --size);
     DoQueuePop(objectQueue, obj3, --size);
-
-    DoQueuePush(objectQueue, obj1, ++size);
-    DoQueuePush(objectQueue, obj2, ++size);
-    DoQueuePush(objectQueue, obj1, ++size);
-    DoQueuePopAndClear(objectQueue, obj1);
 }
 
 //==============================================================================

--- a/test/config/main.cpp
+++ b/test/config/main.cpp
@@ -94,7 +94,7 @@ public:
      */
     virtual void SetUp()
     {
-        ASSERT_TRUE(fly::System::MakeDirectory(m_path));
+        ASSERT_TRUE(fly::System::MakePath(m_path));
         ASSERT_TRUE(m_spConfigManager->Start());
     }
 
@@ -104,7 +104,7 @@ public:
     virtual void TearDown()
     {
         m_spConfigManager->Stop();
-        ASSERT_TRUE(fly::System::RemoveDirectory(m_path));
+        ASSERT_TRUE(fly::System::RemovePath(m_path));
     }
 
 protected:

--- a/test/config/main.cpp
+++ b/test/config/main.cpp
@@ -95,8 +95,6 @@ public:
     virtual void SetUp()
     {
         ASSERT_TRUE(fly::System::MakeDirectory(m_path));
-        std::remove(GetFullPath().c_str());
-
         ASSERT_TRUE(m_spConfigManager->Start());
     }
 
@@ -106,7 +104,7 @@ public:
     virtual void TearDown()
     {
         m_spConfigManager->Stop();
-        std::remove(m_path.c_str());
+        ASSERT_TRUE(fly::System::RemoveDirectory(m_path));
     }
 
 protected:

--- a/test/file/file_monitor_test.cpp
+++ b/test/file/file_monitor_test.cpp
@@ -1,6 +1,7 @@
 #include <cstdio>
 #include <fstream>
 #include <functional>
+#include <map>
 #include <sstream>
 
 #include <gtest/gtest.h>
@@ -15,17 +16,23 @@ class FileMonitorTest : public ::testing::Test
 {
 public:
     FileMonitorTest() :
-        m_spMonitor(),
-        m_path(fly::System::Join(
+        m_spMonitor(std::make_shared<fly::FileMonitorImpl>()),
+
+        m_path1(fly::System::Join(
             fly::System::GetTempDirectory(), fly::String::GenerateRandomString(10)
         )),
-        m_file(fly::String::GenerateRandomString(10) + ".txt"),
-        m_numCreatedFiles(0),
-        m_numDeletedFiles(0),
-        m_numChangedFiles(0),
-        m_numOtherEvents(0)
+        m_path2(fly::System::Join(
+            fly::System::GetTempDirectory(), fly::String::GenerateRandomString(10)
+        )),
+
+        m_file1(fly::String::GenerateRandomString(10) + ".txt"),
+        m_file2(fly::String::GenerateRandomString(10) + ".txt"),
+        m_file3(fly::String::GenerateRandomString(10) + ".txt"),
+
+        m_fullPath1(fly::System::Join(m_path1, m_file1)),
+        m_fullPath2(fly::System::Join(m_path1, m_file2)),
+        m_fullPath3(fly::System::Join(m_path2, m_file3))
     {
-        LOGC("Using path '%s' : '%s'", m_path, m_file);
     }
 
     /**
@@ -33,13 +40,16 @@ public:
      */
     virtual void SetUp()
     {
-        ASSERT_TRUE(fly::System::MakeDirectory(m_path));
-        std::remove(GetFullPath().c_str());
+        ASSERT_TRUE(fly::System::MakeDirectory(m_path1));
+        ASSERT_TRUE(fly::System::MakeDirectory(m_path2));
 
-        auto callback = std::bind(&FileMonitorTest::HandleEvent, this, std::placeholders::_1);
-        m_spMonitor = std::make_shared<fly::FileMonitorImpl>(callback, m_path, m_file);
+        auto callback = std::bind(&FileMonitorTest::HandleEvent, this,
+            std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
 
         ASSERT_TRUE(m_spMonitor && m_spMonitor->Start());
+        ASSERT_TRUE(m_spMonitor->AddFile(m_path1, m_file1, callback));
+        ASSERT_TRUE(m_spMonitor->AddFile(m_path1, m_file2, callback));
+        ASSERT_TRUE(m_spMonitor->AddFile(m_path2, m_file3, callback));
     }
 
     /**
@@ -48,33 +58,41 @@ public:
     virtual void TearDown()
     {
         m_spMonitor->Stop();
-        std::remove(m_path.c_str());
+        ASSERT_TRUE(fly::System::RemoveDirectory(m_path1));
+        ASSERT_TRUE(fly::System::RemoveDirectory(m_path2));
     }
 
 protected:
     /**
      * Handle a file change notification.
      *
+     * @param path Path to the changed file.
+     * @param file Name of the changed file.
      * @param FileEvent The type of event that occurred.
      */
-    void HandleEvent(fly::FileMonitor::FileEvent eventType)
+    void HandleEvent(
+        const std::string &path,
+        const std::string &file,
+        fly::FileMonitor::FileEvent eventType)
     {
+        const std::string full = fly::System::Join(path, file);
+
         switch (eventType)
         {
         case fly::FileMonitor::FILE_CREATED:
-            ++m_numCreatedFiles;
+            ++m_numCreatedFiles[full];
             break;
 
         case fly::FileMonitor::FILE_DELETED:
-            ++m_numDeletedFiles;
+            ++m_numDeletedFiles[full];
             break;
 
         case fly::FileMonitor::FILE_CHANGED:
-            ++m_numChangedFiles;
+            ++m_numChangedFiles[full];
             break;
 
         default:
-            ++m_numOtherEvents;
+            ++m_numOtherEvents[full];
             break;
         }
     }
@@ -82,28 +100,19 @@ protected:
     /**
      * Create a file with the given contents.
      *
-     * @param string Contents of the file to create.
-     */
-    void CreateFile(const std::string &contents)
-    {
-        CreateFile(GetFullPath(), contents);
-    }
-
-    /**
-     * Create a file with the given contents.
-     *
+     * @param path Full path to the file to create.
      * @param file Name of the file to create.
      * @param string Contents of the file to create.
      */
-    void CreateFile(const std::string &file, const std::string &contents)
+    void CreateFile(const std::string &path, const std::string &contents)
     {
         {
-            std::ofstream stream(file, std::ios::out);
+            std::ofstream stream(path, std::ios::out);
             ASSERT_TRUE(stream.good());
             stream << contents;
         }
         {
-            std::ifstream stream(file, std::ios::in);
+            std::ifstream stream(path, std::ios::in);
             ASSERT_TRUE(stream.good());
 
             std::stringstream sstream;
@@ -113,152 +122,176 @@ protected:
         }
     }
 
-    /**
-     * @return The full path to the file being monitored.
-     */
-    std::string GetFullPath() const
-    {
-        static const char sep = fly::System::GetSeparator();
-        return fly::String::Join(sep, m_path, m_file);
-    }
-
     fly::FileMonitorPtr m_spMonitor;
 
-    std::string m_path;
-    std::string m_file;
+    std::string m_path1;
+    std::string m_path2;
 
-    unsigned int m_numCreatedFiles;
-    unsigned int m_numDeletedFiles;
-    unsigned int m_numChangedFiles;
-    unsigned int m_numOtherEvents;
+    std::string m_file1;
+    std::string m_file2;
+    std::string m_file3;
+
+    std::string m_fullPath1;
+    std::string m_fullPath2;
+    std::string m_fullPath3;
+
+    std::map<std::string, unsigned int> m_numCreatedFiles;
+    std::map<std::string, unsigned int> m_numDeletedFiles;
+    std::map<std::string, unsigned int> m_numChangedFiles;
+    std::map<std::string, unsigned int> m_numOtherEvents;
 };
 
 //==============================================================================
 TEST_F(FileMonitorTest, NonExistingPathTest)
 {
-    m_spMonitor->Stop();
-    m_spMonitor = std::make_shared<fly::FileMonitorImpl>(nullptr, m_path + "foo", m_file);
-    ASSERT_FALSE(m_spMonitor->Start());
-}
-
-//==============================================================================
-TEST_F(FileMonitorTest, NoChangeTest)
-{
-    EXPECT_EQ(m_numCreatedFiles, 0);
-    EXPECT_EQ(m_numDeletedFiles, 0);
-    EXPECT_EQ(m_numChangedFiles, 0);
-    EXPECT_EQ(m_numOtherEvents, 0);
-
-    std::this_thread::sleep_for(std::chrono::seconds(8));
-
-    EXPECT_EQ(m_numCreatedFiles, 0);
-    EXPECT_EQ(m_numDeletedFiles, 0);
-    EXPECT_EQ(m_numChangedFiles, 0);
-    EXPECT_EQ(m_numOtherEvents, 0);
+    ASSERT_FALSE(m_spMonitor->AddFile(m_path1 + "foo", m_file1, [](...) { }));
 }
 
 //==============================================================================
 TEST_F(FileMonitorTest, NullCallbackTest)
 {
-    m_spMonitor->Stop();
-    m_spMonitor = std::make_shared<fly::FileMonitorImpl>(nullptr, m_path, m_file);
-    ASSERT_TRUE(m_spMonitor->Start());
+    ASSERT_FALSE(m_spMonitor->AddFile(m_path1, m_file1, nullptr));
+}
 
-    EXPECT_EQ(m_numCreatedFiles, 0);
-    EXPECT_EQ(m_numDeletedFiles, 0);
-    EXPECT_EQ(m_numChangedFiles, 0);
-    EXPECT_EQ(m_numOtherEvents, 0);
+//==============================================================================
+TEST_F(FileMonitorTest, NoChangeTest)
+{
+    EXPECT_EQ(m_numCreatedFiles[m_fullPath1], 0);
+    EXPECT_EQ(m_numDeletedFiles[m_fullPath1], 0);
+    EXPECT_EQ(m_numChangedFiles[m_fullPath1], 0);
+    EXPECT_EQ(m_numOtherEvents[m_fullPath1], 0);
 
-    CreateFile(std::string());
-    std::this_thread::sleep_for(std::chrono::seconds(8));
+    std::this_thread::sleep_for(std::chrono::seconds(2));
 
-    EXPECT_EQ(m_numCreatedFiles, 0);
-    EXPECT_EQ(m_numDeletedFiles, 0);
-    EXPECT_EQ(m_numChangedFiles, 0);
-    EXPECT_EQ(m_numOtherEvents, 0);
+    EXPECT_EQ(m_numCreatedFiles[m_fullPath1], 0);
+    EXPECT_EQ(m_numDeletedFiles[m_fullPath1], 0);
+    EXPECT_EQ(m_numChangedFiles[m_fullPath1], 0);
+    EXPECT_EQ(m_numOtherEvents[m_fullPath1], 0);
 }
 
 //==============================================================================
 TEST_F(FileMonitorTest, CreateTest)
 {
-    EXPECT_EQ(m_numCreatedFiles, 0);
-    EXPECT_EQ(m_numDeletedFiles, 0);
-    EXPECT_EQ(m_numChangedFiles, 0);
-    EXPECT_EQ(m_numOtherEvents, 0);
+    EXPECT_EQ(m_numCreatedFiles[m_fullPath1], 0);
+    EXPECT_EQ(m_numDeletedFiles[m_fullPath1], 0);
+    EXPECT_EQ(m_numChangedFiles[m_fullPath1], 0);
+    EXPECT_EQ(m_numOtherEvents[m_fullPath1], 0);
 
-    CreateFile(std::string());
-    std::this_thread::sleep_for(std::chrono::seconds(8));
+    CreateFile(m_fullPath1, std::string());
+    std::this_thread::sleep_for(std::chrono::seconds(2));
 
-    EXPECT_EQ(m_numCreatedFiles, 1);
-    EXPECT_EQ(m_numDeletedFiles, 0);
-    EXPECT_EQ(m_numChangedFiles, 0);
-    EXPECT_EQ(m_numOtherEvents, 0);
+    EXPECT_EQ(m_numCreatedFiles[m_fullPath1], 1);
+    EXPECT_EQ(m_numDeletedFiles[m_fullPath1], 0);
+    EXPECT_EQ(m_numChangedFiles[m_fullPath1], 0);
+    EXPECT_EQ(m_numOtherEvents[m_fullPath1], 0);
 }
 
 //==============================================================================
 TEST_F(FileMonitorTest, DeleteTest)
 {
-    EXPECT_EQ(m_numCreatedFiles, 0);
-    EXPECT_EQ(m_numDeletedFiles, 0);
-    EXPECT_EQ(m_numChangedFiles, 0);
-    EXPECT_EQ(m_numOtherEvents, 0);
+    EXPECT_EQ(m_numCreatedFiles[m_fullPath1], 0);
+    EXPECT_EQ(m_numDeletedFiles[m_fullPath1], 0);
+    EXPECT_EQ(m_numChangedFiles[m_fullPath1], 0);
+    EXPECT_EQ(m_numOtherEvents[m_fullPath1], 0);
 
-    CreateFile(std::string());
-    std::remove(GetFullPath().c_str());
+    CreateFile(m_fullPath1, std::string());
+    std::remove(m_fullPath1.c_str());
 
-    std::this_thread::sleep_for(std::chrono::seconds(8));
+    std::this_thread::sleep_for(std::chrono::seconds(2));
 
-    EXPECT_EQ(m_numCreatedFiles, 0);
-    EXPECT_EQ(m_numDeletedFiles, 1);
-    EXPECT_EQ(m_numChangedFiles, 0);
-    EXPECT_EQ(m_numOtherEvents, 0);
+    EXPECT_EQ(m_numCreatedFiles[m_fullPath1], 1);
+    EXPECT_EQ(m_numDeletedFiles[m_fullPath1], 1);
+    EXPECT_EQ(m_numChangedFiles[m_fullPath1], 0);
+    EXPECT_EQ(m_numOtherEvents[m_fullPath1], 0);
 }
 
 //==============================================================================
 TEST_F(FileMonitorTest, ChangeTest)
 {
-    EXPECT_EQ(m_numCreatedFiles, 0);
-    EXPECT_EQ(m_numDeletedFiles, 0);
-    EXPECT_EQ(m_numChangedFiles, 0);
-    EXPECT_EQ(m_numOtherEvents, 0);
+    EXPECT_EQ(m_numCreatedFiles[m_fullPath1], 0);
+    EXPECT_EQ(m_numDeletedFiles[m_fullPath1], 0);
+    EXPECT_EQ(m_numChangedFiles[m_fullPath1], 0);
+    EXPECT_EQ(m_numOtherEvents[m_fullPath1], 0);
 
-    CreateFile("abcdefghi");
-    std::this_thread::sleep_for(std::chrono::seconds(8));
+    CreateFile(m_fullPath1, "abcdefghi");
+    std::this_thread::sleep_for(std::chrono::seconds(2));
 
-    EXPECT_EQ(m_numCreatedFiles, 0);
-    EXPECT_EQ(m_numDeletedFiles, 0);
-    EXPECT_EQ(m_numChangedFiles, 1);
-    EXPECT_EQ(m_numOtherEvents, 0);
+    EXPECT_EQ(m_numCreatedFiles[m_fullPath1], 1);
+    EXPECT_EQ(m_numDeletedFiles[m_fullPath1], 0);
+    EXPECT_EQ(m_numChangedFiles[m_fullPath1], 1);
+    EXPECT_EQ(m_numOtherEvents[m_fullPath1], 0);
 }
 
 //==============================================================================
 TEST_F(FileMonitorTest, OtherFileTest)
 {
 
-    EXPECT_EQ(m_numCreatedFiles, 0);
-    EXPECT_EQ(m_numDeletedFiles, 0);
-    EXPECT_EQ(m_numChangedFiles, 0);
-    EXPECT_EQ(m_numOtherEvents, 0);
+    EXPECT_EQ(m_numCreatedFiles[m_fullPath1], 0);
+    EXPECT_EQ(m_numDeletedFiles[m_fullPath1], 0);
+    EXPECT_EQ(m_numChangedFiles[m_fullPath1], 0);
+    EXPECT_EQ(m_numOtherEvents[m_fullPath1], 0);
 
-    std::string file = GetFullPath() + ".diff";
-    CreateFile(file, "abcdefghi");
-    std::remove(file.c_str());
+    std::string path = fly::System::Join(m_path1, m_file1 + ".diff");
+    CreateFile(path, "abcdefghi");
 
-    std::this_thread::sleep_for(std::chrono::seconds(8));
+    std::this_thread::sleep_for(std::chrono::seconds(2));
 
-    EXPECT_EQ(m_numCreatedFiles, 0);
-    EXPECT_EQ(m_numDeletedFiles, 0);
-    EXPECT_EQ(m_numChangedFiles, 0);
-    EXPECT_EQ(m_numOtherEvents, 0);
+    EXPECT_EQ(m_numCreatedFiles[m_fullPath1], 0);
+    EXPECT_EQ(m_numDeletedFiles[m_fullPath1], 0);
+    EXPECT_EQ(m_numChangedFiles[m_fullPath1], 0);
+    EXPECT_EQ(m_numOtherEvents[m_fullPath1], 0);
 
-    file = file.substr(0, file.length() - 8);
-    CreateFile(file, "abcdefghi");
-    std::remove(file.c_str());
+    path = path.substr(0, path.length() - 8);
+    CreateFile(path, "abcdefghi");
 
-    std::this_thread::sleep_for(std::chrono::seconds(8));
+    std::this_thread::sleep_for(std::chrono::seconds(2));
 
-    EXPECT_EQ(m_numCreatedFiles, 0);
-    EXPECT_EQ(m_numDeletedFiles, 0);
-    EXPECT_EQ(m_numChangedFiles, 0);
-    EXPECT_EQ(m_numOtherEvents, 0);
+    EXPECT_EQ(m_numCreatedFiles[m_fullPath1], 0);
+    EXPECT_EQ(m_numDeletedFiles[m_fullPath1], 0);
+    EXPECT_EQ(m_numChangedFiles[m_fullPath1], 0);
+    EXPECT_EQ(m_numOtherEvents[m_fullPath1], 0);
+}
+
+//==============================================================================
+TEST_F(FileMonitorTest, MultipleFileTest)
+{
+    EXPECT_EQ(m_numCreatedFiles[m_fullPath1], 0);
+    EXPECT_EQ(m_numDeletedFiles[m_fullPath1], 0);
+    EXPECT_EQ(m_numChangedFiles[m_fullPath1], 0);
+    EXPECT_EQ(m_numOtherEvents[m_fullPath1], 0);
+
+    EXPECT_EQ(m_numCreatedFiles[m_fullPath2], 0);
+    EXPECT_EQ(m_numDeletedFiles[m_fullPath2], 0);
+    EXPECT_EQ(m_numChangedFiles[m_fullPath2], 0);
+    EXPECT_EQ(m_numOtherEvents[m_fullPath2], 0);
+
+    EXPECT_EQ(m_numCreatedFiles[m_fullPath3], 0);
+    EXPECT_EQ(m_numDeletedFiles[m_fullPath3], 0);
+    EXPECT_EQ(m_numChangedFiles[m_fullPath3], 0);
+    EXPECT_EQ(m_numOtherEvents[m_fullPath3], 0);
+
+    CreateFile(m_fullPath1, std::string());
+
+    CreateFile(m_fullPath2, std::string());
+    std::remove(m_fullPath2.c_str());
+
+    CreateFile(m_fullPath3, "abcdefghi");
+    std::remove(m_fullPath3.c_str());
+
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    EXPECT_EQ(m_numCreatedFiles[m_fullPath1], 1);
+    EXPECT_EQ(m_numDeletedFiles[m_fullPath1], 0);
+    EXPECT_EQ(m_numChangedFiles[m_fullPath1], 0);
+    EXPECT_EQ(m_numOtherEvents[m_fullPath1], 0);
+
+    EXPECT_EQ(m_numCreatedFiles[m_fullPath2], 1);
+    EXPECT_EQ(m_numDeletedFiles[m_fullPath2], 1);
+    EXPECT_EQ(m_numChangedFiles[m_fullPath2], 0);
+    EXPECT_EQ(m_numOtherEvents[m_fullPath2], 0);
+
+    EXPECT_EQ(m_numCreatedFiles[m_fullPath3], 1);
+    EXPECT_EQ(m_numDeletedFiles[m_fullPath3], 1);
+    EXPECT_EQ(m_numChangedFiles[m_fullPath3], 1);
+    EXPECT_EQ(m_numOtherEvents[m_fullPath3], 0);
 }

--- a/test/file/file_monitor_test.cpp
+++ b/test/file/file_monitor_test.cpp
@@ -40,8 +40,8 @@ public:
      */
     virtual void SetUp()
     {
-        ASSERT_TRUE(fly::System::MakeDirectory(m_path1));
-        ASSERT_TRUE(fly::System::MakeDirectory(m_path2));
+        ASSERT_TRUE(fly::System::MakePath(m_path1));
+        ASSERT_TRUE(fly::System::MakePath(m_path2));
 
         auto callback = std::bind(&FileMonitorTest::HandleEvent, this,
             std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
@@ -58,8 +58,8 @@ public:
     virtual void TearDown()
     {
         m_spMonitor->Stop();
-        ASSERT_TRUE(fly::System::RemoveDirectory(m_path1));
-        ASSERT_TRUE(fly::System::RemoveDirectory(m_path2));
+        ASSERT_TRUE(fly::System::RemovePath(m_path1));
+        ASSERT_TRUE(fly::System::RemovePath(m_path2));
     }
 
 protected:

--- a/test/file/file_monitor_test.cpp
+++ b/test/file/file_monitor_test.cpp
@@ -58,6 +58,7 @@ public:
     virtual void TearDown()
     {
         m_spMonitor->Stop();
+
         ASSERT_TRUE(fly::System::RemovePath(m_path1));
         ASSERT_TRUE(fly::System::RemovePath(m_path2));
     }
@@ -225,7 +226,6 @@ TEST_F(FileMonitorTest, ChangeTest)
 //==============================================================================
 TEST_F(FileMonitorTest, OtherFileTest)
 {
-
     EXPECT_EQ(m_numCreatedFiles[m_fullPath1], 0);
     EXPECT_EQ(m_numDeletedFiles[m_fullPath1], 0);
     EXPECT_EQ(m_numChangedFiles[m_fullPath1], 0);
@@ -294,4 +294,30 @@ TEST_F(FileMonitorTest, MultipleFileTest)
     EXPECT_EQ(m_numDeletedFiles[m_fullPath3], 1);
     EXPECT_EQ(m_numChangedFiles[m_fullPath3], 1);
     EXPECT_EQ(m_numOtherEvents[m_fullPath3], 0);
+}
+
+//==============================================================================
+TEST_F(FileMonitorTest, RemoveTest)
+{
+    // Test removing files and paths that were not being monitored
+    EXPECT_FALSE(m_spMonitor->RemoveFile("was not", m_file1));
+    EXPECT_FALSE(m_spMonitor->RemoveFile(m_path1, "monitoring"));
+    EXPECT_FALSE(m_spMonitor->RemovePath("any of this"));
+
+    // For the path with two monitored files:
+    // 1. Remove one of the files - should succeed
+    // 2. Remove the whole path - should succeed
+    // 3. Remove the second file - should fail, wasn't being monitored any more
+    // 4. Remove the whole path - should fail
+    EXPECT_TRUE(m_spMonitor->RemoveFile(m_path1, m_file1));
+    EXPECT_TRUE(m_spMonitor->RemovePath(m_path1));
+    EXPECT_FALSE(m_spMonitor->RemoveFile(m_path1, m_file2));
+    EXPECT_FALSE(m_spMonitor->RemovePath(m_path1));
+
+    // For the path with one monitored file:
+    // 1. Remove the monitored file - should succeed
+    // 2. Remove the whole path - should fail, path will gets removed when the
+    //    last monitored file is removed
+    EXPECT_TRUE(m_spMonitor->RemoveFile(m_path2, m_file3));
+    EXPECT_FALSE(m_spMonitor->RemovePath(m_path2));
 }

--- a/test/file/ini_parser_test.cpp
+++ b/test/file/ini_parser_test.cpp
@@ -28,7 +28,6 @@ public:
     virtual void SetUp()
     {
         ASSERT_TRUE(fly::System::MakeDirectory(m_path));
-        std::remove(GetFullPath().c_str());
     }
 
     /**
@@ -36,7 +35,7 @@ public:
      */
     virtual void TearDown()
     {
-        std::remove(m_path.c_str());
+        ASSERT_TRUE(fly::System::RemoveDirectory(m_path));
     }
 
 protected:

--- a/test/file/ini_parser_test.cpp
+++ b/test/file/ini_parser_test.cpp
@@ -27,7 +27,7 @@ public:
      */
     virtual void SetUp()
     {
-        ASSERT_TRUE(fly::System::MakeDirectory(m_path));
+        ASSERT_TRUE(fly::System::MakePath(m_path));
     }
 
     /**
@@ -35,7 +35,7 @@ public:
      */
     virtual void TearDown()
     {
-        ASSERT_TRUE(fly::System::RemoveDirectory(m_path));
+        ASSERT_TRUE(fly::System::RemovePath(m_path));
     }
 
 protected:


### PR DESCRIPTION
Previously, would have to create a file monitor object per a file being monitored, which resulted in one thread being created per file. Terrible. Update to allow adding multiple files to a single file monitor.