### PR TITLE
 Clean up socket interface

### DIFF
--- a/fly/socket/async_request.cpp
+++ b/fly/socket/async_request.cpp
@@ -13,7 +13,7 @@ AsyncRequest::AsyncRequest() :
     m_socketId(s_invalidId),
     m_requestOffset(0),
     m_request(),
-    m_hostname(),
+    m_address(),
     m_port()
 {
 }
@@ -23,7 +23,7 @@ AsyncRequest::AsyncRequest(int socketId, const std::string &request) :
     m_socketId(socketId),
     m_requestOffset(0),
     m_request(request),
-    m_hostname(),
+    m_address(),
     m_port()
 {
 }
@@ -32,13 +32,13 @@ AsyncRequest::AsyncRequest(int socketId, const std::string &request) :
 AsyncRequest::AsyncRequest(
     int socketId,
     const std::string &request,
-    const std::string &hostname,
+    address_type address,
     port_type port
 ) :
     m_socketId(socketId),
     m_requestOffset(0),
     m_request(request),
-    m_hostname(hostname),
+    m_address(address),
     m_port(port)
 {
 }
@@ -62,7 +62,7 @@ void AsyncRequest::IncrementRequestOffset(std::string::size_type offset)
 }
 
 //==============================================================================
-std::string AsyncRequest::GetRequest() const
+const std::string &AsyncRequest::GetRequest() const
 {
     return m_request;
 }
@@ -74,9 +74,9 @@ std::string AsyncRequest::GetRequestRemaining() const
 }
 
 //==============================================================================
-std::string AsyncRequest::GetHostname() const
+address_type AsyncRequest::GetAddress() const
 {
-    return m_hostname;
+    return m_address;
 }
 
 //==============================================================================

--- a/fly/socket/async_request.h
+++ b/fly/socket/async_request.h
@@ -33,6 +33,12 @@ public:
      * Constructor to set the ID of the owning socket, the request message, and
      * the address and port of the owning socket.
      */
+    AsyncRequest(int, const std::string &, address_type, port_type);
+
+    /**
+     * Constructor to set the ID of the owning socket, the request message, and
+     * the address and port of the owning socket.
+     */
     AsyncRequest(int, const std::string &, const std::string &, port_type);
 
     /**
@@ -56,7 +62,7 @@ public:
     /**
      * @return The request message - the message to be sent or received.
      */
-    std::string GetRequest() const;
+    const std::string &GetRequest() const;
 
     /**
      * @return The request message starting at its current offset.
@@ -64,9 +70,9 @@ public:
     std::string GetRequestRemaining() const;
 
     /**
-     * @return The request hostname (for UDP sockets).
+     * @return The request address (for UDP sockets).
      */
-    std::string GetHostname() const;
+    address_type GetAddress() const;
 
     /**
      * @return The request port (for UDP sockets).
@@ -79,7 +85,7 @@ private:
     std::string::size_type m_requestOffset;
     std::string m_request;
 
-    std::string m_hostname;
+    address_type m_address;
     port_type m_port;
 };
 

--- a/fly/socket/nix/socket_impl.cpp
+++ b/fly/socket/nix/socket_impl.cpp
@@ -140,7 +140,7 @@ bool SocketImpl::Bind(const std::string &hostname, port_type port) const
 bool SocketImpl::BindForReuse(address_type address, port_type port) const
 {
     const int opt = 1;
-    socklen_t len = sizeof(opt);
+    const socklen_t len = sizeof(opt);
 
     if (::setsockopt(m_socketHandle, SOL_SOCKET, SO_REUSEADDR, &opt, len) == -1)
     {
@@ -450,16 +450,15 @@ std::string SocketImpl::RecvFrom(bool &wouldBlock, bool &isComplete) const
     wouldBlock = false;
     isComplete = false;
 
-    struct sockaddr_in client;
-    socklen_t clientLen = sizeof(client);
-
-    struct sockaddr *socketAddress = reinterpret_cast<sockaddr *>(&client);
+    struct sockaddr_in socketAddress;
+    struct sockaddr *pSocketAddress = reinterpret_cast<sockaddr *>(&socketAddress);
+    socklen_t socketAddressLength = sizeof(socketAddress);
 
     while (keepReading)
     {
         char *buff = (char *)calloc(1, m_packetSize * sizeof(char));
         ssize_t bytesRead = ::recvfrom(m_socketHandle, buff, m_packetSize,
-            0, socketAddress, &clientLen);
+            0, pSocketAddress, &socketAddressLength);
 
         if (bytesRead > 0)
         {

--- a/fly/socket/nix/socket_impl.cpp
+++ b/fly/socket/nix/socket_impl.cpp
@@ -53,6 +53,27 @@ SocketImpl::~SocketImpl()
 }
 
 //==============================================================================
+bool SocketImpl::HostnameToAddress(
+    const std::string &hostname,
+    address_type &address
+)
+{
+    struct hostent *ipAddress = ::gethostbyname(hostname.c_str());
+
+    if (ipAddress == NULL)
+    {
+        LOGS(-1, "Error resolving %s", hostname);
+        return false;
+    }
+
+    memcpy((char *)&address, ipAddress->h_addr, ipAddress->h_length);
+    address = ntohl(address);
+
+    LOGD(-1, "Converted hostname %s to %d", hostname, address);
+    return true;
+}
+
+//==============================================================================
 address_type SocketImpl::InAddrAny()
 {
     return INADDR_ANY;
@@ -394,27 +415,6 @@ std::string SocketImpl::RecvFrom(bool &wouldBlock, bool &isComplete) const
     }
 
     return ret;
-}
-
-//==============================================================================
-bool SocketImpl::HostnameToAddress(
-    const std::string &hostname,
-    address_type &address
-) const
-{
-    struct hostent *ipAddress = ::gethostbyname(hostname.c_str());
-
-    if (ipAddress == NULL)
-    {
-        LOGS(m_socketHandle, "Error resolving %s", hostname);
-        return false;
-    }
-
-    memcpy((char *)&address, ipAddress->h_addr, ipAddress->h_length);
-    address = ntohl(address);
-
-    LOGD(m_socketHandle, "Converted hostname %s to %d", hostname, address);
-    return true;
 }
 
 }

--- a/fly/socket/nix/socket_impl.cpp
+++ b/fly/socket/nix/socket_impl.cpp
@@ -147,23 +147,6 @@ bool SocketImpl::Bind(
 }
 
 //==============================================================================
-bool SocketImpl::Bind(
-    const std::string &hostname,
-    port_type port,
-    BindOption option
-) const
-{
-    address_type address = 0;
-
-    if (HostnameToAddress(hostname, address))
-    {
-        return Bind(address, port, option);
-    }
-
-    return false;
-}
-
-//==============================================================================
 bool SocketImpl::Listen()
 {
     if (::listen(m_socketHandle, 100) == -1)
@@ -200,19 +183,6 @@ bool SocketImpl::Connect(address_type address, port_type port)
 }
 
 //==============================================================================
-bool SocketImpl::Connect(const std::string &hostname, port_type port)
-{
-    address_type address = 0;
-
-    if (HostnameToAddress(hostname, address))
-    {
-        return Connect(address, port);
-    }
-
-    return false;
-}
-
-//==============================================================================
 SocketPtr SocketImpl::Accept() const
 {
     SocketImplPtr ret = std::make_shared<SocketImpl>(m_protocol, m_spConfig);
@@ -239,13 +209,6 @@ SocketPtr SocketImpl::Accept() const
     }
 
     return ret;
-}
-
-//==============================================================================
-size_t SocketImpl::Send(const std::string &message) const
-{
-    bool wouldBlock = false;
-    return Send(message, wouldBlock);
 }
 
 //==============================================================================
@@ -289,28 +252,6 @@ size_t SocketImpl::Send(const std::string &message, bool &wouldBlock) const
     }
 
     return bytesSent;
-}
-
-//==============================================================================
-size_t SocketImpl::SendTo(
-    const std::string &message,
-    address_type address,
-    port_type port
-) const
-{
-    bool wouldBlock = false;
-    return SendTo(message, address, port, wouldBlock);
-}
-
-//==============================================================================
-size_t SocketImpl::SendTo(
-    const std::string &message,
-    const std::string &hostname,
-    port_type port
-) const
-{
-    bool wouldBlock = false;
-    return SendTo(message, hostname, port, wouldBlock);
 }
 
 //==============================================================================
@@ -367,31 +308,6 @@ size_t SocketImpl::SendTo(
 }
 
 //==============================================================================
-size_t SocketImpl::SendTo(
-    const std::string &message,
-    const std::string &hostname,
-    port_type port,
-    bool &wouldBlock
-) const
-{
-    address_type address = 0;
-
-    if (HostnameToAddress(hostname, address))
-    {
-        return SendTo(message, address, port, wouldBlock);
-    }
-
-    return 0;
-}
-
-//==============================================================================
-std::string SocketImpl::Recv() const
-{
-    bool wouldBlock = false, isComplete = false;
-    return Recv(wouldBlock, isComplete);
-}
-
-//==============================================================================
 std::string SocketImpl::Recv(bool &wouldBlock, bool &isComplete) const
 {
     std::string ret;
@@ -431,13 +347,6 @@ std::string SocketImpl::Recv(bool &wouldBlock, bool &isComplete) const
     }
 
     return ret;
-}
-
-//==============================================================================
-std::string SocketImpl::RecvFrom() const
-{
-    bool wouldBlock = false, isComplete = false;
-    return RecvFrom(wouldBlock, isComplete);
 }
 
 //==============================================================================

--- a/fly/socket/nix/socket_impl.h
+++ b/fly/socket/nix/socket_impl.h
@@ -33,11 +33,8 @@ public:
 
     bool SetAsync();
 
-    bool Bind(address_type, port_type) const;
-    bool Bind(const std::string &, port_type) const;
-
-    bool BindForReuse(address_type, port_type) const;
-    bool BindForReuse(const std::string &, port_type) const;
+    bool Bind(address_type, port_type, BindOption) const;
+    bool Bind(const std::string &, port_type, BindOption) const;
 
     bool Listen();
 

--- a/fly/socket/nix/socket_impl.h
+++ b/fly/socket/nix/socket_impl.h
@@ -41,13 +41,13 @@ public:
 
     SocketPtr Accept() const;
 
+protected:
     size_t Send(const std::string &, bool &) const;
     size_t SendTo(const std::string &, address_type, port_type, bool &) const;
 
     std::string Recv(bool &, bool &) const;
     std::string RecvFrom(bool &, bool &) const;
 
-protected:
     bool HostnameToAddress(const std::string &, address_type &) const;
 };
 

--- a/fly/socket/nix/socket_impl.h
+++ b/fly/socket/nix/socket_impl.h
@@ -34,15 +34,25 @@ public:
     bool SetAsync();
 
     bool Bind(address_type, port_type) const;
+    bool Bind(const std::string &, port_type) const;
+
     bool BindForReuse(address_type, port_type) const;
+    bool BindForReuse(const std::string &, port_type) const;
+
     bool Listen();
+
+    bool Connect(address_type, port_type);
     bool Connect(const std::string &, port_type);
+
     SocketPtr Accept() const;
 
     size_t Send(const std::string &) const;
     size_t Send(const std::string &, bool &) const;
 
+    size_t SendTo(const std::string &, address_type, port_type) const;
     size_t SendTo(const std::string &, const std::string &, port_type) const;
+
+    size_t SendTo(const std::string &, address_type, port_type, bool &) const;
     size_t SendTo(const std::string &, const std::string &, port_type, bool &) const;
 
     std::string Recv() const;
@@ -50,6 +60,9 @@ public:
 
     std::string RecvFrom() const;
     std::string RecvFrom(bool &, bool &) const;
+
+protected:
+    bool HostnameToAddress(const std::string &, address_type &) const;
 };
 
 }

--- a/fly/socket/nix/socket_impl.h
+++ b/fly/socket/nix/socket_impl.h
@@ -23,6 +23,8 @@ public:
     SocketImpl(Protocol, const SocketConfigPtr &);
     ~SocketImpl();
 
+    static bool HostnameToAddress(const std::string &, address_type &);
+
     static address_type InAddrAny();
 
     static socket_type InvalidSocket();
@@ -47,8 +49,6 @@ protected:
 
     std::string Recv(bool &, bool &) const;
     std::string RecvFrom(bool &, bool &) const;
-
-    bool HostnameToAddress(const std::string &, address_type &) const;
 };
 
 }

--- a/fly/socket/nix/socket_impl.h
+++ b/fly/socket/nix/socket_impl.h
@@ -34,28 +34,17 @@ public:
     bool SetAsync();
 
     bool Bind(address_type, port_type, BindOption) const;
-    bool Bind(const std::string &, port_type, BindOption) const;
 
     bool Listen();
 
     bool Connect(address_type, port_type);
-    bool Connect(const std::string &, port_type);
 
     SocketPtr Accept() const;
 
-    size_t Send(const std::string &) const;
     size_t Send(const std::string &, bool &) const;
-
-    size_t SendTo(const std::string &, address_type, port_type) const;
-    size_t SendTo(const std::string &, const std::string &, port_type) const;
-
     size_t SendTo(const std::string &, address_type, port_type, bool &) const;
-    size_t SendTo(const std::string &, const std::string &, port_type, bool &) const;
 
-    std::string Recv() const;
     std::string Recv(bool &, bool &) const;
-
-    std::string RecvFrom() const;
     std::string RecvFrom(bool &, bool &) const;
 
 protected:

--- a/fly/socket/socket.cpp
+++ b/fly/socket/socket.cpp
@@ -26,6 +26,15 @@ Socket::Socket(Protocol protocol, const SocketConfigPtr &spConfig) :
 }
 
 //==============================================================================
+bool Socket::HostnameToAddress(
+    const std::string &hostname,
+    address_type &address
+)
+{
+    return SocketImpl::HostnameToAddress(hostname, address);
+}
+
+//==============================================================================
 address_type Socket::InAddrAny()
 {
     return SocketImpl::InAddrAny();

--- a/fly/socket/socket.cpp
+++ b/fly/socket/socket.cpp
@@ -104,6 +104,36 @@ bool Socket::IsConnected() const
 }
 
 //==============================================================================
+bool Socket::Bind(
+    const std::string &hostname,
+    port_type port,
+    BindOption option
+) const
+{
+    address_type address = 0;
+
+    if (HostnameToAddress(hostname, address))
+    {
+        return Bind(address, port, option);
+    }
+
+    return false;
+}
+
+//==============================================================================
+bool Socket::Connect(const std::string &hostname, port_type port)
+{
+    address_type address = 0;
+
+    if (HostnameToAddress(hostname, address))
+    {
+        return Connect(address, port);
+    }
+
+    return false;
+}
+
+//==============================================================================
 ConnectedState Socket::ConnectAsync(address_type address, port_type port)
 {
     ConnectedState state = ConnectedState::Disconnected;
@@ -165,6 +195,53 @@ bool Socket::FinishConnect()
 }
 
 //==============================================================================
+size_t Socket::Send(const std::string &message) const
+{
+    bool wouldBlock = false;
+    return Send(message, wouldBlock);
+}
+
+//==============================================================================
+size_t Socket::SendTo(
+    const std::string &message,
+    address_type address,
+    port_type port
+) const
+{
+    bool wouldBlock = false;
+    return SendTo(message, address, port, wouldBlock);
+}
+
+//==============================================================================
+size_t Socket::SendTo(
+    const std::string &message,
+    const std::string &hostname,
+    port_type port
+) const
+{
+    bool wouldBlock = false;
+    return SendTo(message, hostname, port, wouldBlock);
+}
+
+//==============================================================================
+size_t Socket::SendTo(
+    const std::string &message,
+    const std::string &hostname,
+    port_type port,
+    bool &wouldBlock
+) const
+{
+    address_type address = 0;
+
+    if (HostnameToAddress(hostname, address))
+    {
+        return SendTo(message, address, port, wouldBlock);
+    }
+
+    return 0;
+}
+
+//==============================================================================
 bool Socket::SendAsync(const std::string &message)
 {
     if (IsTcp() && IsAsync())
@@ -211,6 +288,20 @@ bool Socket::SendToAsync(
     }
 
     return false;
+}
+
+//==============================================================================
+std::string Socket::Recv() const
+{
+    bool wouldBlock = false, isComplete = false;
+    return Recv(wouldBlock, isComplete);
+}
+
+//==============================================================================
+std::string Socket::RecvFrom() const
+{
+    bool wouldBlock = false, isComplete = false;
+    return RecvFrom(wouldBlock, isComplete);
 }
 
 //==============================================================================

--- a/fly/socket/socket.h
+++ b/fly/socket/socket.h
@@ -15,25 +15,6 @@ FLY_CLASS_PTRS(Socket);
 FLY_CLASS_PTRS(SocketConfig);
 
 /**
- * Types of supported sockets.
- */
-enum class Protocol
-{
-    TCP,
-    UDP
-};
-
-/**
- * Enumerated connection state values.
- */
-enum class ConnectedState
-{
-    Disconnected,
-    Connecting,
-    Connected
-};
-
-/**
  * Virtual interface to represent a network socket. This interface is platform
  * independent - OS dependent implementations should inherit from this class.
  *
@@ -119,7 +100,7 @@ public:
      *
      * @return True if the binding was successful.
      */
-    virtual bool Bind(address_type, port_type) const = 0;
+    virtual bool Bind(address_type, port_type, BindOption) const = 0;
 
     /**
      * Bind this socket to an address.
@@ -129,27 +110,7 @@ public:
      *
      * @return True if the binding was successful.
      */
-    virtual bool Bind(const std::string &, port_type) const = 0;
-
-    /**
-     * Bind this socket to an address, allowing the port to be reused.
-     *
-     * @param address_type The host-order IPv4 address to bind to.
-     * @param port_type The port to bind to.
-     *
-     * @return True if the binding was successful.
-     */
-    virtual bool BindForReuse(address_type, port_type) const = 0;
-
-    /**
-     * Bind this socket to an address, allowing the port to be reused.
-     *
-     * @param string The hostname or IPv4 address to bind to.
-     * @param port_type The port to bind to.
-     *
-     * @return True if the binding was successful.
-     */
-    virtual bool BindForReuse(const std::string &, port_type) const = 0;
+    virtual bool Bind(const std::string &, port_type, BindOption) const = 0;
 
     /**
      * Allow socket to listen for incoming connections.

--- a/fly/socket/socket.h
+++ b/fly/socket/socket.h
@@ -44,7 +44,10 @@ class Socket
 {
 public:
     /**
-     * Default constructor to initialize all values.
+     * Constructor.
+     *
+     * @param Protocol The communication protocol of the socket.
+     * @param SocketConfigPtr Reference to the socket configuration.
      */
     Socket(Protocol, const SocketConfigPtr &);
 
@@ -111,22 +114,42 @@ public:
     /**
      * Bind this socket to an address.
      *
-     * @param address_type The server IP to bind to.
-     * @param port_type The server port to bind to.
+     * @param address_type The host-order IPv4 address to bind to.
+     * @param port_type The port to bind to.
      *
      * @return True if the binding was successful.
      */
     virtual bool Bind(address_type, port_type) const = 0;
 
     /**
+     * Bind this socket to an address.
+     *
+     * @param string The hostname or IPv4 address to bind to.
+     * @param port_type The port to bind to.
+     *
+     * @return True if the binding was successful.
+     */
+    virtual bool Bind(const std::string &, port_type) const = 0;
+
+    /**
      * Bind this socket to an address, allowing the port to be reused.
      *
-     * @param address_type The server IP to bind to.
-     * @param port_type The server port to bind to.
+     * @param address_type The host-order IPv4 address to bind to.
+     * @param port_type The port to bind to.
      *
      * @return True if the binding was successful.
      */
     virtual bool BindForReuse(address_type, port_type) const = 0;
+
+    /**
+     * Bind this socket to an address, allowing the port to be reused.
+     *
+     * @param string The hostname or IPv4 address to bind to.
+     * @param port_type The port to bind to.
+     *
+     * @return True if the binding was successful.
+     */
+    virtual bool BindForReuse(const std::string &, port_type) const = 0;
 
     /**
      * Allow socket to listen for incoming connections.
@@ -166,6 +189,16 @@ public:
     /**
      * Connect to a listening socket.
      *
+     * @param address_type The host-order IPv4 address to connect to.
+     * @param port_type The port to connect to.
+     *
+     * @param bool True if the connection was successful, false otherwise.
+     */
+    virtual bool Connect(address_type, port_type) = 0;
+
+    /**
+     * Connect to a listening socket.
+     *
      * @param string The hostname or IPv4 address to connect to.
      * @param port_type The port to connect to.
      *
@@ -178,12 +211,24 @@ public:
      * immediately, so the connection state is returned rather than a binary
      * boolean. If this is not an asynchronous socket, nothing will occur.
      *
+     * @param address_type The host-order IPv4 address to connect to.
+     * @param port_type The port to connect to.
+     *
+     * @return The connection state (not connected, connecting, or connected).
+     */
+    ConnectedState ConnectAsync(address_type, port_type);
+
+    /**
+     * Asynchronously connect to a listening socket. The connect may finish
+     * immediately, so the connection state is returned rather than a binary
+     * boolean. If this is not an asynchronous socket, nothing will occur.
+     *
      * @param string The hostname or IPv4 address to connect to.
      * @param port_type The port to connect to.
      *
      * @return The connection state (not connected, connecting, or connected).
      */
-    ConnectedState ConnectAsync(std::string, port_type);
+    ConnectedState ConnectAsync(const std::string &, port_type);
 
     /**
      * After an asynchronous socket in a connecting state becomes available for
@@ -223,12 +268,35 @@ public:
      * Write data on the socket.
      *
      * @param string The data to send.
+     * @param address_type The host-order IPv4 address to send data to.
+     * @param port_type The port to send data to.
+     *
+     * @return The number of bytes sent.
+     */
+    virtual size_t SendTo(const std::string &, address_type, port_type) const = 0;
+
+    /**
+     * Write data on the socket.
+     *
+     * @param string The data to send.
      * @param string The hostname or IPv4 address to send data to.
      * @param port_type The port to send data to.
      *
      * @return The number of bytes sent.
      */
     virtual size_t SendTo(const std::string &, const std::string &, port_type) const = 0;
+
+    /**
+     * Write data on the socket.
+     *
+     * @param string The data to send.
+     * @param address_type The host-order IPv4 address to send data to.
+     * @param port_type The port to send data to.
+     * @param bool & Reference to a bool, set to true if the operation would block.
+     *
+     * @return The number of bytes sent.
+     */
+    virtual size_t SendTo(const std::string &, address_type, port_type, bool &) const = 0;
 
     /**
      * Write data on the socket.
@@ -251,6 +319,18 @@ public:
      * @return True if the request was made.
      */
     bool SendAsync(const std::string &);
+
+    /**
+     * Request data to be written on the socket asynchronously. If this is not
+     * an ansynchronous socket, nothing will occur.
+     *
+     * @param string The data to send.
+     * @param string The host-order IPv4 address to send data to.
+     * @param port_type The port to send data to.
+     *
+     * @return True if the request was made.
+     */
+    bool SendToAsync(const std::string &, address_type, port_type);
 
     /**
      * Request data to be written on the socket asynchronously. If this is not
@@ -316,6 +396,17 @@ public:
     void ServiceRecvRequests(AsyncRequest::RequestQueue &);
 
 protected:
+    /**
+     * Convert a string hostname or IPv4 address to a host-order numeric IPv4
+     * address.
+     *
+     * @param string The hostname or IPv4 address to convert.
+     * @param address_type The location to store the converted address.
+     *
+     * @return bool True if the hostname/address string could be converted.
+     */
+    virtual bool HostnameToAddress(const std::string &, address_type &) const = 0;
+
     // Socket protocol
     Protocol m_protocol;
 

--- a/fly/socket/socket.h
+++ b/fly/socket/socket.h
@@ -33,6 +33,17 @@ public:
     Socket(Protocol, const SocketConfigPtr &);
 
     /**
+     * Convert a string hostname or IPv4 address to a host-order numeric IPv4
+     * address.
+     *
+     * @param string The hostname or IPv4 address to convert.
+     * @param address_type The location to store the converted address.
+     *
+     * @return bool True if the hostname/address string could be converted.
+     */
+    static bool HostnameToAddress(const std::string &, address_type &);
+
+    /**
      * INADDR_ANY may be different depending on the OS. This function will
      * return the value for the compiled target's OS.
      *
@@ -356,17 +367,6 @@ protected:
      * @return The data received.
      */
     virtual std::string RecvFrom(bool &, bool &) const = 0;
-
-    /**
-     * Convert a string hostname or IPv4 address to a host-order numeric IPv4
-     * address.
-     *
-     * @param string The hostname or IPv4 address to convert.
-     * @param address_type The location to store the converted address.
-     *
-     * @return bool True if the hostname/address string could be converted.
-     */
-    virtual bool HostnameToAddress(const std::string &, address_type &) const = 0;
 
     // Socket protocol
     Protocol m_protocol;

--- a/fly/socket/socket.h
+++ b/fly/socket/socket.h
@@ -219,16 +219,6 @@ public:
      * Write data on the socket.
      *
      * @param string The data to send.
-     * @param bool & Reference to a bool, set to true if the operation would block.
-     *
-     * @return The number of bytes sent.
-     */
-    virtual size_t Send(const std::string &, bool &) const = 0;
-
-    /**
-     * Write data on the socket.
-     *
-     * @param string The data to send.
      * @param address_type The host-order IPv4 address to send data to.
      * @param port_type The port to send data to.
      *
@@ -246,30 +236,6 @@ public:
      * @return The number of bytes sent.
      */
     size_t SendTo(const std::string &, const std::string &, port_type) const;
-
-    /**
-     * Write data on the socket.
-     *
-     * @param string The data to send.
-     * @param address_type The host-order IPv4 address to send data to.
-     * @param port_type The port to send data to.
-     * @param bool & Reference to a bool, set to true if the operation would block.
-     *
-     * @return The number of bytes sent.
-     */
-    virtual size_t SendTo(const std::string &, address_type, port_type, bool &) const = 0;
-
-    /**
-     * Write data on the socket.
-     *
-     * @param string The data to send.
-     * @param string The hostname or IPv4 address to send data to.
-     * @param port_type The port to send data to.
-     * @param bool & Reference to a bool, set to true if the operation would block.
-     *
-     * @return The number of bytes sent.
-     */
-    size_t SendTo(const std::string &, const std::string &, port_type, bool &) const;
 
     /**
      * Request data to be written on the socket asynchronously. If this is not
@@ -315,29 +281,9 @@ public:
     /**
      * Read data on this socket until the end-of-message character is received.
      *
-     * @param bool & Reference to a bool, set to true if the operation would block.
-     * @param bool & Reference to a bool, set to true if the EoM char was received.
-     *
-     * @return The data received.
-     */
-    virtual std::string Recv(bool &, bool &) const = 0;
-
-    /**
-     * Read data on this socket until the end-of-message character is received.
-     *
      * @return The data received.
      */
     std::string RecvFrom() const;
-
-    /**
-     * Read data on this socket until the end-of-message character is received.
-     *
-     * @param bool & Reference to a bool, set to true if the operation would block.
-     * @param bool & Reference to a bool, set to true if the EoM char was received.
-     *
-     * @return The data received.
-     */
-    virtual std::string RecvFrom(bool &, bool &) const = 0;
 
     /**
      * Iterate thru all pending asynchronous sends. Service each request until
@@ -357,6 +303,60 @@ public:
     void ServiceRecvRequests(AsyncRequest::RequestQueue &);
 
 protected:
+    /**
+     * Write data on the socket.
+     *
+     * @param string The data to send.
+     * @param bool Reference to a bool, set to true if the operation would block.
+     *
+     * @return The number of bytes sent.
+     */
+    virtual size_t Send(const std::string &, bool &) const = 0;
+
+    /**
+     * Write data on the socket.
+     *
+     * @param string The data to send.
+     * @param address_type The host-order IPv4 address to send data to.
+     * @param port_type The port to send data to.
+     * @param bool Reference to a bool, set to true if the operation would block.
+     *
+     * @return The number of bytes sent.
+     */
+    virtual size_t SendTo(const std::string &, address_type, port_type, bool &) const = 0;
+
+    /**
+     * Write data on the socket.
+     *
+     * @param string The data to send.
+     * @param string The hostname or IPv4 address to send data to.
+     * @param port_type The port to send data to.
+     * @param bool Reference to a bool, set to true if the operation would block.
+     *
+     * @return The number of bytes sent.
+     */
+    size_t SendTo(const std::string &, const std::string &, port_type, bool &) const;
+
+    /**
+     * Read data on this socket until the end-of-message character is received.
+     *
+     * @param bool Reference to a bool, set to true if the operation would block.
+     * @param bool Reference to a bool, set to true if the EoM char was received.
+     *
+     * @return The data received.
+     */
+    virtual std::string Recv(bool &, bool &) const = 0;
+
+    /**
+     * Read data on this socket until the end-of-message character is received.
+     *
+     * @param bool Reference to a bool, set to true if the operation would block.
+     * @param bool Reference to a bool, set to true if the EoM char was received.
+     *
+     * @return The data received.
+     */
+    virtual std::string RecvFrom(bool &, bool &) const = 0;
+
     /**
      * Convert a string hostname or IPv4 address to a host-order numeric IPv4
      * address.

--- a/fly/socket/socket.h
+++ b/fly/socket/socket.h
@@ -93,31 +93,6 @@ public:
     int GetSocketId() const;
 
     /**
-     * Bind this socket to an address.
-     *
-     * @param address_type The host-order IPv4 address to bind to.
-     * @param port_type The port to bind to.
-     *
-     * @return True if the binding was successful.
-     */
-    virtual bool Bind(address_type, port_type, BindOption) const = 0;
-
-    /**
-     * Bind this socket to an address.
-     *
-     * @param string The hostname or IPv4 address to bind to.
-     * @param port_type The port to bind to.
-     *
-     * @return True if the binding was successful.
-     */
-    virtual bool Bind(const std::string &, port_type, BindOption) const = 0;
-
-    /**
-     * Allow socket to listen for incoming connections.
-     */
-    virtual bool Listen() = 0;
-
-    /**
      * @return True if this is a TCP socket, false otherwise.
      */
     bool IsTcp() const;
@@ -148,6 +123,31 @@ public:
     bool IsConnected() const;
 
     /**
+     * Bind this socket to an address.
+     *
+     * @param address_type The host-order IPv4 address to bind to.
+     * @param port_type The port to bind to.
+     *
+     * @return True if the binding was successful.
+     */
+    virtual bool Bind(address_type, port_type, BindOption) const = 0;
+
+    /**
+     * Bind this socket to an address.
+     *
+     * @param string The hostname or IPv4 address to bind to.
+     * @param port_type The port to bind to.
+     *
+     * @return True if the binding was successful.
+     */
+    bool Bind(const std::string &, port_type, BindOption) const;
+
+    /**
+     * Allow socket to listen for incoming connections.
+     */
+    virtual bool Listen() = 0;
+
+    /**
      * Connect to a listening socket.
      *
      * @param address_type The host-order IPv4 address to connect to.
@@ -165,7 +165,7 @@ public:
      *
      * @param bool True if the connection was successful, false otherwise.
      */
-    virtual bool Connect(const std::string &, port_type) = 0;
+    bool Connect(const std::string &, port_type);
 
     /**
      * Asynchronously connect to a listening socket. The connect may finish
@@ -213,7 +213,7 @@ public:
      *
      * @return The number of bytes sent.
      */
-    virtual size_t Send(const std::string &) const = 0;
+    size_t Send(const std::string &) const;
 
     /**
      * Write data on the socket.
@@ -234,7 +234,7 @@ public:
      *
      * @return The number of bytes sent.
      */
-    virtual size_t SendTo(const std::string &, address_type, port_type) const = 0;
+    size_t SendTo(const std::string &, address_type, port_type) const;
 
     /**
      * Write data on the socket.
@@ -245,7 +245,7 @@ public:
      *
      * @return The number of bytes sent.
      */
-    virtual size_t SendTo(const std::string &, const std::string &, port_type) const = 0;
+    size_t SendTo(const std::string &, const std::string &, port_type) const;
 
     /**
      * Write data on the socket.
@@ -269,7 +269,7 @@ public:
      *
      * @return The number of bytes sent.
      */
-    virtual size_t SendTo(const std::string &, const std::string &, port_type, bool &) const = 0;
+    size_t SendTo(const std::string &, const std::string &, port_type, bool &) const;
 
     /**
      * Request data to be written on the socket asynchronously. If this is not
@@ -310,7 +310,7 @@ public:
      *
      * @return The data received.
      */
-    virtual std::string Recv() const = 0;
+    std::string Recv() const;
 
     /**
      * Read data on this socket until the end-of-message character is received.
@@ -327,7 +327,7 @@ public:
      *
      * @return The data received.
      */
-    virtual std::string RecvFrom() const = 0;
+    std::string RecvFrom() const;
 
     /**
      * Read data on this socket until the end-of-message character is received.

--- a/fly/socket/socket_manager.h
+++ b/fly/socket/socket_manager.h
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -17,7 +18,7 @@ FLY_CLASS_PTRS(ConfigManager);
 FLY_CLASS_PTRS(Socket);
 FLY_CLASS_PTRS(SocketConfig);
 FLY_CLASS_PTRS(SocketManager);
-enum class Protocol;
+enum class Protocol : uint8_t;
 
 /**
  * Class to manage the creation of sockets and IO operations over asynchronous

--- a/fly/socket/socket_types.h
+++ b/fly/socket/socket_types.h
@@ -21,4 +21,32 @@ namespace fly {
 typedef uint32_t address_type;
 typedef uint16_t port_type;
 
+/**
+ * Types of supported sockets.
+ */
+enum class Protocol : uint8_t
+{
+    TCP,
+    UDP
+};
+
+/**
+ * Supported options for binding sockets.
+ */
+enum class BindOption : uint8_t
+{
+    SingleUse,
+    AllowReuse
+};
+
+/**
+ * TCP socket connection states.
+ */
+enum class ConnectedState : uint8_t
+{
+    Disconnected,
+    Connecting,
+    Connected
+};
+
 }

--- a/fly/socket/win/socket_impl.cpp
+++ b/fly/socket/win/socket_impl.cpp
@@ -138,23 +138,6 @@ bool SocketImpl::Bind(
 }
 
 //==============================================================================
-bool SocketImpl::Bind(
-    const std::string &hostname,
-    port_type port,
-    BindOption option
-) const
-{
-    address_type address = 0;
-
-    if (HostnameToAddress(hostname, address))
-    {
-        return Bind(address, port, option);
-    }
-
-    return false;
-}
-
-//==============================================================================
 bool SocketImpl::Listen()
 {
     if (::listen(m_socketHandle, 100) == SOCKET_ERROR)
@@ -191,19 +174,6 @@ bool SocketImpl::Connect(address_type address, port_type port)
 }
 
 //==============================================================================
-bool SocketImpl::Connect(const std::string &hostname, port_type port)
-{
-    address_type address = 0;
-
-    if (HostnameToAddress(hostname, address))
-    {
-        return Connect(address, port);
-    }
-
-    return false;
-}
-
-//==============================================================================
 SocketPtr SocketImpl::Accept() const
 {
     SocketImplPtr ret = std::make_shared<SocketImpl>(m_protocol, m_spConfig);
@@ -230,13 +200,6 @@ SocketPtr SocketImpl::Accept() const
     }
 
     return ret;
-}
-
-//==============================================================================
-size_t SocketImpl::Send(const std::string &message) const
-{
-    bool wouldBlock = false;
-    return Send(message, wouldBlock);
 }
 
 //==============================================================================
@@ -297,28 +260,6 @@ size_t SocketImpl::Send(const std::string &message, bool &wouldBlock) const
 size_t SocketImpl::SendTo(
     const std::string &message,
     address_type address,
-    port_type port
-) const
-{
-    bool wouldBlock = false;
-    return SendTo(message, address, port, wouldBlock);
-}
-
-//==============================================================================
-size_t SocketImpl::SendTo(
-    const std::string &message,
-    const std::string &hostname,
-    port_type port
-) const
-{
-    bool wouldBlock = false;
-    return SendTo(message, hostname, port, wouldBlock);
-}
-
-//==============================================================================
-size_t SocketImpl::SendTo(
-    const std::string &message,
-    address_type address,
     port_type port,
     bool &wouldBlock
 ) const
@@ -369,31 +310,6 @@ size_t SocketImpl::SendTo(
 }
 
 //==============================================================================
-size_t SocketImpl::SendTo(
-    const std::string &message,
-    const std::string &hostname,
-    port_type port,
-    bool &wouldBlock
-) const
-{
-    address_type address = 0;
-
-    if (HostnameToAddress(hostname, address))
-    {
-        return SendTo(message, address, port, wouldBlock);
-    }
-
-    return 0;
-}
-
-//==============================================================================
-std::string SocketImpl::Recv() const
-{
-    bool wouldBlock = false, isComplete = false;
-    return Recv(wouldBlock, isComplete);
-}
-
-//==============================================================================
 std::string SocketImpl::Recv(bool &wouldBlock, bool &isComplete) const
 {
     std::string ret;
@@ -435,13 +351,6 @@ std::string SocketImpl::Recv(bool &wouldBlock, bool &isComplete) const
     }
 
     return ret;
-}
-
-//==============================================================================
-std::string SocketImpl::RecvFrom() const
-{
-    bool wouldBlock = false, isComplete = false;
-    return RecvFrom(wouldBlock, isComplete);
 }
 
 //==============================================================================

--- a/fly/socket/win/socket_impl.cpp
+++ b/fly/socket/win/socket_impl.cpp
@@ -3,6 +3,7 @@
 #include "fly/socket/win/socket_impl.h"
 
 #include <WinSock.h>
+#include <socketapi.h>
 
 #include "fly/logger/logger.h"
 #include "fly/socket/socket_config.h"
@@ -12,28 +13,16 @@ namespace fly {
 
 namespace
 {
-    struct sockaddr_in HostToSocketAddress(
-        size_t socketId,
-        const std::string &hostname,
-        port_type port
-    )
+    struct sockaddr_in CreateSocketAddress(address_type address, port_type port)
     {
-        struct hostent *ipAddress = ::gethostbyname(hostname.c_str());
-        struct sockaddr_in address;
+        struct sockaddr_in socketAddress;
+        memset(&socketAddress, 0, sizeof(socketAddress));
 
-        if (ipAddress == NULL)
-        {
-            LOGS(socketId, "Error resolving %s", hostname);
-        }
-        else
-        {
-            memset(&address, 0, sizeof(address));
-            address.sin_family = AF_INET;
-            memcpy((char *)&address.sin_addr, ipAddress->h_addr, ipAddress->h_length);
-            address.sin_port = htons(port);
-        }
+        socketAddress.sin_family = AF_INET;
+        socketAddress.sin_addr.s_addr = htonl(address);
+        socketAddress.sin_port = htons(port);
 
-        return address;
+        return socketAddress;
     }
 }
 
@@ -113,16 +102,10 @@ bool SocketImpl::SetAsync()
 //==============================================================================
 bool SocketImpl::Bind(address_type address, port_type port) const
 {
-    struct sockaddr_in serverAddress;
-    memset(&serverAddress, 0, sizeof(serverAddress));
+    struct sockaddr_in socketAddress = CreateSocketAddress(address, port);
+    struct sockaddr *pSocketAddress = reinterpret_cast<sockaddr *>(&socketAddress);
 
-    serverAddress.sin_family = AF_INET;
-    serverAddress.sin_addr.s_addr = htonl(address);
-    serverAddress.sin_port = htons(port);
-
-    struct sockaddr *socketAddress = reinterpret_cast<sockaddr *>(&serverAddress);
-
-    if (::bind(m_socketHandle, socketAddress, sizeof(serverAddress)) == SOCKET_ERROR)
+    if (::bind(m_socketHandle, pSocketAddress, sizeof(socketAddress)) == SOCKET_ERROR)
     {
         LOGS(m_socketHandle, "Error binding to %d", port);
         return false;
@@ -132,17 +115,44 @@ bool SocketImpl::Bind(address_type address, port_type port) const
 }
 
 //==============================================================================
+bool SocketImpl::Bind(const std::string &hostname, port_type port) const
+{
+    address_type address = 0;
+
+    if (HostnameToAddress(hostname, address))
+    {
+        return Bind(address, port);
+    }
+
+    return false;
+}
+
+//==============================================================================
 bool SocketImpl::BindForReuse(address_type address, port_type port) const
 {
     const char opt = 1;
+    const int len = static_cast<int>(sizeof(opt));
 
-    if (::setsockopt(m_socketHandle, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) == SOCKET_ERROR)
+    if (::setsockopt(m_socketHandle, SOL_SOCKET, SO_REUSEADDR, &opt, len) == SOCKET_ERROR)
     {
         LOGS(m_socketHandle, "Error setting reuse flag");
         return false;
     }
 
     return Bind(address, port);
+}
+
+//==============================================================================
+bool SocketImpl::BindForReuse(const std::string &hostname, port_type port) const
+{
+    address_type address = 0;
+
+    if (HostnameToAddress(hostname, address))
+    {
+        return BindForReuse(address, port);
+    }
+
+    return false;
 }
 
 //==============================================================================
@@ -159,11 +169,12 @@ bool SocketImpl::Listen()
 }
 
 //==============================================================================
-bool SocketImpl::Connect(const std::string &hostname, port_type port)
+bool SocketImpl::Connect(address_type address, port_type port)
 {
-    struct sockaddr_in server = HostToSocketAddress(m_socketHandle, hostname, port);
+    struct sockaddr_in socketAddress = CreateSocketAddress(address, port);
+    struct sockaddr *pSocketAddress = reinterpret_cast<sockaddr *>(&socketAddress);
 
-    if (::connect(m_socketHandle, (struct sockaddr *)&server, sizeof(server)) == SOCKET_ERROR)
+    if (::connect(m_socketHandle, pSocketAddress, sizeof(socketAddress)) == SOCKET_ERROR)
     {
         LOGS(m_socketHandle, "Error connecting");
         int error = System::GetErrorCode();
@@ -181,14 +192,28 @@ bool SocketImpl::Connect(const std::string &hostname, port_type port)
 }
 
 //==============================================================================
+bool SocketImpl::Connect(const std::string &hostname, port_type port)
+{
+    address_type address = 0;
+
+    if (HostnameToAddress(hostname, address))
+    {
+        return Connect(address, port);
+    }
+
+    return false;
+}
+
+//==============================================================================
 SocketPtr SocketImpl::Accept() const
 {
     SocketImplPtr ret = std::make_shared<SocketImpl>(m_protocol, m_spConfig);
 
-    struct sockaddr_in client;
-    int clientLen = sizeof(client);
+    struct sockaddr_in socketAddress;
+    struct sockaddr *pSocketAddress = reinterpret_cast<sockaddr *>(&socketAddress);
+    int socketAddressLength = static_cast<int>(sizeof(socketAddress));
 
-    socket_type skt = ::accept(m_socketHandle, (struct sockaddr *)&client, &clientLen);
+    socket_type skt = ::accept(m_socketHandle, pSocketAddress, &socketAddressLength);
 
     if (skt == InvalidSocket())
     {
@@ -200,8 +225,8 @@ SocketPtr SocketImpl::Accept() const
         LOGD(m_socketHandle, "Accepted new socket: %d (%d)", ret->GetSocketId(), skt);
 
         ret->m_socketHandle = skt;
-        ret->m_clientIp = ntohl(client.sin_addr.s_addr);
-        ret->m_clientPort = ntohs(client.sin_port);
+        ret->m_clientIp = ntohl(socketAddress.sin_addr.s_addr);
+        ret->m_clientPort = ntohs(socketAddress.sin_port);
         ret->m_aConnectedState.store(ConnectedState::Connected);
     }
 
@@ -209,17 +234,17 @@ SocketPtr SocketImpl::Accept() const
 }
 
 //==============================================================================
-size_t SocketImpl::Send(const std::string &msg) const
+size_t SocketImpl::Send(const std::string &message) const
 {
     bool wouldBlock = false;
-    return Send(msg, wouldBlock);
+    return Send(message, wouldBlock);
 }
 
 //==============================================================================
-size_t SocketImpl::Send(const std::string &msg, bool &wouldBlock) const
+size_t SocketImpl::Send(const std::string &message, bool &wouldBlock) const
 {
     static const std::string eom(1, m_socketEoM);
-    std::string toSend = msg + eom;
+    std::string toSend = message + eom;
 
     bool keepSending = !toSend.empty();
     size_t bytesSent = 0;
@@ -271,37 +296,49 @@ size_t SocketImpl::Send(const std::string &msg, bool &wouldBlock) const
 
 //==============================================================================
 size_t SocketImpl::SendTo(
-    const std::string &msg,
+    const std::string &message,
+    address_type address,
+    port_type port
+) const
+{
+    bool wouldBlock = false;
+    return SendTo(message, address, port, wouldBlock);
+}
+
+//==============================================================================
+size_t SocketImpl::SendTo(
+    const std::string &message,
     const std::string &hostname,
     port_type port
 ) const
 {
     bool wouldBlock = false;
-    return SendTo(msg, hostname, port, wouldBlock);
+    return SendTo(message, hostname, port, wouldBlock);
 }
 
 //==============================================================================
 size_t SocketImpl::SendTo(
-    const std::string &msg,
-    const std::string &hostname,
+    const std::string &message,
+    address_type address,
     port_type port,
     bool &wouldBlock
 ) const
 {
     static const std::string eom(1, m_socketEoM);
-    std::string toSend = msg + eom;
+    std::string toSend = message + eom;
 
     bool keepSending = !toSend.empty();
     size_t bytesSent = 0;
     wouldBlock = false;
 
-    struct sockaddr_in server = HostToSocketAddress(m_socketHandle, hostname, port);
+    struct sockaddr_in socketAddress = CreateSocketAddress(address, port);
+    struct sockaddr *pSocketAddress = reinterpret_cast<sockaddr *>(&socketAddress);
 
     while (keepSending)
     {
         int toSendSize = static_cast<int>(std::min(m_packetSize, toSend.size()));
         int currSent = ::sendto(m_socketHandle, toSend.c_str(), toSendSize, 0,
-            (struct sockaddr *)&server, sizeof(server));
+            pSocketAddress, sizeof(socketAddress));
 
         if (currSent > 0)
         {
@@ -330,6 +367,24 @@ size_t SocketImpl::SendTo(
     }
 
     return bytesSent;
+}
+
+//==============================================================================
+size_t SocketImpl::SendTo(
+    const std::string &message,
+    const std::string &hostname,
+    port_type port,
+    bool &wouldBlock
+) const
+{
+    address_type address = 0;
+
+    if (HostnameToAddress(hostname, address))
+    {
+        return SendTo(message, address, port, wouldBlock);
+    }
+
+    return 0;
 }
 
 //==============================================================================
@@ -399,17 +454,17 @@ std::string SocketImpl::RecvFrom(bool &wouldBlock, bool &isComplete) const
     wouldBlock = false;
     isComplete = false;
 
-    struct sockaddr_in client;
-    int clientLen = sizeof(client);
+    struct sockaddr_in socketAddress;
+    struct sockaddr *pSocketAddress = reinterpret_cast<sockaddr *>(&socketAddress);
+    int socketAddressLength = static_cast<int>(sizeof(socketAddress));
 
-    struct sockaddr *socketAddress = reinterpret_cast<sockaddr *>(&client);
     const int packetSize = static_cast<int>(m_packetSize);
 
     while (keepReading)
     {
         char *buff = (char *)calloc(1, m_packetSize * sizeof(char));
-        int bytesRead = ::recvfrom(m_socketHandle, buff, packetSize,
-            0, socketAddress, &clientLen);
+        int bytesRead = ::recvfrom(m_socketHandle, buff, packetSize, 0,
+            pSocketAddress, &socketAddressLength);
 
         if (bytesRead > 0)
         {
@@ -437,6 +492,26 @@ std::string SocketImpl::RecvFrom(bool &wouldBlock, bool &isComplete) const
     }
 
     return ret;
+}
+
+//==============================================================================
+bool SocketImpl::HostnameToAddress(
+    const std::string &hostname,
+    address_type &address
+) const
+{
+    struct hostent *ipAddress = ::gethostbyname(hostname.c_str());
+
+    if (ipAddress == NULL)
+    {
+        LOGS(m_socketHandle, "Error resolving %s", hostname);
+        return false;
+    }
+
+    memcpy((char *)&address, ipAddress->h_addr, ipAddress->h_length);
+    address = ntohl(address);
+
+    return true;
 }
 
 }

--- a/fly/socket/win/socket_impl.cpp
+++ b/fly/socket/win/socket_impl.cpp
@@ -107,7 +107,8 @@ bool SocketImpl::Bind(
 ) const
 {
     static const char bindForReuseOption = 1;
-    static const int bindForReuseOptionLength = static_cast<int>(sizeof(opt));
+    static const int bindForReuseOptionLength =
+        static_cast<int>(sizeof(bindForReuseOption));
 
     struct sockaddr_in socketAddress = CreateSocketAddress(address, port);
     struct sockaddr *pSocketAddress = reinterpret_cast<sockaddr *>(&socketAddress);

--- a/fly/socket/win/socket_impl.cpp
+++ b/fly/socket/win/socket_impl.cpp
@@ -49,6 +49,27 @@ SocketImpl::~SocketImpl()
 }
 
 //==============================================================================
+bool SocketImpl::HostnameToAddress(
+    const std::string &hostname,
+    address_type &address
+)
+{
+    struct hostent *ipAddress = ::gethostbyname(hostname.c_str());
+
+    if (ipAddress == NULL)
+    {
+        LOGS(-1, "Error resolving %s", hostname);
+        return false;
+    }
+
+    memcpy((char *)&address, ipAddress->h_addr, ipAddress->h_length);
+    address = ntohl(address);
+
+    LOGD(-1, "Converted hostname %s to %d", hostname, address);
+    return true;
+}
+
+//==============================================================================
 address_type SocketImpl::InAddrAny()
 {
     return INADDR_ANY;
@@ -401,26 +422,6 @@ std::string SocketImpl::RecvFrom(bool &wouldBlock, bool &isComplete) const
     }
 
     return ret;
-}
-
-//==============================================================================
-bool SocketImpl::HostnameToAddress(
-    const std::string &hostname,
-    address_type &address
-) const
-{
-    struct hostent *ipAddress = ::gethostbyname(hostname.c_str());
-
-    if (ipAddress == NULL)
-    {
-        LOGS(m_socketHandle, "Error resolving %s", hostname);
-        return false;
-    }
-
-    memcpy((char *)&address, ipAddress->h_addr, ipAddress->h_length);
-    address = ntohl(address);
-
-    return true;
 }
 
 }

--- a/fly/socket/win/socket_impl.h
+++ b/fly/socket/win/socket_impl.h
@@ -33,11 +33,8 @@ public:
 
     bool SetAsync();
 
-    bool Bind(address_type, port_type) const;
-    bool Bind(const std::string &, port_type) const;
-
-    bool BindForReuse(address_type, port_type) const;
-    bool BindForReuse(const std::string &, port_type) const;
+    bool Bind(address_type, port_type, BindOption) const;
+    bool Bind(const std::string &, port_type, BindOption) const;
 
     bool Listen();
 

--- a/fly/socket/win/socket_impl.h
+++ b/fly/socket/win/socket_impl.h
@@ -41,13 +41,13 @@ public:
 
     SocketPtr Accept() const;
 
+protected:
     size_t Send(const std::string &, bool &) const;
     size_t SendTo(const std::string &, address_type, port_type, bool &) const;
 
     std::string Recv(bool &, bool &) const;
     std::string RecvFrom(bool &, bool &) const;
 
-protected:
     bool HostnameToAddress(const std::string &, address_type &) const;
 };
 

--- a/fly/socket/win/socket_impl.h
+++ b/fly/socket/win/socket_impl.h
@@ -34,15 +34,25 @@ public:
     bool SetAsync();
 
     bool Bind(address_type, port_type) const;
+    bool Bind(const std::string &, port_type) const;
+
     bool BindForReuse(address_type, port_type) const;
+    bool BindForReuse(const std::string &, port_type) const;
+
     bool Listen();
+
+    bool Connect(address_type, port_type);
     bool Connect(const std::string &, port_type);
+
     SocketPtr Accept() const;
 
     size_t Send(const std::string &) const;
     size_t Send(const std::string &, bool &) const;
 
+    size_t SendTo(const std::string &, address_type, port_type) const;
     size_t SendTo(const std::string &, const std::string &, port_type) const;
+
+    size_t SendTo(const std::string &, address_type, port_type, bool &) const;
     size_t SendTo(const std::string &, const std::string &, port_type, bool &) const;
 
     std::string Recv() const;
@@ -50,6 +60,9 @@ public:
 
     std::string RecvFrom() const;
     std::string RecvFrom(bool &, bool &) const;
+
+protected:
+    bool HostnameToAddress(const std::string &, address_type &) const;
 };
 
 }

--- a/fly/socket/win/socket_impl.h
+++ b/fly/socket/win/socket_impl.h
@@ -23,6 +23,8 @@ public:
     SocketImpl(Protocol, const SocketConfigPtr &);
     ~SocketImpl();
 
+    static bool HostnameToAddress(const std::string &, address_type &);
+
     static address_type InAddrAny();
 
     static socket_type InvalidSocket();
@@ -47,8 +49,6 @@ protected:
 
     std::string Recv(bool &, bool &) const;
     std::string RecvFrom(bool &, bool &) const;
-
-    bool HostnameToAddress(const std::string &, address_type &) const;
 };
 
 }

--- a/fly/socket/win/socket_impl.h
+++ b/fly/socket/win/socket_impl.h
@@ -34,28 +34,17 @@ public:
     bool SetAsync();
 
     bool Bind(address_type, port_type, BindOption) const;
-    bool Bind(const std::string &, port_type, BindOption) const;
 
     bool Listen();
 
     bool Connect(address_type, port_type);
-    bool Connect(const std::string &, port_type);
 
     SocketPtr Accept() const;
 
-    size_t Send(const std::string &) const;
     size_t Send(const std::string &, bool &) const;
-
-    size_t SendTo(const std::string &, address_type, port_type) const;
-    size_t SendTo(const std::string &, const std::string &, port_type) const;
-
     size_t SendTo(const std::string &, address_type, port_type, bool &) const;
-    size_t SendTo(const std::string &, const std::string &, port_type, bool &) const;
 
-    std::string Recv() const;
     std::string Recv(bool &, bool &) const;
-
-    std::string RecvFrom() const;
     std::string RecvFrom(bool &, bool &) const;
 
 protected:

--- a/test/socket/main.cpp
+++ b/test/socket/main.cpp
@@ -153,8 +153,8 @@ TEST_F(SocketTest, Bind_MockBindFail)
     fly::MockSystem mock(fly::MockCall::Bind);
 
     fly::SocketPtr spSocket = CreateSocket(m_spServerSocketManager, fly::Protocol::TCP, false);
-    ASSERT_FALSE(spSocket->BindForReuse(fly::Socket::InAddrAny(), m_port));
-    ASSERT_FALSE(spSocket->Bind(fly::Socket::InAddrAny(), m_port));
+    ASSERT_FALSE(spSocket->Bind(fly::Socket::InAddrAny(), m_port, fly::BindOption::AllowReuse));
+    ASSERT_FALSE(spSocket->Bind(fly::Socket::InAddrAny(), m_port, fly::BindOption::SingleUse));
 }
 
 /**
@@ -165,7 +165,7 @@ TEST_F(SocketTest, Bind_MockSetsockoptFail)
     fly::MockSystem mock(fly::MockCall::Setsockopt);
 
     fly::SocketPtr spSocket = CreateSocket(m_spServerSocketManager, fly::Protocol::TCP, false);
-    ASSERT_FALSE(spSocket->BindForReuse(fly::Socket::InAddrAny(), m_port));
+    ASSERT_FALSE(spSocket->Bind(fly::Socket::InAddrAny(), m_port, fly::BindOption::AllowReuse));
 }
 
 /**
@@ -176,7 +176,7 @@ TEST_F(SocketTest, Listen_MockListenFail)
     fly::MockSystem mock(fly::MockCall::Listen);
 
     fly::SocketPtr spSocket = CreateSocket(m_spServerSocketManager, fly::Protocol::TCP, false);
-    ASSERT_TRUE(spSocket->BindForReuse(fly::Socket::InAddrAny(), m_port));
+    ASSERT_TRUE(spSocket->Bind(fly::Socket::InAddrAny(), m_port, fly::BindOption::AllowReuse));
     ASSERT_FALSE(spSocket->Listen());
 }
 
@@ -188,7 +188,7 @@ TEST_F(SocketTest, Connect_Sync_MockConnectFail)
     fly::MockSystem mock(fly::MockCall::Connect);
 
     fly::SocketPtr spServerSocket = CreateSocket(m_spServerSocketManager, fly::Protocol::TCP, true);
-    ASSERT_TRUE(spServerSocket->BindForReuse(fly::Socket::InAddrAny(), m_port));
+    ASSERT_TRUE(spServerSocket->Bind(fly::Socket::InAddrAny(), m_port, fly::BindOption::AllowReuse));
     ASSERT_TRUE(spServerSocket->Listen());
 
     fly::SocketPtr spClientSocket = CreateSocket(m_spClientSocketManager, fly::Protocol::TCP, false);
@@ -203,7 +203,7 @@ TEST_F(SocketTest, Connect_Sync_MockGethostbynameFail)
     fly::MockSystem mock(fly::MockCall::Gethostbyname);
 
     fly::SocketPtr spServerSocket = CreateSocket(m_spServerSocketManager, fly::Protocol::TCP, true);
-    ASSERT_TRUE(spServerSocket->BindForReuse(fly::Socket::InAddrAny(), m_port));
+    ASSERT_TRUE(spServerSocket->Bind(fly::Socket::InAddrAny(), m_port, fly::BindOption::AllowReuse));
     ASSERT_TRUE(spServerSocket->Listen());
 
     fly::SocketPtr spClientSocket = CreateSocket(m_spClientSocketManager, fly::Protocol::TCP, false);
@@ -218,7 +218,7 @@ TEST_F(SocketTest, Connect_Async_MockConnectFail)
     fly::MockSystem mock(fly::MockCall::Connect);
 
     fly::SocketPtr spServerSocket = CreateSocket(m_spServerSocketManager, fly::Protocol::TCP, true);
-    ASSERT_TRUE(spServerSocket->BindForReuse(fly::Socket::InAddrAny(), m_port));
+    ASSERT_TRUE(spServerSocket->Bind(fly::Socket::InAddrAny(), m_port, fly::BindOption::AllowReuse));
     ASSERT_TRUE(spServerSocket->Listen());
 
     fly::SocketPtr spClientSocket = CreateSocket(m_spClientSocketManager, fly::Protocol::TCP, true);
@@ -235,7 +235,7 @@ TEST_F(SocketTest, Connect_Async_MockConnectImmediateSuccess)
     fly::MockSystem mock(fly::MockCall::Connect, false);
 
     fly::SocketPtr spServerSocket = CreateSocket(m_spServerSocketManager, fly::Protocol::TCP, true);
-    ASSERT_TRUE(spServerSocket->BindForReuse(fly::Socket::InAddrAny(), m_port));
+    ASSERT_TRUE(spServerSocket->Bind(fly::Socket::InAddrAny(), m_port, fly::BindOption::AllowReuse));
     ASSERT_TRUE(spServerSocket->Listen());
 
     fly::SocketPtr spClientSocket = CreateSocket(m_spClientSocketManager, fly::Protocol::TCP, true);
@@ -252,7 +252,7 @@ TEST_F(SocketTest, Connect_Async_MockGetsockoptFail)
     fly::MockSystem mock(fly::MockCall::Getsockopt);
 
     fly::SocketPtr spServerSocket = CreateSocket(m_spServerSocketManager, fly::Protocol::TCP, true);
-    ASSERT_TRUE(spServerSocket->BindForReuse(fly::Socket::InAddrAny(), m_port));
+    ASSERT_TRUE(spServerSocket->Bind(fly::Socket::InAddrAny(), m_port, fly::BindOption::AllowReuse));
     ASSERT_TRUE(spServerSocket->Listen());
 
     fly::SocketManager::SocketCallback callback([&](...) { m_eventQueue.Push(1); } );
@@ -284,7 +284,7 @@ TEST_F(SocketTest, Accept_MockAcceptFail)
     fly::MockSystem mock(fly::MockCall::Accept);
 
     fly::SocketPtr spSocket = CreateSocket(m_spServerSocketManager, fly::Protocol::TCP, false);
-    ASSERT_TRUE(spSocket->BindForReuse(fly::Socket::InAddrAny(), m_port));
+    ASSERT_TRUE(spSocket->Bind(fly::Socket::InAddrAny(), m_port, fly::BindOption::AllowReuse));
     ASSERT_TRUE(spSocket->Listen());
 
     ASSERT_FALSE(spSocket->Accept());
@@ -298,7 +298,7 @@ TEST_F(SocketTest, Send_Sync_MockSendFail)
     fly::MockSystem mock(fly::MockCall::Send);
 
     fly::SocketPtr spServerSocket = CreateSocket(m_spServerSocketManager, fly::Protocol::TCP, true);
-    ASSERT_TRUE(spServerSocket->BindForReuse(fly::Socket::InAddrAny(), m_port));
+    ASSERT_TRUE(spServerSocket->Bind(fly::Socket::InAddrAny(), m_port, fly::BindOption::AllowReuse));
     ASSERT_TRUE(spServerSocket->Listen());
 
     fly::SocketPtr spClientSocket = CreateSocket(m_spClientSocketManager, fly::Protocol::TCP, false);
@@ -315,7 +315,7 @@ TEST_F(SocketTest, Send_Async_MockSendFail)
     fly::MockSystem mock(fly::MockCall::Send);
 
     fly::SocketPtr spServerSocket = CreateSocket(m_spServerSocketManager, fly::Protocol::TCP, true);
-    ASSERT_TRUE(spServerSocket->BindForReuse(fly::Socket::InAddrAny(), m_port));
+    ASSERT_TRUE(spServerSocket->Bind(fly::Socket::InAddrAny(), m_port, fly::BindOption::AllowReuse));
     ASSERT_TRUE(spServerSocket->Listen());
 
     fly::SocketManager::SocketCallback callback([&](...) { m_eventQueue.Push(1); } );
@@ -349,7 +349,7 @@ TEST_F(SocketTest, Send_Sync_MockSendtoFail)
     fly::MockSystem mock(fly::MockCall::Sendto);
 
     fly::SocketPtr spServerSocket = CreateSocket(m_spServerSocketManager, fly::Protocol::TCP, true);
-    ASSERT_TRUE(spServerSocket->BindForReuse(fly::Socket::InAddrAny(), m_port));
+    ASSERT_TRUE(spServerSocket->Bind(fly::Socket::InAddrAny(), m_port, fly::BindOption::AllowReuse));
 
     fly::SocketPtr spClientSocket = CreateSocket(m_spClientSocketManager, fly::Protocol::UDP, false);
     ASSERT_EQ(spClientSocket->SendTo(s_smallMessage, m_host, m_port), 0);
@@ -363,7 +363,7 @@ TEST_F(SocketTest, Send_Async_MockSendtoFail)
     fly::MockSystem mock(fly::MockCall::Sendto);
 
     fly::SocketPtr spServerSocket = CreateSocket(m_spServerSocketManager, fly::Protocol::TCP, true);
-    ASSERT_TRUE(spServerSocket->BindForReuse(fly::Socket::InAddrAny(), m_port));
+    ASSERT_TRUE(spServerSocket->Bind(fly::Socket::InAddrAny(), m_port, fly::BindOption::AllowReuse));
 
     fly::SocketManager::SocketCallback callback([&](...) { m_eventQueue.Push(1); } );
     m_spClientSocketManager->SetClientCallbacks(nullptr, callback);
@@ -386,7 +386,7 @@ TEST_F(SocketTest, Recv_Sync_MockRecvFail)
     fly::MockSystem mock(fly::MockCall::Recv);
 
     fly::SocketPtr spServerSocket = CreateSocket(m_spServerSocketManager, fly::Protocol::TCP, true);
-    ASSERT_TRUE(spServerSocket->BindForReuse(fly::Socket::InAddrAny(), m_port));
+    ASSERT_TRUE(spServerSocket->Bind(fly::Socket::InAddrAny(), m_port, fly::BindOption::AllowReuse));
     ASSERT_TRUE(spServerSocket->Listen());
 
     fly::SocketPtr spClientSocket = CreateSocket(m_spClientSocketManager, fly::Protocol::TCP, false);
@@ -401,7 +401,7 @@ TEST_F(SocketTest, Recv_Async_MockRecvFail)
     fly::MockSystem mock(fly::MockCall::Recv);
 
     fly::SocketPtr spServerSocket = CreateSocket(m_spServerSocketManager, fly::Protocol::TCP, true);
-    ASSERT_TRUE(spServerSocket->BindForReuse(fly::Socket::InAddrAny(), m_port));
+    ASSERT_TRUE(spServerSocket->Bind(fly::Socket::InAddrAny(), m_port, fly::BindOption::AllowReuse));
     ASSERT_TRUE(spServerSocket->Listen());
 
     fly::SocketPtr spRecvSocket;
@@ -436,7 +436,7 @@ TEST_F(SocketTest, Recv_Sync_MockRecvfromFail)
     fly::MockSystem mock(fly::MockCall::Recvfrom);
 
     fly::SocketPtr spServerSocket = CreateSocket(m_spServerSocketManager, fly::Protocol::UDP, true);
-    ASSERT_TRUE(spServerSocket->BindForReuse(fly::Socket::InAddrAny(), m_port));
+    ASSERT_TRUE(spServerSocket->Bind(fly::Socket::InAddrAny(), m_port, fly::BindOption::AllowReuse));
 
     fly::SocketPtr spClientSocket = CreateSocket(m_spClientSocketManager, fly::Protocol::UDP, false);
     ASSERT_EQ(spClientSocket->RecvFrom(), std::string());
@@ -450,7 +450,7 @@ TEST_F(SocketTest, Recv_Async_MockRecvfromFail)
     fly::MockSystem mock(fly::MockCall::Recvfrom);
 
     fly::SocketPtr spServerSocket = CreateSocket(m_spServerSocketManager, fly::Protocol::UDP, true);
-    ASSERT_TRUE(spServerSocket->BindForReuse(fly::Socket::InAddrAny(), m_port));
+    ASSERT_TRUE(spServerSocket->Bind(fly::Socket::InAddrAny(), m_port, fly::BindOption::AllowReuse));
 
     fly::SocketManager::SocketCallback callback([&](...) { m_eventQueue.Push(1); } );
     m_spServerSocketManager->SetClientCallbacks(nullptr, callback);
@@ -489,7 +489,7 @@ public:
         ASSERT_TRUE(spAcceptSocket->IsTcp());
         ASSERT_FALSE(spAcceptSocket->IsUdp());
 
-        ASSERT_TRUE(spAcceptSocket->BindForReuse(fly::Socket::InAddrAny(), m_port));
+        ASSERT_TRUE(spAcceptSocket->Bind(fly::Socket::InAddrAny(), m_port, fly::BindOption::AllowReuse));
         ASSERT_TRUE(spAcceptSocket->Listen());
         m_eventQueue.Push(1);
 
@@ -652,7 +652,7 @@ public:
         ASSERT_FALSE(spRecvSocket->IsTcp());
         ASSERT_TRUE(spRecvSocket->IsUdp());
 
-        ASSERT_TRUE(spRecvSocket->BindForReuse(fly::Socket::InAddrAny(), m_port));
+        ASSERT_TRUE(spRecvSocket->Bind(fly::Socket::InAddrAny(), m_port, fly::BindOption::AllowReuse));
         m_eventQueue.Push(1);
 
         if (doAsync)


### PR DESCRIPTION
Some methods took string addresses/hostnames as parameters, others took
numeric addresses. For flexibility, provide both for each of those methods.

A bunch of methods don't need to be repeatedly defined for each socket
implementation. Move them from the SocketImpl class to the Socket class.

The methods that take in a bool to store whether the operation would
block or is complete do not need to be public.