### PR TITLE
Add support for clang 6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,10 @@ matrix:
 
           packages:
             - clang-6.0
+            - gcc-7
+            - g++-7
+            - gcc-7-multilib
+            - g++-7-multilib
 
       env:
         - MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,9 @@ matrix:
 
       addons:
         apt:
+          sources:
+            - llvm-toolchain-trusty-6.0
+
           packages:
             - clang-6.0
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ matrix:
         apt:
           sources:
             - llvm-toolchain-trusty-6.0
+            - ubuntu-toolchain-r-test
 
           packages:
             - clang-6.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ dist: trusty
 
 matrix:
   include:
+    # Linux GCC 7
     - os: linux
 
       addons:
@@ -20,6 +21,17 @@ matrix:
 
       env:
         - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+
+    # Linux Clang 6
+    - os: linux
+
+      addons:
+        apt:
+          packages:
+            - clang-6.0
+
+      env:
+        - MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0"
 
 before_install:
   - eval "$MATRIX_EVAL"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ dist: trusty
 
 matrix:
   include:
-    # Linux GCC 7
     - os: linux
 
       addons:
@@ -21,25 +20,6 @@ matrix:
 
       env:
         - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
-
-    # Linux Clang 6
-    - os: linux
-
-      addons:
-        apt:
-          sources:
-            - llvm-toolchain-trusty-6.0
-            - ubuntu-toolchain-r-test
-
-          packages:
-            - clang-6.0
-            - gcc-7
-            - g++-7
-            - gcc-7-multilib
-            - g++-7-multilib
-
-      env:
-        - MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0"
 
 before_install:
   - eval "$MATRIX_EVAL"

--- a/build/nix/flags.mk
+++ b/build/nix/flags.mk
@@ -26,7 +26,9 @@ ifneq ($(findstring $(target),$(TEST_TARGETS)),)
     CF_ALL += -I$(SOURCE_ROOT)/test/googletest/googletest
 endif
 
-# Optimize release builds and add GDB symbols to debug builds
+# Optimize release builds, and add debug symbols / use address sanitizer for
+# debug builds - but only use address sanitizer on 64-bit builds:
+# https://github.com/google/sanitizers/issues/954
 ifeq ($(release), 1)
     CF_ALL += -O2
 
@@ -34,7 +36,11 @@ ifeq ($(release), 1)
         CF_ALL += -fPIC
     endif
 else
-    CF_ALL += -O0 -g --coverage -fsanitize=address -fno-omit-frame-pointer
+    CF_ALL += -O0 -g --coverage
+
+    ifeq ($(arch), x64)
+        CF_ALL += -fsanitize=address -fno-omit-frame-pointer
+    endif
 endif
 
 # Qt5 flags

--- a/fly/files.mk
+++ b/fly/files.mk
@@ -7,7 +7,8 @@ SRC_DIRS_$(d) := \
     fly/socket \
     fly/string \
     fly/system \
-    fly/task
+    fly/task \
+    fly/types
 
 # Add libfly.so to release package
 $(eval $(call ADD_REL_LIB, $(TARGET_NAME)))

--- a/fly/parser/ini_parser.h
+++ b/fly/parser/ini_parser.h
@@ -25,6 +25,11 @@ public:
      */
     IniParser();
 
+    /**
+     * Destructor.
+     */
+    virtual ~IniParser() = default;
+
 protected:
     /**
      * Parse a stream and retrieve the parsed values.

--- a/fly/parser/json_parser.h
+++ b/fly/parser/json_parser.h
@@ -58,6 +58,11 @@ public:
      */
     JsonParser();
 
+    /**
+     * Constructor.
+     */
+    virtual ~JsonParser() = default;
+
 protected:
     /**
      * Parse a stream and retrieve the parsed values.

--- a/fly/parser/parser.h
+++ b/fly/parser/parser.h
@@ -26,6 +26,11 @@ public:
     Parser();
 
     /**
+     * Destructor.
+     */
+    virtual ~Parser() = default;
+
+    /**
      * Parse a string and retrieve parsed values.
      *
      * @param string String contents to parse.

--- a/fly/socket/nix/socket_impl.h
+++ b/fly/socket/nix/socket_impl.h
@@ -21,7 +21,7 @@ class SocketImpl : public Socket
 {
 public:
     SocketImpl(Protocol, const SocketConfigPtr &);
-    ~SocketImpl();
+    virtual ~SocketImpl();
 
     static bool HostnameToAddress(const std::string &, address_type &);
 

--- a/fly/socket/nix/socket_manager_impl.cpp
+++ b/fly/socket/nix/socket_manager_impl.cpp
@@ -75,10 +75,8 @@ void SocketManagerImpl::handleSocketIO(fd_set *readFd, fd_set *writeFd)
 {
     SocketList newClients, connectedClients, closedClients;
 
-    for (auto it = m_aioSockets.begin(); it != m_aioSockets.end(); ++it)
+    for (const SocketPtr &spSocket : m_aioSockets)
     {
-        SocketPtr &spSocket = *it;
-
         if (spSocket->IsValid())
         {
             socket_type handle = spSocket->GetHandle();
@@ -110,10 +108,6 @@ void SocketManagerImpl::handleSocketIO(fd_set *readFd, fd_set *writeFd)
                     if (spSocket->FinishConnect())
                     {
                         connectedClients.push_back(spSocket);
-                    }
-                    else
-                    {
-                        closedClients.push_back(spSocket);
                     }
                 }
                 else if (spSocket->IsConnected() || spSocket->IsUdp())

--- a/fly/socket/socket.h
+++ b/fly/socket/socket.h
@@ -33,6 +33,11 @@ public:
     Socket(Protocol, const SocketConfigPtr &);
 
     /**
+     * Destructor.
+     */
+    virtual ~Socket() = default;
+
+    /**
      * Convert a string hostname or IPv4 address to a host-order numeric IPv4
      * address.
      *

--- a/fly/socket/socket_manager.cpp
+++ b/fly/socket/socket_manager.cpp
@@ -103,17 +103,15 @@ void SocketManager::HandleNewAndClosedSockets(
     m_aioSockets.insert(m_aioSockets.end(), newSockets.begin(), newSockets.end());
 
     // Remove closed sockets from the socket system
-    for (auto it = closedSockets.begin(); it != closedSockets.end(); ++it)
+    for (const SocketPtr &spSocket : closedSockets)
     {
-        const SocketPtr &spSocket = *it;
-
-        auto is_same_socket = [&spSocket](SocketPtr spClosed)
+        auto is_same = [&spSocket](const SocketPtr &spClosed) -> bool
         {
             return (spSocket->GetSocketId() == spClosed->GetSocketId());
         };
 
         m_aioSockets.erase(
-            std::remove_if(m_aioSockets.begin(), m_aioSockets.end(), is_same_socket),
+            std::remove_if(m_aioSockets.begin(), m_aioSockets.end(), is_same),
             m_aioSockets.end()
         );
     }

--- a/fly/socket/win/socket_impl.h
+++ b/fly/socket/win/socket_impl.h
@@ -21,7 +21,7 @@ class SocketImpl : public Socket
 {
 public:
     SocketImpl(Protocol, const SocketConfigPtr &);
-    ~SocketImpl();
+    virtual ~SocketImpl();
 
     static bool HostnameToAddress(const std::string &, address_type &);
 

--- a/fly/types/json.cpp
+++ b/fly/types/json.cpp
@@ -742,7 +742,7 @@ void Json::validateCharacter(
         return true;
     };
 
-    auto invalid = [this, &c](int location)
+    auto invalid = [&c](int location)
     {
         throw JsonException(nullptr, fly::String::Format(
             "Invalid control character '%x' (location %d)", int(c), location

--- a/test/config/config.cpp
+++ b/test/config/config.cpp
@@ -1,3 +1,5 @@
+#include <cstddef>
+
 #include <gtest/gtest.h>
 
 #include "fly/config/config.h"
@@ -32,7 +34,7 @@ TEST_F(ConfigTest, NonCovertibleTest)
     m_spConfig->Update(values);
 
     EXPECT_EQ(m_spConfig->GetValue<int>("name", 12), 12);
-    EXPECT_EQ(m_spConfig->GetValue<nullptr_t>("address", nullptr), nullptr);
+    EXPECT_EQ(m_spConfig->GetValue<std::nullptr_t>("address", nullptr), nullptr);
 }
 
 //==============================================================================

--- a/test/config/files.mk
+++ b/test/config/files.mk
@@ -10,7 +10,9 @@ SRC_DIRS_$(d) := \
     fly/types
 
 # Define libraries to link
-LDLIBS_$(d) := -lpthread
+LDLIBS_$(d) := \
+    -latomic \
+    -lpthread
 
 # Define source files
 $(eval $(call WILDCARD_SOURCES))

--- a/test/logger/files.mk
+++ b/test/logger/files.mk
@@ -10,7 +10,9 @@ SRC_DIRS_$(d) := \
     fly/types
 
 # Define libraries to link
-LDLIBS_$(d) := -lpthread
+LDLIBS_$(d) := \
+    -latomic \
+    -lpthread
 
 # Define source files
 $(eval $(call WILDCARD_SOURCES))

--- a/test/parser/files.mk
+++ b/test/parser/files.mk
@@ -10,7 +10,9 @@ SRC_DIRS_$(d) := \
     fly/types
 
 # Define libraries to link
-LDLIBS_$(d) := -lpthread
+LDLIBS_$(d) := \
+    -latomic \
+    -lpthread
 
 # Define source files
 $(eval $(call WILDCARD_SOURCES))

--- a/test/path/files.mk
+++ b/test/path/files.mk
@@ -10,7 +10,9 @@ SRC_DIRS_$(d) := \
     fly/types
 
 # Define libraries to link
-LDLIBS_$(d) := -lpthread
+LDLIBS_$(d) := \
+    -latomic \
+    -lpthread
 
 # Define source files
 $(eval $(call WILDCARD_SOURCES))

--- a/test/socket/files.mk
+++ b/test/socket/files.mk
@@ -11,7 +11,9 @@ SRC_DIRS_$(d) := \
     fly/types
 
 # Define libraries to link
-LDLIBS_$(d) := -lpthread
+LDLIBS_$(d) := \
+    -latomic \
+    -lpthread
 
 # Define source files
 $(eval $(call WILDCARD_SOURCES))

--- a/test/socket/main.cpp
+++ b/test/socket/main.cpp
@@ -285,8 +285,8 @@ TEST_F(SocketTest, Connect_Async_MockGetsockoptFail)
     ASSERT_TRUE(spServerSocket->Bind(fly::Socket::InAddrAny(), m_port, fly::BindOption::AllowReuse));
     ASSERT_TRUE(spServerSocket->Listen());
 
-    fly::SocketManager::SocketCallback callback([&](...) { m_eventQueue.Push(1); } );
-    m_spClientSocketManager->SetClientCallbacks(callback, callback);
+    fly::SocketManager::SocketCallback callback([&](fly::SocketPtr) { m_eventQueue.Push(1); } );
+    m_spClientSocketManager->SetClientCallbacks(nullptr, callback);
 
     int item = 0;
     std::chrono::seconds waitTime(10);
@@ -295,11 +295,6 @@ TEST_F(SocketTest, Connect_Async_MockGetsockoptFail)
 
     fly::ConnectedState state = spClientSocket->ConnectAsync(m_host, m_port);
     ASSERT_NE(state, fly::ConnectedState::Disconnected);
-
-    if (state == fly::ConnectedState::Connecting)
-    {
-        ASSERT_TRUE(m_eventQueue.Pop(item, waitTime));
-    }
 
     ASSERT_TRUE(m_eventQueue.Pop(item, waitTime));
     ASSERT_FALSE(spClientSocket->IsConnected());
@@ -334,7 +329,7 @@ TEST_F(SocketTest, Send_Sync_MockSendFail)
     fly::SocketPtr spClientSocket = CreateSocket(m_spClientSocketManager, fly::Protocol::TCP, false);
     ASSERT_TRUE(spClientSocket->Connect(m_host, m_port));
 
-    ASSERT_EQ(spClientSocket->Send(s_smallMessage), 0);
+    ASSERT_EQ(spClientSocket->Send(s_smallMessage), 0U);
 }
 
 /**
@@ -348,7 +343,7 @@ TEST_F(SocketTest, Send_Async_MockSendFail)
     ASSERT_TRUE(spServerSocket->Bind(fly::Socket::InAddrAny(), m_port, fly::BindOption::AllowReuse));
     ASSERT_TRUE(spServerSocket->Listen());
 
-    fly::SocketManager::SocketCallback callback([&](...) { m_eventQueue.Push(1); } );
+    fly::SocketManager::SocketCallback callback([&](fly::SocketPtr) { m_eventQueue.Push(1); } );
     m_spClientSocketManager->SetClientCallbacks(callback, callback);
 
     int item = 0;
@@ -382,7 +377,7 @@ TEST_F(SocketTest, Send_Sync_MockSendtoFail)
     ASSERT_TRUE(spServerSocket->Bind(fly::Socket::InAddrAny(), m_port, fly::BindOption::AllowReuse));
 
     fly::SocketPtr spClientSocket = CreateSocket(m_spClientSocketManager, fly::Protocol::UDP, false);
-    ASSERT_EQ(spClientSocket->SendTo(s_smallMessage, m_host, m_port), 0);
+    ASSERT_EQ(spClientSocket->SendTo(s_smallMessage, m_host, m_port), 0U);
 }
 
 /**
@@ -396,7 +391,7 @@ TEST_F(SocketTest, Send_Sync_MockGethostbynameFail)
     ASSERT_TRUE(spServerSocket->Bind(fly::Socket::InAddrAny(), m_port, fly::BindOption::AllowReuse));
 
     fly::SocketPtr spClientSocket = CreateSocket(m_spClientSocketManager, fly::Protocol::UDP, false);
-    ASSERT_EQ(spClientSocket->SendTo(s_smallMessage, m_host, m_port), 0);
+    ASSERT_EQ(spClientSocket->SendTo(s_smallMessage, m_host, m_port), 0U);
 }
 
 /**
@@ -409,7 +404,7 @@ TEST_F(SocketTest, Send_Async_MockSendtoFail)
     fly::SocketPtr spServerSocket = CreateSocket(m_spServerSocketManager, fly::Protocol::TCP, true);
     ASSERT_TRUE(spServerSocket->Bind(fly::Socket::InAddrAny(), m_port, fly::BindOption::AllowReuse));
 
-    fly::SocketManager::SocketCallback callback([&](...) { m_eventQueue.Push(1); } );
+    fly::SocketManager::SocketCallback callback([&](fly::SocketPtr) { m_eventQueue.Push(1); } );
     m_spClientSocketManager->SetClientCallbacks(nullptr, callback);
 
     int item = 0;
@@ -470,7 +465,7 @@ TEST_F(SocketTest, Recv_Async_MockRecvFail)
         m_eventQueue.Push(1);
     });
 
-    fly::SocketManager::SocketCallback disconnectCallback([&](...) { m_eventQueue.Push(1); } );
+    fly::SocketManager::SocketCallback disconnectCallback([&](fly::SocketPtr) { m_eventQueue.Push(1); } );
     m_spServerSocketManager->SetClientCallbacks(connectCallback, disconnectCallback);
 
     int item = 0;
@@ -510,7 +505,7 @@ TEST_F(SocketTest, Recv_Async_MockRecvfromFail)
     fly::SocketPtr spServerSocket = CreateSocket(m_spServerSocketManager, fly::Protocol::UDP, true);
     ASSERT_TRUE(spServerSocket->Bind(fly::Socket::InAddrAny(), m_port, fly::BindOption::AllowReuse));
 
-    fly::SocketManager::SocketCallback callback([&](...) { m_eventQueue.Push(1); } );
+    fly::SocketManager::SocketCallback callback([&](fly::SocketPtr) { m_eventQueue.Push(1); } );
     m_spServerSocketManager->SetClientCallbacks(nullptr, callback);
 
     int item = 0;
@@ -593,7 +588,7 @@ public:
         std::chrono::seconds waitTime(120);
         ASSERT_TRUE(m_eventQueue.Pop(item, waitTime));
 
-        fly::SocketManager::SocketCallback callback([&](...) { m_eventQueue.Push(1); } );
+        fly::SocketManager::SocketCallback callback([&](fly::SocketPtr) { m_eventQueue.Push(1); } );
         m_spClientSocketManager->SetClientCallbacks(callback, nullptr);
 
         if (doAsync)

--- a/test/string/files.mk
+++ b/test/string/files.mk
@@ -3,7 +3,9 @@ SRC_DIRS_$(d) := \
     fly/string
 
 # Define libraries to link
-LDLIBS_$(d) := -lpthread
+LDLIBS_$(d) := \
+    -latomic \
+    -lpthread
 
 # Define source files
 $(eval $(call WILDCARD_SOURCES))

--- a/test/system/files.mk
+++ b/test/system/files.mk
@@ -13,7 +13,9 @@ SRC_DIRS_$(d) := \
 LDFLAGS_$(d) += -static-libstdc++
 
 # Define libraries to link
-LDLIBS_$(d) := -lpthread
+LDLIBS_$(d) := \
+    -latomic \
+    -lpthread
 
 # Define source files
 $(eval $(call WILDCARD_SOURCES))

--- a/test/task/files.mk
+++ b/test/task/files.mk
@@ -10,7 +10,9 @@ SRC_DIRS_$(d) := \
     fly/types
 
 # Define libraries to link
-LDLIBS_$(d) := -lpthread
+LDLIBS_$(d) := \
+    -latomic \
+    -lpthread
 
 # Define source files
 $(eval $(call WILDCARD_SOURCES))

--- a/test/traits/files.mk
+++ b/test/traits/files.mk
@@ -2,7 +2,9 @@
 SRC_DIRS_$(d) :=
 
 # Define libraries to link
-LDLIBS_$(d) := -lpthread
+LDLIBS_$(d) := \
+    -latomic \
+    -lpthread
 
 # Define source files
 $(eval $(call WILDCARD_SOURCES))

--- a/test/types/files.mk
+++ b/test/types/files.mk
@@ -4,7 +4,9 @@ SRC_DIRS_$(d) := \
     fly/types
 
 # Define libraries to link
-LDLIBS_$(d) := -lpthread
+LDLIBS_$(d) := \
+    -latomic \
+    -lpthread
 
 # Define source files
 $(eval $(call WILDCARD_SOURCES))


### PR DESCRIPTION
Fix warnings and errors found with clang. Mostly compiler/linker stuff, e.g.
deleting polymorphic classes with non-virtual destructors.

Only really interesting one was SIGILL is raised in socket_test when the socket
callbacks were declared like this:

    [&](...) { };

Instead of:

    [&](fly::SocketPtr) { };

Not really sure why.

Haven't added clang to the Travis build, having trouble getting Travis to run
with clang 6.0.