### PR TITLE
 Make socket test faster by not using huge messages

### DIFF
--- a/fly/socket/nix/socket_impl.cpp
+++ b/fly/socket/nix/socket_impl.cpp
@@ -140,7 +140,7 @@ bool SocketImpl::Bind(
     static const socklen_t bindForReuseOptionLength = sizeof(bindForReuseOption);
 
     struct sockaddr_in socketAddress = CreateSocketAddress(address, port);
-    struct sockaddr *pSocketAddress = reinterpret_cast<sockaddr *>(&socketAddress);
+    auto *pSocketAddress = reinterpret_cast<sockaddr *>(&socketAddress);
 
     switch (option)
     {
@@ -184,7 +184,7 @@ bool SocketImpl::Listen()
 bool SocketImpl::Connect(address_type address, port_type port)
 {
     struct sockaddr_in socketAddress = CreateSocketAddress(address, port);
-    struct sockaddr *pSocketAddress = reinterpret_cast<sockaddr *>(&socketAddress);
+    auto *pSocketAddress = reinterpret_cast<sockaddr *>(&socketAddress);
 
     if (::connect(m_socketHandle, pSocketAddress, sizeof(socketAddress)) == -1)
     {
@@ -209,7 +209,7 @@ SocketPtr SocketImpl::Accept() const
     SocketImplPtr ret = std::make_shared<SocketImpl>(m_protocol, m_spConfig);
 
     struct sockaddr_in socketAddress;
-    struct sockaddr *pSocketAddress = reinterpret_cast<sockaddr *>(&socketAddress);
+    auto *pSocketAddress = reinterpret_cast<sockaddr *>(&socketAddress);
     socklen_t socketAddressLength = sizeof(socketAddress);
 
     socket_type skt = ::accept(m_socketHandle, pSocketAddress, &socketAddressLength);
@@ -258,7 +258,7 @@ size_t SocketImpl::Send(const std::string &message, bool &wouldBlock) const
             }
 
             toSend = toSend.substr(currSent, std::string::npos);
-            keepSending = (toSend.length() > 0);
+            keepSending = !toSend.empty();
         }
         else
         {
@@ -291,7 +291,7 @@ size_t SocketImpl::SendTo(
     wouldBlock = false;
 
     struct sockaddr_in socketAddress = CreateSocketAddress(address, port);
-    struct sockaddr *pSocketAddress = reinterpret_cast<sockaddr *>(&socketAddress);
+    auto *pSocketAddress = reinterpret_cast<sockaddr *>(&socketAddress);
 
     while (keepSending)
     {
@@ -311,7 +311,7 @@ size_t SocketImpl::SendTo(
             }
 
             toSend = toSend.substr(currSent, std::string::npos);
-            keepSending = (toSend.length() > 0);
+            keepSending = !toSend.empty();
         }
         else
         {
@@ -380,7 +380,7 @@ std::string SocketImpl::RecvFrom(bool &wouldBlock, bool &isComplete) const
     isComplete = false;
 
     struct sockaddr_in socketAddress;
-    struct sockaddr *pSocketAddress = reinterpret_cast<sockaddr *>(&socketAddress);
+    auto *pSocketAddress = reinterpret_cast<sockaddr *>(&socketAddress);
     socklen_t socketAddressLength = sizeof(socketAddress);
 
     while (keepReading)

--- a/test/mock/mock_system.cpp
+++ b/test/mock/mock_system.cpp
@@ -59,7 +59,7 @@ bool MockSystem::MockEnabled(MockCall mock, bool &fail)
 
         if (it != s_mockedCalls.end())
         {
-            LOGC_NO_LOCK("Using mock for %s()", mock);
+            LOGC_NO_LOCK("Using mock for %s", mock);
             fail = it->second;
             return true;
         }

--- a/test/mock/nix/mock_list.cpp
+++ b/test/mock/nix/mock_list.cpp
@@ -61,6 +61,9 @@ std::ostream &operator << (std::ostream &stream, MockCall call)
     case MockCall::Send:
         stream << "send";
         break;
+    case MockCall::Send_Blocking:
+        stream << "send (blocking)";
+        break;
     case MockCall::Sendto:
         stream << "sendto";
         break;

--- a/test/mock/nix/mock_list.h
+++ b/test/mock/nix/mock_list.h
@@ -28,6 +28,7 @@ enum class MockCall : unsigned int
     Recvfrom,
     Remove,
     Send,
+    Send_Blocking,
     Sendto,
     Setsockopt,
     Socket,

--- a/test/mock/nix/mock_send.cpp
+++ b/test/mock/nix/mock_send.cpp
@@ -17,10 +17,17 @@ extern "C"
         if (fly::MockSystem::MockEnabled(fly::MockCall::Send))
         {
             errno = 0;
-            return -1;
+        }
+        else if (fly::MockSystem::MockEnabled(fly::MockCall::Send_Blocking))
+        {
+            errno = EWOULDBLOCK;
+        }
+        else
+        {
+            return __real_send(sockfd, buf, len, flags);
         }
 
-        return __real_send(sockfd, buf, len, flags);
+        return -1;
     }
 
 #ifdef __cplusplus

--- a/test/mock/nix/mock_send.cpp
+++ b/test/mock/nix/mock_send.cpp
@@ -17,17 +17,21 @@ extern "C"
         if (fly::MockSystem::MockEnabled(fly::MockCall::Send))
         {
             errno = 0;
+            return -1;
         }
         else if (fly::MockSystem::MockEnabled(fly::MockCall::Send_Blocking))
         {
-            errno = EWOULDBLOCK;
-        }
-        else
-        {
-            return __real_send(sockfd, buf, len, flags);
+            // On the first call, send all but the last byte, setting errno to
+            // indicate that the send would have "blocked". Subsequent calls
+            // will have len == 1; go ahead and finish the send at that point.
+            if (len > 1)
+            {
+                errno = EWOULDBLOCK;
+                len -= 1;
+            }
         }
 
-        return -1;
+        return __real_send(sockfd, buf, len, flags);
     }
 
 #ifdef __cplusplus

--- a/test/socket/main.cpp
+++ b/test/socket/main.cpp
@@ -20,12 +20,6 @@
     #include "test/mock/mock_system.h"
 #endif
 
-namespace
-{
-    static std::string s_largeMessage;
-    static std::string s_smallMessage;
-}
-
 //==============================================================================
 class SocketTest : public ::testing::Test
 {
@@ -40,16 +34,10 @@ public:
 
         m_host("localhost"),
         m_address(0),
-        m_port(12390)
+        m_port(12390),
+
+        m_message(fly::String::GenerateRandomString((1 << 10) - 1))
     {
-        if (s_largeMessage.empty())
-        {
-            s_largeMessage = fly::String::GenerateRandomString((128 << 20) - 1);
-        }
-        if (s_smallMessage.empty())
-        {
-            s_smallMessage = fly::String::GenerateRandomString((64 << 10) - 1);
-        }
     }
 
     virtual void ServerThread(bool)
@@ -117,6 +105,8 @@ protected:
     std::string m_host;
     fly::address_type m_address;
     fly::port_type m_port;
+
+    std::string m_message;
 };
 
 #ifdef FLY_LINUX
@@ -289,7 +279,7 @@ TEST_F(SocketTest, Connect_Async_MockGetsockoptFail)
     m_spClientSocketManager->SetClientCallbacks(nullptr, callback);
 
     int item = 0;
-    std::chrono::seconds waitTime(10);
+    std::chrono::milliseconds waitTime(100);
 
     fly::SocketPtr spClientSocket = CreateSocket(m_spClientSocketManager, fly::Protocol::TCP, true);
 
@@ -329,7 +319,7 @@ TEST_F(SocketTest, Send_Sync_MockSendFail)
     fly::SocketPtr spClientSocket = CreateSocket(m_spClientSocketManager, fly::Protocol::TCP, false);
     ASSERT_TRUE(spClientSocket->Connect(m_host, m_port));
 
-    ASSERT_EQ(spClientSocket->Send(s_smallMessage), 0U);
+    ASSERT_EQ(spClientSocket->Send(m_message), 0U);
 }
 
 /**
@@ -347,7 +337,7 @@ TEST_F(SocketTest, Send_Async_MockSendFail)
     m_spClientSocketManager->SetClientCallbacks(callback, callback);
 
     int item = 0;
-    std::chrono::seconds waitTime(10);
+    std::chrono::milliseconds waitTime(100);
 
     fly::SocketPtr spClientSocket = CreateSocket(m_spClientSocketManager, fly::Protocol::TCP, true);
 
@@ -360,10 +350,45 @@ TEST_F(SocketTest, Send_Async_MockSendFail)
     }
 
     ASSERT_TRUE(spClientSocket->IsConnected());
-    ASSERT_TRUE(spClientSocket->SendAsync(s_smallMessage));
+    ASSERT_TRUE(spClientSocket->SendAsync(m_message));
 
     ASSERT_TRUE(m_eventQueue.Pop(item, waitTime));
     ASSERT_FALSE(spClientSocket->IsValid());
+}
+
+/**
+ * Test handling for when socket sending (TCP) blocks due to ::send() system call.
+ */
+TEST_F(SocketTest, Send_Async_MockSendBlock)
+{
+    fly::MockSystem mock(fly::MockCall::Send_Blocking);
+
+    fly::SocketPtr spServerSocket = CreateSocket(m_spServerSocketManager, fly::Protocol::TCP, true);
+    ASSERT_TRUE(spServerSocket->Bind(fly::Socket::InAddrAny(), m_port, fly::BindOption::AllowReuse));
+    ASSERT_TRUE(spServerSocket->Listen());
+
+    fly::SocketManager::SocketCallback callback([&](fly::SocketPtr) { m_eventQueue.Push(1); } );
+    m_spClientSocketManager->SetClientCallbacks(callback, callback);
+
+    int item = 0;
+    std::chrono::milliseconds waitTime(100);
+
+    fly::SocketPtr spClientSocket = CreateSocket(m_spClientSocketManager, fly::Protocol::TCP, true);
+
+    fly::ConnectedState state = spClientSocket->ConnectAsync(m_host, m_port);
+    ASSERT_NE(state, fly::ConnectedState::Disconnected);
+
+    if (state == fly::ConnectedState::Connecting)
+    {
+        ASSERT_TRUE(m_eventQueue.Pop(item, waitTime));
+    }
+
+    ASSERT_TRUE(spClientSocket->IsConnected());
+    ASSERT_TRUE(spClientSocket->SendAsync(m_message));
+
+    fly::AsyncRequest request;
+    ASSERT_FALSE(m_spClientSocketManager->WaitForCompletedSend(request, waitTime));
+    ASSERT_TRUE(spClientSocket->IsValid());
 }
 
 /**
@@ -377,7 +402,7 @@ TEST_F(SocketTest, Send_Sync_MockSendtoFail)
     ASSERT_TRUE(spServerSocket->Bind(fly::Socket::InAddrAny(), m_port, fly::BindOption::AllowReuse));
 
     fly::SocketPtr spClientSocket = CreateSocket(m_spClientSocketManager, fly::Protocol::UDP, false);
-    ASSERT_EQ(spClientSocket->SendTo(s_smallMessage, m_host, m_port), 0U);
+    ASSERT_EQ(spClientSocket->SendTo(m_message, m_host, m_port), 0U);
 }
 
 /**
@@ -391,7 +416,7 @@ TEST_F(SocketTest, Send_Sync_MockGethostbynameFail)
     ASSERT_TRUE(spServerSocket->Bind(fly::Socket::InAddrAny(), m_port, fly::BindOption::AllowReuse));
 
     fly::SocketPtr spClientSocket = CreateSocket(m_spClientSocketManager, fly::Protocol::UDP, false);
-    ASSERT_EQ(spClientSocket->SendTo(s_smallMessage, m_host, m_port), 0U);
+    ASSERT_EQ(spClientSocket->SendTo(m_message, m_host, m_port), 0U);
 }
 
 /**
@@ -408,10 +433,10 @@ TEST_F(SocketTest, Send_Async_MockSendtoFail)
     m_spClientSocketManager->SetClientCallbacks(nullptr, callback);
 
     int item = 0;
-    std::chrono::seconds waitTime(10);
+    std::chrono::milliseconds waitTime(100);
 
     fly::SocketPtr spClientSocket = CreateSocket(m_spClientSocketManager, fly::Protocol::UDP, true);
-    ASSERT_TRUE(spClientSocket->SendToAsync(s_smallMessage, m_host, m_port));
+    ASSERT_TRUE(spClientSocket->SendToAsync(m_message, m_host, m_port));
 
     ASSERT_TRUE(m_eventQueue.Pop(item, waitTime));
     ASSERT_FALSE(spClientSocket->IsValid());
@@ -428,7 +453,7 @@ TEST_F(SocketTest, Send_Async_MockGethostbynameFail)
     ASSERT_TRUE(spServerSocket->Bind(fly::Socket::InAddrAny(), m_port, fly::BindOption::AllowReuse));
 
     fly::SocketPtr spClientSocket = CreateSocket(m_spClientSocketManager, fly::Protocol::UDP, true);
-    ASSERT_FALSE(spClientSocket->SendToAsync(s_smallMessage, m_host, m_port));
+    ASSERT_FALSE(spClientSocket->SendToAsync(m_message, m_host, m_port));
 }
 
 /**
@@ -469,13 +494,13 @@ TEST_F(SocketTest, Recv_Async_MockRecvFail)
     m_spServerSocketManager->SetClientCallbacks(connectCallback, disconnectCallback);
 
     int item = 0;
-    std::chrono::seconds waitTime(10);
+    std::chrono::milliseconds waitTime(100);
 
     fly::SocketPtr spClientSocket = CreateSocket(m_spClientSocketManager, fly::Protocol::TCP, false);
     ASSERT_TRUE(spClientSocket->Connect(m_host, m_port));
     ASSERT_TRUE(m_eventQueue.Pop(item, waitTime));
 
-    ASSERT_EQ(spClientSocket->Send(s_smallMessage), s_smallMessage.size());
+    ASSERT_EQ(spClientSocket->Send(m_message), m_message.size());
 
     ASSERT_TRUE(m_eventQueue.Pop(item, waitTime));
     ASSERT_FALSE(spRecvSocket->IsValid());
@@ -509,10 +534,10 @@ TEST_F(SocketTest, Recv_Async_MockRecvfromFail)
     m_spServerSocketManager->SetClientCallbacks(nullptr, callback);
 
     int item = 0;
-    std::chrono::seconds waitTime(10);
+    std::chrono::milliseconds waitTime(100);
 
     fly::SocketPtr spClientSocket = CreateSocket(m_spClientSocketManager, fly::Protocol::UDP, false);
-    ASSERT_EQ(spClientSocket->SendTo(s_smallMessage, m_host, m_port), s_smallMessage.size());
+    ASSERT_EQ(spClientSocket->SendTo(m_message, m_host, m_port), m_message.size());
 
     ASSERT_TRUE(m_eventQueue.Pop(item, waitTime));
     ASSERT_FALSE(spServerSocket->IsValid());
@@ -545,18 +570,18 @@ public:
         if (doAsync)
         {
             fly::AsyncRequest request;
-            std::chrono::seconds waitTime(120);
+            std::chrono::seconds waitTime(10);
 
             ASSERT_TRUE(m_spServerSocketManager->WaitForCompletedReceive(request, waitTime));
-            ASSERT_EQ(s_largeMessage.length(), request.GetRequest().length());
-            ASSERT_EQ(s_largeMessage, request.GetRequest());
+            ASSERT_EQ(m_message.length(), request.GetRequest().length());
+            ASSERT_EQ(m_message, request.GetRequest());
 
             ASSERT_GE(request.GetSocketId(), 0);
         }
         else
         {
             fly::SocketPtr spRecvSocket = spAcceptSocket->Accept();
-            ASSERT_EQ(spRecvSocket->Recv(), s_largeMessage);
+            ASSERT_EQ(spRecvSocket->Recv(), m_message);
 
             ASSERT_GT(spRecvSocket->GetClientIp(), 0U);
             ASSERT_GT(spRecvSocket->GetClientPort(), 0U);
@@ -581,7 +606,7 @@ public:
         ASSERT_FALSE(spSendSocket->IsUdp());
 
         int item = 0;
-        std::chrono::seconds waitTime(120);
+        std::chrono::seconds waitTime(10);
         ASSERT_TRUE(m_eventQueue.Pop(item, waitTime));
 
         fly::SocketManager::SocketCallback callback([&](fly::SocketPtr) { m_eventQueue.Push(1); } );
@@ -598,21 +623,19 @@ public:
                 ASSERT_TRUE(spSendSocket->IsConnected());
             }
 
-            ASSERT_TRUE(spSendSocket->SendAsync(s_largeMessage));
+            ASSERT_TRUE(spSendSocket->SendAsync(m_message));
 
             fly::AsyncRequest request;
-            std::chrono::seconds waitTime(120);
-
             ASSERT_TRUE(m_spClientSocketManager->WaitForCompletedSend(request, waitTime));
-            ASSERT_EQ(s_largeMessage.length(), request.GetRequest().length());
-            ASSERT_EQ(s_largeMessage, request.GetRequest());
+            ASSERT_EQ(m_message.length(), request.GetRequest().length());
+            ASSERT_EQ(m_message, request.GetRequest());
 
             ASSERT_EQ(request.GetSocketId(), spSendSocket->GetSocketId());
         }
         else
         {
             ASSERT_TRUE(spSendSocket->Connect(m_host, m_port));
-            ASSERT_EQ(spSendSocket->Send(s_largeMessage), s_largeMessage.length());
+            ASSERT_EQ(spSendSocket->Send(m_message), m_message.length());
         }
 
         m_spClientSocketManager->ClearClientCallbacks();
@@ -627,8 +650,8 @@ TEST_F(TcpSocketTest, AsyncOperationsOnSyncSocketTest)
     fly::SocketPtr spSocket = CreateSocket(m_spServerSocketManager, fly::Protocol::TCP, false);
 
     ASSERT_EQ(spSocket->ConnectAsync(m_host, m_port), fly::ConnectedState::Disconnected);
-    ASSERT_FALSE(spSocket->SendAsync(s_smallMessage));
-    ASSERT_FALSE(spSocket->SendToAsync(s_smallMessage, m_host, m_port));
+    ASSERT_FALSE(spSocket->SendAsync(m_message));
+    ASSERT_FALSE(spSocket->SendToAsync(m_message, m_host, m_port));
 }
 
 /**
@@ -703,16 +726,16 @@ public:
         if (doAsync)
         {
             fly::AsyncRequest request;
-            std::chrono::seconds waitTime(120);
+            std::chrono::seconds waitTime(10);
 
             ASSERT_TRUE(m_spServerSocketManager->WaitForCompletedReceive(request, waitTime));
-            ASSERT_EQ(s_smallMessage, request.GetRequest());
+            ASSERT_EQ(m_message, request.GetRequest());
 
             ASSERT_EQ(request.GetSocketId(), spRecvSocket->GetSocketId());
         }
         else
         {
-            ASSERT_EQ(spRecvSocket->RecvFrom(), s_smallMessage);
+            ASSERT_EQ(spRecvSocket->RecvFrom(), m_message);
         }
     }
 
@@ -733,25 +756,23 @@ public:
         ASSERT_TRUE(spSendSocket->IsUdp());
 
         int item = 0;
-        std::chrono::seconds waitTime(120);
+        std::chrono::seconds waitTime(10);
         m_eventQueue.Pop(item, waitTime);
 
         if (doAsync)
         {
             if ((callCount++ % 2) == 0)
             {
-                ASSERT_TRUE(spSendSocket->SendToAsync(s_smallMessage, m_address, m_port));
+                ASSERT_TRUE(spSendSocket->SendToAsync(m_message, m_address, m_port));
             }
             else
             {
-                ASSERT_TRUE(spSendSocket->SendToAsync(s_smallMessage, m_host, m_port));
+                ASSERT_TRUE(spSendSocket->SendToAsync(m_message, m_host, m_port));
             }
 
             fly::AsyncRequest request;
-            std::chrono::seconds waitTime(120);
-
             ASSERT_TRUE(m_spClientSocketManager->WaitForCompletedSend(request, waitTime));
-            ASSERT_EQ(s_smallMessage, request.GetRequest());
+            ASSERT_EQ(m_message, request.GetRequest());
 
             ASSERT_EQ(request.GetSocketId(), spSendSocket->GetSocketId());
         }
@@ -759,11 +780,11 @@ public:
         {
             if ((callCount++ % 2) == 0)
             {
-                ASSERT_EQ(spSendSocket->SendTo(s_smallMessage, m_address, m_port), s_smallMessage.length());
+                ASSERT_EQ(spSendSocket->SendTo(m_message, m_address, m_port), m_message.length());
             }
             else
             {
-                ASSERT_EQ(spSendSocket->SendTo(s_smallMessage, m_host, m_port), s_smallMessage.length());
+                ASSERT_EQ(spSendSocket->SendTo(m_message, m_host, m_port), m_message.length());
             }
         }
     }
@@ -777,8 +798,8 @@ TEST_F(UdpSocketTest, AsyncOperationsOnSyncSocketTest)
     fly::SocketPtr spSocket = CreateSocket(m_spServerSocketManager, fly::Protocol::UDP, false);
 
     ASSERT_EQ(spSocket->ConnectAsync(m_host, m_port), fly::ConnectedState::Disconnected);
-    ASSERT_FALSE(spSocket->SendAsync(s_smallMessage));
-    ASSERT_FALSE(spSocket->SendToAsync(s_smallMessage, m_host, m_port));
+    ASSERT_FALSE(spSocket->SendAsync(m_message));
+    ASSERT_FALSE(spSocket->SendToAsync(m_message, m_host, m_port));
 }
 
 /**

--- a/test/socket/main.cpp
+++ b/test/socket/main.cpp
@@ -387,8 +387,11 @@ TEST_F(SocketTest, Send_Async_MockSendBlock)
     ASSERT_TRUE(spClientSocket->SendAsync(m_message));
 
     fly::AsyncRequest request;
-    ASSERT_FALSE(m_spClientSocketManager->WaitForCompletedSend(request, waitTime));
-    ASSERT_TRUE(spClientSocket->IsValid());
+    ASSERT_TRUE(m_spClientSocketManager->WaitForCompletedSend(request, waitTime));
+    ASSERT_EQ(m_message.length(), request.GetRequest().length());
+    ASSERT_EQ(m_message, request.GetRequest());
+
+    ASSERT_EQ(request.GetSocketId(), spClientSocket->GetSocketId());
 }
 
 /**


### PR DESCRIPTION
The point of using a really large message was to force packet fragmentation.
This can be mocked instead. Add a mock system flag for send() to enable mocking
EWOULDBLOCK. If set, send all but the last byte of the string, setting errno to
EWOULDBLOCK. On subsequent calls, send the last byte through.

Also fix some bad return value checks in the Window's socket implementation
(should be checking for SOCKET_ERROR instead of -1).