### PR TITLE
Add support for non-compliant JSON parser features

### DIFF
--- a/fly/parser/json_parser.h
+++ b/fly/parser/json_parser.h
@@ -1,8 +1,11 @@
 #pragma once
 
+#include <cstdint>
 #include <fstream>
+#include <limits>
 #include <stack>
 #include <string>
+#include <type_traits>
 
 #include "fly/fly.h"
 #include "fly/parser/parser.h"
@@ -23,12 +26,14 @@ class JsonParser : public Parser
     enum class Token
     {
         Tab = 0x09, // \t
-        NewLine = 0x0A, // \n
-        CarriageReturn = 0x0D, // \r
+        NewLine = 0x0a, // \n
+        CarriageReturn = 0x0d, // \r
         Space = 0x20, // <space>
 
+        Asterisk = 0x2a, // *
         Quote = 0x22, // "
         Comma = 0x2c, // ,
+        Solidus = 0x2f, // /
         Colon = 0x3a, // :
 
         StartBracket = 0x5b, // [
@@ -37,7 +42,7 @@ class JsonParser : public Parser
         StartBrace = 0x7b, // {
         CloseBrace = 0x7d, // }
 
-        ReverseSolidus = 0x5C, /* \ */
+        ReverseSolidus = 0x5c, /* \ */
     };
 
     enum class State
@@ -48,8 +53,40 @@ class JsonParser : public Parser
         ParsingName,
         ParsingValue,
         ParsingColon,
-        ParsingComma
+        ParsingComma,
     };
+
+public:
+    /**
+     * Optional parsing features. May be combined with bitwise and/or operators.
+     */
+    enum class Features : uint8_t
+    {
+        // Strict compliance with http://www.json.org.
+        Strict = 0,
+
+        // Allows single-line (//) and multi-line (/* */) comments.
+        AllowComments = 1 << 0,
+
+        // Allows the last element in an object/array to have one trailing comma
+        AllowTrailingComma = 1 << 1,
+
+        // Allows all of the above features
+        AllFeatures =
+            std::numeric_limits<std::underlying_type_t<Features>>::max()
+    };
+
+    /**
+     * Constructor. Create a parser with strict http://www.json.org compliance.
+     */
+    JsonParser();
+
+    /**
+     * Constructor. Create a parser with the specific features.
+     *
+     * @param Features The extra features to allow.
+     */
+    JsonParser(Features);
 
 protected:
     /**
@@ -60,8 +97,8 @@ protected:
      * @return Json The parsed values.
      *
      * @throws ParserException If an error occurs parsing the stream.
-     * @throws UnexpectedCharacterException If a parsed character was unexpected.
-     * @throws BadConversionException If a parsed object was invalid.
+     * @throws UnexpectedCharacterException A parsed character was unexpected.
+     * @throws BadConversionException A parsed object was invalid.
      */
     Json ParseInternal(std::istream &) override;
 
@@ -72,7 +109,7 @@ private:
      * @param Token The current parsed token.
      * @param int The current parsed character.
      *
-     * @throws UnexpectedCharacterException If a parsed character was unexpected.
+     * @throws UnexpectedCharacterException A parsed character was unexpected.
      */
     void onWhitespace(Token, int);
 
@@ -82,7 +119,7 @@ private:
      * @param Token The current parsed token.
      * @param int The current parsed character ({ or [).
      *
-     * @throws UnexpectedCharacterException If a parsed character was unexpected.
+     * @throws UnexpectedCharacterException A parsed character was unexpected.
      */
     void onStartBraceOrBracket(Token, int);
 
@@ -92,8 +129,8 @@ private:
      * @param Token The current parsed token.
      * @param int The current parsed character (} or ]).
      *
-     * @throws UnexpectedCharacterException If a parsed character was unexpected.
-     * @throws BadConversionException If a parsed object was invalid.
+     * @throws UnexpectedCharacterException A parsed character was unexpected.
+     * @throws BadConversionException A parsed object was invalid.
      */
     void onCloseBraceOrBracket(Token, int);
 
@@ -102,7 +139,7 @@ private:
      *
      * @param int The current parsed character (").
      *
-     * @throws UnexpectedCharacterException If a parsed character was unexpected.
+     * @throws UnexpectedCharacterException A parsed character was unexpected.
      */
     void onQuotation(int);
 
@@ -111,7 +148,7 @@ private:
      *
      * @param int The current parsed character (:).
      *
-     * @throws UnexpectedCharacterException If a parsed character was unexpected.
+     * @throws UnexpectedCharacterException A parsed character was unexpected.
      */
     void onColon(int);
 
@@ -120,10 +157,21 @@ private:
      *
      * @param int The current parsed character (,).
      *
-     * @throws UnexpectedCharacterException If a parsed character was unexpected.
-     * @throws BadConversionException If a parsed object was invalid.
+     * @throws UnexpectedCharacterException A parsed character was unexpected.
+     * @throws BadConversionException A parsed object was invalid.
      */
     void onComma(int);
+
+    /**
+     * Handle the start of a comment, if comments are allowed. Consumes the
+     * stream until the end of the comment.
+     *
+     * @param int The current parsed character.
+     * @param istream Stream holding the contents to parse.
+     *
+     * @throws UnexpectedCharacterException A parsed character was unexpected.
+     */
+    void onSolidus(int, std::istream &);
 
     /**
      * Handle any other character. If the character is a reverse solidus, accept
@@ -133,7 +181,7 @@ private:
      * @param int The current parsed character.
      * @param istream Stream holding the contents to parse.
      *
-     * @throws UnexpectedCharacterException If a parsed character was unexpected.
+     * @throws UnexpectedCharacterException A parsed character was unexpected.
      */
     void onCharacter(Token, int, std::istream &);
 
@@ -157,7 +205,7 @@ private:
      *
      * @return bool True if a value was stored.
      *
-     * @throws BadConversionException If a parsed object was invalid.
+     * @throws BadConversionException A parsed object was invalid.
      */
     bool storeValue();
 
@@ -168,9 +216,20 @@ private:
      * @param bool Set to true if the parsed number is a floating point.
      * @param bool Set to true if the parsed number is signed.
      *
-     * @throws BadConversionException If a parsed number was invalid.
+     * @throws BadConversionException A parsed number was invalid.
      */
     void validateNumber(const std::string &, bool &, bool &) const;
+
+    /**
+     * Check if a feature has been allowed.
+     *
+     * @param Features The feature to check.
+     *
+     * @return True if the feature is allowed.
+     */
+    bool isFeatureAllowed(Features) const;
+
+    Features m_features;
 
     std::stack<State> m_states;
 
@@ -185,5 +244,15 @@ private:
     bool m_parsedString;
     bool m_expectingValue;
 };
+
+/**
+ * Combine two Features instances into a single instance via bitwise-and.
+ */
+JsonParser::Features operator & (JsonParser::Features, JsonParser::Features);
+
+/**
+ * Combine two Features instances into a single instance via bitwise-or.
+ */
+JsonParser::Features operator | (JsonParser::Features, JsonParser::Features);
 
 }


### PR DESCRIPTION
By default, parse JSON files with strict compliance. But add options for the
follow non-compliant features:
1. Single-line (//) and multi-line (/* */) comments
2. A single trailing comma after the last element in an object or array