### PR TITLE
 Use C++17 std::variant in JSON class

### DIFF
--- a/build/win/libfly_unit_tests/libfly_unit_tests.vcxproj
+++ b/build/win/libfly_unit_tests/libfly_unit_tests.vcxproj
@@ -124,7 +124,7 @@
       </AdditionalLibraryDirectories>
       <AdditionalDependencies>pdh.lib;ws2_32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
-      <StackReserveSize>2097152</StackReserveSize>
+      <StackReserveSize>4194304</StackReserveSize>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -144,7 +144,7 @@
       </AdditionalLibraryDirectories>
       <AdditionalDependencies>pdh.lib;ws2_32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
-      <StackReserveSize>2097152</StackReserveSize>
+      <StackReserveSize>4194304</StackReserveSize>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -168,7 +168,7 @@
       </AdditionalLibraryDirectories>
       <AdditionalDependencies>pdh.lib;ws2_32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
-      <StackReserveSize>2097152</StackReserveSize>
+      <StackReserveSize>4194304</StackReserveSize>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -192,7 +192,7 @@
       </AdditionalLibraryDirectories>
       <AdditionalDependencies>pdh.lib;ws2_32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
-      <StackReserveSize>2097152</StackReserveSize>
+      <StackReserveSize>4194304</StackReserveSize>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/fly/traits/traits.h
+++ b/fly/traits/traits.h
@@ -79,11 +79,10 @@ struct if_string
     struct __
     {
         template <typename T>
-        using is_string = std::integral_constant<
-            bool,
+        using is_string = std::bool_constant<
             std::is_same<char *, std::decay_t<T>>::value ||
-                std::is_same<char const *, std::decay_t<T>>::value ||
-                std::is_same<std::string, std::decay_t<T>>::value>;
+            std::is_same<char const *, std::decay_t<T>>::value ||
+            std::is_same<std::string, std::decay_t<T>>::value>;
     };
 
     template <typename T>
@@ -101,11 +100,10 @@ struct if_signed_integer
     struct __
     {
         template <typename T>
-        using is_signed_integer = std::integral_constant<
-            bool,
+        using is_signed_integer = std::bool_constant<
             std::is_integral<std::decay_t<T>>::value &&
-                std::is_signed<std::decay_t<T>>::value &&
-                !std::is_same<bool, std::decay_t<T>>::value>;
+            std::is_signed<std::decay_t<T>>::value &&
+            !std::is_same<bool, std::decay_t<T>>::value>;
     };
 
     template <typename T>
@@ -123,11 +121,10 @@ struct if_unsigned_integer
     struct __
     {
         template <typename T>
-        using is_unsigned_integer = std::integral_constant<
-            bool,
+        using is_unsigned_integer = std::bool_constant<
             std::is_integral<std::decay_t<T>>::value &&
-                std::is_unsigned<std::decay_t<T>>::value &&
-                !std::is_same<bool, std::decay_t<T>>::value>;
+            std::is_unsigned<std::decay_t<T>>::value &&
+            !std::is_same<bool, std::decay_t<T>>::value>;
     };
 
     template <typename T>
@@ -145,9 +142,8 @@ struct if_floating_point
     struct __
     {
         template <typename T>
-        using is_floating_point = std::integral_constant<
-            bool,
-            std::is_floating_point<std::decay_t<T>>::value>;
+        using is_floating_point =
+            std::bool_constant<std::is_floating_point<std::decay_t<T>>::value>;
     };
 
     template <typename T>
@@ -165,10 +161,9 @@ struct if_numeric
     struct __
     {
         template <typename T>
-        using is_numeric = std::integral_constant<
-            bool,
+        using is_numeric = std::bool_constant<
             std::is_arithmetic<std::decay_t<T>>::value &&
-                !std::is_same<bool, std::decay_t<T>>::value>;
+            !std::is_same<bool, std::decay_t<T>>::value>;
     };
 
     template <typename T>
@@ -186,8 +181,8 @@ struct if_boolean
     struct __
     {
         template <typename T>
-        using is_boolean = std::
-            integral_constant<bool, std::is_same<bool, std::decay_t<T>>::value>;
+        using is_boolean =
+            std::bool_constant<std::is_same<bool, std::decay_t<T>>::value>;
     };
 
     template <typename T>

--- a/fly/types/json.cpp
+++ b/fly/types/json.cpp
@@ -7,187 +7,156 @@
 namespace fly {
 
 //==============================================================================
-Json::Json() noexcept : m_type(Type::Null), m_value()
+Json::Json() noexcept : m_value(nullptr)
 {
 }
 
 //==============================================================================
-Json::Json(const null_type &value) noexcept : m_type(Type::Null), m_value(value)
+Json::Json(const null_type &value) noexcept : m_value(value)
 {
 }
 
 //==============================================================================
-Json::Json(const Json &json) noexcept : m_type(json.m_type), m_value()
+Json::Json(const Json &json) noexcept : m_value(json.m_value)
 {
-    switch (m_type)
-    {
-        case Type::String:
-            m_value = *(json.m_value.m_pString);
-            break;
-
-        case Type::Object:
-            m_value = *(json.m_value.m_pObject);
-            break;
-
-        case Type::Array:
-            m_value = *(json.m_value.m_pArray);
-            break;
-
-        case Type::Boolean:
-            m_value = json.m_value.m_boolean;
-            break;
-
-        case Type::Signed:
-            m_value = json.m_value.m_signed;
-            break;
-
-        case Type::Unsigned:
-            m_value = json.m_value.m_unsigned;
-            break;
-
-        case Type::Float:
-            m_value = json.m_value.m_float;
-            break;
-
-        case Type::Null:
-            break;
-    }
 }
 
 //==============================================================================
-Json::Json(Json &&json) noexcept :
-    m_type(std::move(json.m_type)),
-    m_value(std::move(json.m_value))
+Json::Json(Json &&json) noexcept : m_value(std::move(json.m_value))
 {
-    json.m_type = Type::Null;
     json.m_value = nullptr;
 }
 
 //==============================================================================
-Json::Json(const std::initializer_list<Json> &initializer) noexcept :
-    m_type(Type::Null),
-    m_value()
+Json::Json(const std::initializer_list<Json> &initializer) noexcept : m_value()
 {
     auto is_object_like = [](const Json &json) { return json.IsObjectLike(); };
 
     if (std::all_of(initializer.begin(), initializer.end(), is_object_like))
     {
-        m_type = Type::Object;
         m_value = object_type();
 
         for (auto it = initializer.begin(); it != initializer.end(); ++it)
         {
-            m_value.m_pObject->emplace(
-                std::move(*((*it)[0].m_value.m_pString)), std::move((*it)[1]));
+            std::get<object_type>(m_value).emplace(
+                std::move(std::get<string_type>((*it)[0].m_value)),
+                std::move((*it)[1]));
         }
     }
     else
     {
-        m_type = Type::Array;
         m_value = array_type();
 
         for (auto it = initializer.begin(); it != initializer.end(); ++it)
         {
-            m_value.m_pArray->push_back(std::move(*it));
+            std::get<array_type>(m_value).push_back(std::move(*it));
         }
     }
-}
-
-//==============================================================================
-Json::~Json() noexcept
-{
-    m_value.Destroy(m_type);
 }
 
 //==============================================================================
 bool Json::IsString() const
 {
-    return m_type == Type::String;
+    return std::holds_alternative<string_type>(m_value);
 }
 
 //==============================================================================
 bool Json::IsObject() const
 {
-    return m_type == Type::Object;
+    return std::holds_alternative<object_type>(m_value);
 }
 
 //==============================================================================
 bool Json::IsObjectLike() const
 {
-    return IsArray() && (m_value.m_pArray->size() == 2) &&
-        m_value.m_pArray->at(0).IsString();
+    const array_type *value = std::get_if<array_type>(&m_value);
+
+    return (value != nullptr) && (value->size() == 2) &&
+        value->at(0).IsString();
 }
 
 //==============================================================================
 bool Json::IsArray() const
 {
-    return m_type == Type::Array;
+    return std::holds_alternative<array_type>(m_value);
 }
 
 //==============================================================================
 bool Json::IsBoolean() const
 {
-    return m_type == Type::Boolean;
+    return std::holds_alternative<boolean_type>(m_value);
 }
 
 //==============================================================================
 bool Json::IsSignedInteger() const
 {
-    return m_type == Type::Signed;
+    return std::holds_alternative<signed_type>(m_value);
 }
 
 //==============================================================================
 bool Json::IsUnsignedInteger() const
 {
-    return m_type == Type::Unsigned;
+    return std::holds_alternative<unsigned_type>(m_value);
 }
 
 //==============================================================================
 bool Json::IsFloat() const
 {
-    return m_type == Type::Float;
+    return std::holds_alternative<float_type>(m_value);
 }
 
 //==============================================================================
 bool Json::IsNull() const
 {
-    return m_type == Type::Null;
+    return std::holds_alternative<null_type>(m_value);
 }
 
 //==============================================================================
 Json &Json::operator=(Json json) noexcept
 {
-    std::swap(m_type, json.m_type);
     std::swap(m_value, json.m_value);
-
     return *this;
 }
 
 //==============================================================================
 Json::operator string_type() const
 {
-    if (IsString())
-    {
-        return *(m_value.m_pString);
-    }
-    else
-    {
-        stream_type stream;
-        stream << *this;
+    auto visitor = [this](const auto &value) -> string_type {
+        using U = std::decay_t<decltype(value)>;
 
-        return stream.str();
-    }
+        if constexpr (std::is_same_v<U, Json::string_type>)
+        {
+            return value;
+        }
+        else
+        {
+            stream_type stream;
+            stream << *this;
+
+            return stream.str();
+        }
+    };
+
+    return std::visit(visitor, m_value);
 }
 
 //==============================================================================
 Json::operator null_type() const
 {
-    if (IsNull())
-    {
-        return m_value.m_null;
-    }
+    auto visitor = [this](const auto &value) -> null_type {
+        using U = std::decay_t<decltype(value)>;
 
-    throw JsonException(*this, String::Format("Type %s is not null", m_type));
+        if constexpr (std::is_same_v<U, Json::null_type>)
+        {
+            return value;
+        }
+        else
+        {
+            throw JsonException(*this, "JSON is not null");
+        }
+    };
+
+    return std::visit(visitor, m_value);
 }
 
 //==============================================================================
@@ -195,18 +164,18 @@ Json &Json::operator[](const typename object_type::key_type &key)
 {
     if (IsNull())
     {
-        m_type = Type::Object;
         m_value = object_type();
     }
 
     if (IsObject())
     {
         const Json json(key);
-        return (*(m_value.m_pObject))[object_type::key_type(json)];
+        object_type &value = std::get<object_type>(m_value);
+
+        return value[object_type::key_type(json)];
     }
 
-    throw JsonException(
-        *this, String::Format("Type %s invalid for operator[key]", m_type));
+    throw JsonException(*this, "JSON invalid for operator[key]");
 }
 
 //==============================================================================
@@ -215,9 +184,11 @@ const Json &Json::operator[](const typename object_type::key_type &key) const
     if (IsObject())
     {
         const Json json(key);
-        auto it = m_value.m_pObject->find(object_type::key_type(json));
+        const object_type &value = std::get<object_type>(m_value);
 
-        if (it == m_value.m_pObject->end())
+        auto it = value.find(object_type::key_type(json));
+
+        if (it == value.end())
         {
             throw JsonException(
                 *this, String::Format("Given key (%s) not found", key));
@@ -226,8 +197,7 @@ const Json &Json::operator[](const typename object_type::key_type &key) const
         return it->second;
     }
 
-    throw JsonException(
-        *this, String::Format("Type %s invalid for operator[key]", m_type));
+    throw JsonException(*this, "JSON invalid for operator[key]");
 }
 
 //==============================================================================
@@ -235,22 +205,22 @@ Json &Json::operator[](const typename array_type::size_type &index)
 {
     if (IsNull())
     {
-        m_type = Type::Array;
         m_value = array_type();
     }
 
     if (IsArray())
     {
-        if (index >= m_value.m_pArray->size())
+        array_type &value = std::get<array_type>(m_value);
+
+        if (index >= value.size())
         {
-            m_value.m_pArray->resize(index + 1);
+            value.resize(index + 1);
         }
 
-        return m_value.m_pArray->at(index);
+        return value.at(index);
     }
 
-    throw JsonException(
-        *this, String::Format("Type %s invalid for operator[index]", m_type));
+    throw JsonException(*this, "JSON invalid for operator[index]");
 }
 
 //==============================================================================
@@ -258,124 +228,66 @@ const Json &Json::operator[](const typename array_type::size_type &index) const
 {
     if (IsArray())
     {
-        if (index >= m_value.m_pArray->size())
+        const array_type &value = std::get<array_type>(m_value);
+
+        if (index >= value.size())
         {
             throw JsonException(
                 *this, String::Format("Given index (%d) not found", index));
         }
 
-        return m_value.m_pArray->at(index);
+        return value.at(index);
     }
 
-    throw JsonException(
-        *this, String::Format("Type %s invalid for operator[index]", m_type));
+    throw JsonException(*this, "JSON invalid for operator[index]");
 }
 
 //==============================================================================
 std::size_t Json::Size() const
 {
-    switch (m_type)
-    {
-        case Type::String:
-            return m_value.m_pString->size();
+    auto visitor = [](const auto &value) -> std::size_t {
+        using U = std::decay_t<decltype(value)>;
 
-        case Type::Object:
-            return m_value.m_pObject->size();
-
-        case Type::Array:
-            return m_value.m_pArray->size();
-
-        case Type::Null:
+        if constexpr (
+            std::is_same_v<U, Json::string_type> ||
+            std::is_same_v<U, Json::object_type> ||
+            std::is_same_v<U, Json::array_type>)
+        {
+            return value.size();
+        }
+        else if constexpr (std::is_same_v<U, Json::null_type>)
+        {
             return 0;
-
-        default:
+        }
+        else
+        {
             return 1;
-    }
+        }
+    };
+
+    return std::visit(visitor, m_value);
 }
 
 //==============================================================================
 bool operator==(const Json &json1, const Json &json2)
 {
-    const Json::Type type1 = json1.m_type;
-    const Json::Type type2 = json2.m_type;
+    auto is_numeric = [](const Json &json) {
+        return json.IsSignedInteger() || json.IsUnsignedInteger() ||
+            json.IsFloat();
+    };
 
-    // Both instances are the same type
-    if (type1 == type2)
+    if (json1.m_value.index() == json2.m_value.index())
     {
-        switch (type1)
-        {
-            case Json::Type::String:
-                return *(json1.m_value.m_pString) == *(json2.m_value.m_pString);
-
-            case Json::Type::Object:
-                return *(json1.m_value.m_pObject) == *(json2.m_value.m_pObject);
-
-            case Json::Type::Array:
-                return *(json1.m_value.m_pArray) == *(json2.m_value.m_pArray);
-
-            case Json::Type::Boolean:
-                return json1.m_value.m_boolean == json2.m_value.m_boolean;
-
-            case Json::Type::Signed:
-                return json1.m_value.m_signed == json2.m_value.m_signed;
-
-            case Json::Type::Unsigned:
-                return json1.m_value.m_unsigned == json2.m_value.m_unsigned;
-
-            case Json::Type::Float:
-                return json1.m_value.m_float == json2.m_value.m_float;
-
-            case Json::Type::Null:
-                return true;
-        }
+        return json1.m_value == json2.m_value;
     }
+    else if (is_numeric(json1) && is_numeric(json2))
+    {
+        auto visitor = [&json2](const auto &value) -> bool {
+            using U = std::decay_t<decltype(value)>;
+            return value == U(json2);
+        };
 
-    // One instance is a signed integer, other instance is an unsigned integer
-    else if (
-        (json1.m_type == Json::Type::Signed) &&
-        (json2.m_type == Json::Type::Unsigned))
-    {
-        auto value2 = static_cast<Json::signed_type>(json2.m_value.m_unsigned);
-        return json1.m_value.m_signed == value2;
-    }
-    else if (
-        (json1.m_type == Json::Type::Unsigned) &&
-        (json2.m_type == Json::Type::Signed))
-    {
-        auto value1 = static_cast<Json::signed_type>(json1.m_value.m_unsigned);
-        return value1 == json2.m_value.m_signed;
-    }
-
-    // One instance is a signed integer, other instance is a float
-    else if (
-        (json1.m_type == Json::Type::Signed) &&
-        (json2.m_type == Json::Type::Float))
-    {
-        auto value1 = static_cast<Json::float_type>(json1.m_value.m_signed);
-        return value1 == json2.m_value.m_float;
-    }
-    else if (
-        (json1.m_type == Json::Type::Float) &&
-        (json2.m_type == Json::Type::Signed))
-    {
-        auto value2 = static_cast<Json::float_type>(json2.m_value.m_signed);
-        return json1.m_value.m_float == value2;
-    }
-
-    // One instance is an unsigned integer, other instance is a float
-    else if (
-        (json1.m_type == Json::Type::Unsigned) &&
-        (json2.m_type == Json::Type::Float))
-    {
-        auto value1 = static_cast<Json::float_type>(json1.m_value.m_unsigned);
-        return value1 == json2.m_value.m_float;
-    }
-    else if (
-        (json1.m_type == Json::Type::Float) &&
-        (json2.m_type == Json::Type::Unsigned))
-    {
-        auto value2 = static_cast<Json::float_type>(json2.m_value.m_unsigned);
-        return json1.m_value.m_float == value2;
+        return std::visit(visitor, json1.m_value);
     }
 
     return false;
@@ -390,112 +302,63 @@ bool operator!=(const Json &json1, const Json &json2)
 //==============================================================================
 std::ostream &operator<<(std::ostream &stream, const Json &json)
 {
-    switch (json.m_type)
-    {
-        case Json::Type::String:
-            stream << '"' << *(json.m_value.m_pString) << '"';
-            break;
+    auto visitor = [&stream](const auto &value) {
+        using U = std::decay_t<decltype(value)>;
 
-        case Json::Type::Object:
+        if constexpr (std::is_same_v<U, Json::string_type>)
         {
-            const Json::object_type *pObject = json.m_value.m_pObject;
+            stream << '"' << value << '"';
+        }
+        else if constexpr (std::is_same_v<U, Json::object_type>)
+        {
             stream << '{';
 
-            for (auto it = pObject->begin(); it != pObject->end();)
+            for (auto it = value.begin(); it != value.end();)
             {
                 stream << '"' << it->first << '"' << ':' << it->second;
 
-                if (++it != pObject->end())
+                if (++it != value.end())
                 {
                     stream << ',';
                 }
             }
 
             stream << '}';
-            break;
         }
-
-        case Json::Type::Array:
+        else if constexpr (std::is_same_v<U, Json::array_type>)
         {
-            const Json::array_type *pArray = json.m_value.m_pArray;
             stream << '[';
 
-            for (auto it = pArray->begin(); it != pArray->end();)
+            for (auto it = value.begin(); it != value.end();)
             {
                 stream << *it;
 
-                if (++it != pArray->end())
+                if (++it != value.end())
                 {
                     stream << ',';
                 }
             }
 
             stream << ']';
-            break;
         }
-
-        case Json::Type::Boolean:
-            stream << std::boolalpha << json.m_value.m_boolean;
-            break;
-
-        case Json::Type::Signed:
-            stream << json.m_value.m_signed;
-            break;
-
-        case Json::Type::Unsigned:
-            stream << json.m_value.m_unsigned;
-            break;
-
-        case Json::Type::Float:
-            stream << json.m_value.m_float;
-            break;
-
-        case Json::Type::Null:
+        else if constexpr (std::is_same_v<U, Json::boolean_type>)
+        {
+            stream << std::boolalpha << value;
+        }
+        else if constexpr (
+            std::is_same_v<U, Json::signed_type> ||
+            std::is_same_v<U, Json::unsigned_type> ||
+            std::is_same_v<U, Json::float_type>)
+        {
+            stream << value;
+        }
+        else
+        {
             stream << "null";
-            break;
-    }
+        }
+    };
 
-    return stream;
-}
-
-//==============================================================================
-std::ostream &operator<<(std::ostream &stream, Json::Type type)
-{
-    switch (type)
-    {
-        case Json::Type::String:
-            stream << "string";
-            break;
-
-        case Json::Type::Object:
-            stream << "object";
-            break;
-
-        case Json::Type::Array:
-            stream << "array";
-            break;
-
-        case Json::Type::Boolean:
-            stream << "boolean";
-            break;
-
-        case Json::Type::Signed:
-            stream << "signed";
-            break;
-
-        case Json::Type::Unsigned:
-            stream << "unsigned";
-            break;
-
-        case Json::Type::Float:
-            stream << "float";
-            break;
-
-        case Json::Type::Null:
-            stream << "null";
-            break;
-    }
-
+    std::visit(visitor, json.m_value);
     return stream;
 }
 
@@ -535,9 +398,7 @@ void Json::readEscapedCharacter(
     if (++it == end)
     {
         throw JsonException(
-            nullptr,
-            fly::String::Format(
-                "Expected escaped character after reverse solidus"));
+            nullptr, "Expected escaped character after reverse solidus");
     }
 
     switch (*it)
@@ -865,38 +726,6 @@ void Json::validateCharacter(
     }
 
     stream << *it;
-}
-
-//==============================================================================
-Json::Value::Value() noexcept : m_null(nullptr)
-{
-}
-
-//==============================================================================
-Json::Value::Value(const null_type &value) noexcept : m_null(value)
-{
-}
-
-//==============================================================================
-void Json::Value::Destroy(const Type &type) noexcept
-{
-    switch (type)
-    {
-        case Type::String:
-            delete m_pString;
-            break;
-
-        case Type::Object:
-            delete m_pObject;
-            break;
-
-        case Type::Array:
-            delete m_pArray;
-            break;
-
-        default:
-            break;
-    }
 }
 
 //==============================================================================

--- a/fly/types/json.h
+++ b/fly/types/json.h
@@ -63,27 +63,27 @@ public:
      * reasonable default types for now, and the Json class constructors allow
      * for type flexibility.
      */
+    using null_type = std::nullptr_t;
     using string_type = std::string;
     using object_type = std::map<string_type, Json>;
     using array_type = std::vector<Json>;
     using boolean_type = bool;
-    using signed_type = std::int64_t;
-    using unsigned_type = std::uint64_t;
+    using signed_type = std::intmax_t;
+    using unsigned_type = std::uintmax_t;
     using float_type = long double;
-    using null_type = std::nullptr_t;
 
     /**
-     * Also for the std::variant holding the above JSON types.
+     * Alias for the std::variant holding the above JSON types.
      */
     using json_type = std::variant<
+        null_type,
         string_type,
         object_type,
         array_type,
         boolean_type,
         signed_type,
         unsigned_type,
-        float_type,
-        null_type>;
+        float_type>;
 
     /**
      * Alias for a basic_stringstream with the JSON string type.
@@ -94,6 +94,13 @@ public:
      * Default constructor. Intializes the Json instance to a NULL value.
      */
     Json() noexcept;
+
+    /**
+     * Null constructor. Intializes the Json instance to a null value.
+     *
+     * @param null_type The null value.
+     */
+    Json(const null_type &) noexcept;
 
     /**
      * String constructor. Intializes the Json instance to a string value. The
@@ -183,13 +190,6 @@ public:
     Json(const T &) noexcept;
 
     /**
-     * Null constructor. Intializes the Json instance to a null value.
-     *
-     * @param null_type The null value.
-     */
-    Json(const null_type &) noexcept;
-
-    /**
      * Copy constructor. Intializes the Json instance with the type and value
      * of another Json instance. The other Json instance is set to a null value.
      *
@@ -217,6 +217,11 @@ public:
      * @param std::initializer_list The initializer list.
      */
     Json(const std::initializer_list<Json> &) noexcept;
+
+    /**
+     * @return bool True if the Json instance is null.
+     */
+    bool IsNull() const;
 
     /**
      * @return bool True if the Json instance is a string.
@@ -264,11 +269,6 @@ public:
     bool IsFloat() const;
 
     /**
-     * @return bool True if the Json instance is null.
-     */
-    bool IsNull() const;
-
-    /**
      * Assignment operator. Intializes the Json instance with the type and value
      * of another Json instance, using the copy-and-swap idiom.
      *
@@ -277,6 +277,15 @@ public:
      * @return Json A reference to this Json instance.
      */
     Json &operator=(Json) noexcept;
+
+    /**
+     * Null conversion operator. Converts the Json instance to a null type.
+     *
+     * @throws JsonException If the Json instance is not null.
+     *
+     * @return null_type The Json instance as a number.
+     */
+    explicit operator null_type() const;
 
     /**
      * String conversion operator. Converts the Json instance to a string. Note
@@ -366,15 +375,6 @@ public:
     explicit operator T() const;
 
     /**
-     * Null conversion operator. Converts the Json instance to a null type.
-     *
-     * @throws JsonException If the Json instance is not null.
-     *
-     * @return null_type The Json instance as a number.
-     */
-    explicit operator null_type() const;
-
-    /**
      * Object access operator.
      *
      * If the Json instance is an object, perform a lookup on the object with a
@@ -445,11 +445,11 @@ public:
      * If the Json instance is an object or array, return the number of elements
      * stored in the object or array.
      *
+     * If the Json instance is null, return 0.
+     *
      * If the Json instance is a string, return the length of the string.
      *
      * If the Json instance is a boolean or numeric, return 1.
-     *
-     * If the Json instance is null, return 0.
      *
      * @return size_t The size of the Json instance.
      */

--- a/fly/types/json.h
+++ b/fly/types/json.h
@@ -11,6 +11,8 @@
 #include <ostream>
 #include <sstream>
 #include <string>
+#include <type_traits>
+#include <variant>
 #include <vector>
 
 namespace fly {
@@ -65,10 +67,23 @@ public:
     using object_type = std::map<string_type, Json>;
     using array_type = std::vector<Json>;
     using boolean_type = bool;
-    using signed_type = int64_t;
-    using unsigned_type = uint64_t;
+    using signed_type = std::int64_t;
+    using unsigned_type = std::uint64_t;
     using float_type = long double;
     using null_type = std::nullptr_t;
+
+    /**
+     * Also for the std::variant holding the above JSON types.
+     */
+    using json_type = std::variant<
+        string_type,
+        object_type,
+        array_type,
+        boolean_type,
+        signed_type,
+        unsigned_type,
+        float_type,
+        null_type>;
 
     /**
      * Alias for a basic_stringstream with the JSON string type.
@@ -202,11 +217,6 @@ public:
      * @param std::initializer_list The initializer list.
      */
     Json(const std::initializer_list<Json> &) noexcept;
-
-    /**
-     * Destructor. Delete any memory allocated for the JSON value.
-     */
-    ~Json() noexcept;
 
     /**
      * @return bool True if the Json instance is a string.
@@ -451,7 +461,8 @@ public:
      *
      * 1. The two Json instances are of the same type and have the same value.
      * 2. The two Json instances are of a numeric type (signed, unsigned, or
-     *    float) and have the same value after converting to the same type.
+     *    float) and have the same value after converting the second Json value
+     *    to the same type as the first Json value.
      *
      * @return bool True if the two Json instances are equal.
      */
@@ -476,146 +487,6 @@ public:
     friend std::ostream &operator<<(std::ostream &, const Json &);
 
 private:
-    /**
-     * An enumerated list of possible JSON types.
-     */
-    enum class Type
-    {
-        Null,
-        String,
-        Object,
-        Array,
-        Boolean,
-        Signed,
-        Unsigned,
-        Float
-    };
-
-    /**
-     * A union to store the JSON value.
-     *
-     * Strings, objects, and arrays must be stored as dynamically allocated
-     * pointers to be allowed in the union. As such, callers must be sure to
-     * release the value by calling the Destroy() method. Hopefully this can be
-     * replaced with std::variant via C++17.
-     */
-    union Value
-    {
-        string_type *m_pString;
-        object_type *m_pObject;
-        array_type *m_pArray;
-        boolean_type m_boolean;
-        signed_type m_signed;
-        unsigned_type m_unsigned;
-        float_type m_float;
-        null_type m_null;
-
-        /**
-         * Default constructor. Intializes the Value instance to a null value.
-         */
-        Value() noexcept;
-
-        /**
-         * String constructor. Intializes the Value instance to a string value.
-         * The SFINAE declaration allows construction of a string value from any
-         * string-like type (e.g. std::string, char *).
-         *
-         * @tparam T The string-like type.
-         *
-         * @param T The string-like value.
-         */
-        template <typename T, fly::if_string::enabled<T> = 0>
-        Value(const T &) noexcept;
-
-        /**
-         * Object constructor. Intializes the Value instance to an object's
-         * values. The SFINAE declaration allows construction of an object value
-         * from any object-like type (e.g. std::map, std::multimap).
-         *
-         * @tparam T The object-like type.
-         *
-         * @param T The object-like value.
-         */
-        template <typename T, fly::if_map::enabled<T> = 0>
-        Value(const T &) noexcept;
-
-        /**
-         * Array constructor. Intializes the Value instance to an array's
-         * values. The SFINAE declaration allows construction of an array value
-         * from any array-like type (e.g. std::list, std::vector).
-         *
-         * @tparam T The array-like type.
-         *
-         * @param T The array value.
-         */
-        template <typename T, fly::if_array::enabled<T> = 0>
-        Value(const T &) noexcept;
-
-        /**
-         * Boolean constructor. Intializes the Value instance to a boolean
-         * value. The SFINAE declaration forbids construction of a boolean value
-         * from any non-boolean type (e.g. int could be implicitly cast to
-         * bool).
-         *
-         * @tparam T The boolean type.
-         *
-         * @param T The boolean value.
-         */
-        template <typename T, fly::if_boolean::enabled<T> = 0>
-        Value(const T &) noexcept;
-
-        /**
-         * Signed integer constructor. Intializes the Value instance to a signed
-         * integer value. The SFINAE declaration allows construction of a signed
-         * integer value from any signed type (e.g. char, int, int64_t).
-         *
-         * @tparam T The signed type.
-         *
-         * @param T The signed value.
-         */
-        template <typename T, fly::if_signed_integer::enabled<T> = 0>
-        Value(const T &) noexcept;
-
-        /**
-         * Unsigned integer constructor. Intializes the Json instance to an
-         * unsigned integer value. The SFINAE declaration allows construction of
-         * an unsigned integer value from any unsigned type (e.g. unsigned char,
-         * unsigned int, uint64_t).
-         *
-         * @tparam T The unsigned type.
-         *
-         * @param T The unsigned value.
-         */
-        template <typename T, fly::if_unsigned_integer::enabled<T> = 0>
-        Value(const T &) noexcept;
-
-        /**
-         * Floating point constructor. Intializes the Json instance to a
-         * floating point value. The SFINAE declaration allows construction of a
-         * floating value from any floating point type (e.g. float, double).
-         *
-         * @tparam T The floating point type.
-         *
-         * @param T The floating point value.
-         */
-        template <typename T, fly::if_floating_point::enabled<T> = 0>
-        Value(const T &) noexcept;
-
-        /**
-         * Null constructor. Intializes the Json instance to a null value.
-         *
-         * @param null_type The null value.
-         */
-        Value(const null_type &) noexcept;
-
-        /**
-         * Pseudo-destructor. The union cannot store its instantiated type, so
-         * callers must be sure to store it and call this method to release the
-         * instantiated value.
-         */
-        void Destroy(const Type &) noexcept;
-    };
-
     /**
      * Validate the string for compliance according to http://www.json.org.
      * Validation includes handling escaped and unicode characters.
@@ -693,13 +564,7 @@ private:
         string_type::const_iterator &,
         const string_type::const_iterator &) const;
 
-    /**
-     * Stream the name of a Json instance's type.
-     */
-    friend std::ostream &operator<<(std::ostream &, Type);
-
-    Type m_type;
-    Value m_value;
+    json_type m_value;
 };
 
 /**
@@ -731,45 +596,45 @@ private:
 
 //==============================================================================
 template <typename T, fly::if_string::enabled<T>>
-Json::Json(const T &value) :
-    m_type(Type::String),
-    m_value(validateString(value))
+Json::Json(const T &value) : m_value(validateString(value))
 {
 }
 
 //==============================================================================
 template <typename T, fly::if_map::enabled<T>>
-Json::Json(const T &value) noexcept : m_type(Type::Object), m_value(value)
+Json::Json(const T &value) noexcept :
+    m_value(object_type(value.begin(), value.end()))
 {
 }
 
 //==============================================================================
 template <typename T, fly::if_array::enabled<T>>
-Json::Json(const T &value) noexcept : m_type(Type::Array), m_value(value)
+Json::Json(const T &value) noexcept :
+    m_value(array_type(value.begin(), value.end()))
 {
 }
 
 //==============================================================================
 template <typename T, fly::if_boolean::enabled<T>>
-Json::Json(const T &value) noexcept : m_type(Type::Boolean), m_value(value)
+Json::Json(const T &value) noexcept : m_value(static_cast<boolean_type>(value))
 {
 }
 
 //==============================================================================
 template <typename T, fly::if_signed_integer::enabled<T>>
-Json::Json(const T &value) noexcept : m_type(Type::Signed), m_value(value)
+Json::Json(const T &value) noexcept : m_value(static_cast<signed_type>(value))
 {
 }
 
 //==============================================================================
 template <typename T, fly::if_unsigned_integer::enabled<T>>
-Json::Json(const T &value) noexcept : m_type(Type::Unsigned), m_value(value)
+Json::Json(const T &value) noexcept : m_value(static_cast<unsigned_type>(value))
 {
 }
 
 //==============================================================================
 template <typename T, fly::if_floating_point::enabled<T>>
-Json::Json(const T &value) noexcept : m_type(Type::Float), m_value(value)
+Json::Json(const T &value) noexcept : m_value(static_cast<float_type>(value))
 {
 }
 
@@ -779,9 +644,10 @@ Json::operator T() const
 {
     if (IsObject())
     {
+        const object_type &value = std::get<object_type>(m_value);
         T t {};
 
-        for (const auto &kv : *(m_value.m_pObject))
+        for (const auto &kv : value)
         {
             t.insert({typename T::key_type(kv.first),
                       typename T::mapped_type(kv.second)});
@@ -790,8 +656,7 @@ Json::operator T() const
         return t;
     }
 
-    throw JsonException(
-        *this, String::Format("Type %s is not an object", m_type));
+    throw JsonException(*this, "JSON is not an object");
 }
 
 //==============================================================================
@@ -800,11 +665,11 @@ Json::operator T() const
 {
     if (IsArray())
     {
-        return T(m_value.m_pArray->begin(), m_value.m_pArray->end());
+        const array_type &value = std::get<array_type>(m_value);
+        return T(value.begin(), value.end());
     }
 
-    throw JsonException(
-        *this, String::Format("Type %s is not an array", m_type));
+    throw JsonException(*this, "JSON is not an array");
 }
 
 //==============================================================================
@@ -813,129 +678,80 @@ Json::operator std::array<T, N>() const
 {
     if (IsArray())
     {
+        const array_type &value = std::get<array_type>(m_value);
         std::array<T, N> array {};
-        const std::size_t size = std::min(N, m_value.m_pArray->size());
 
-        for (std::size_t i = 0; i < size; ++i)
+        for (std::size_t i = 0; i < std::min(N, value.size()); ++i)
         {
-            array[i] = T(m_value.m_pArray->at(i));
+            array[i] = T(value.at(i));
         }
 
         return array;
     }
 
-    throw JsonException(
-        *this, String::Format("Type %s is not an array", m_type));
+    throw JsonException(*this, "JSON is not an array");
 }
 
 //==============================================================================
 template <typename T, fly::if_boolean::enabled<T>>
 Json::operator T() const
 {
-    switch (m_type)
-    {
-        case Type::String:
-            return !(m_value.m_pString->empty());
+    auto visitor = [](const auto &value) -> T {
+        using U = std::decay_t<decltype(value)>;
 
-        case Type::Object:
-            return !(m_value.m_pObject->empty());
-
-        case Type::Array:
-            return !(m_value.m_pArray->empty());
-
-        case Type::Boolean:
-            return m_value.m_boolean;
-
-        case Type::Signed:
-            return (m_value.m_signed != 0);
-
-        case Type::Unsigned:
-            return (m_value.m_unsigned != 0);
-
-        case Type::Float:
-            return (m_value.m_float != 0.0);
-
-        default:
+        if constexpr (
+            std::is_same_v<U, Json::string_type> ||
+            std::is_same_v<U, Json::object_type> ||
+            std::is_same_v<U, Json::array_type>)
+        {
+            return !value.empty();
+        }
+        else if constexpr (
+            std::is_same_v<U, Json::boolean_type> ||
+            std::is_same_v<U, Json::signed_type> ||
+            std::is_same_v<U, Json::unsigned_type> ||
+            std::is_same_v<U, Json::float_type>)
+        {
+            return value != static_cast<U>(0);
+        }
+        else
+        {
             return false;
-    }
+        }
+    };
+
+    return std::visit(visitor, m_value);
 }
 
 //==============================================================================
 template <typename T, fly::if_numeric::enabled<T>>
 Json::operator T() const
 {
-    switch (m_type)
-    {
-        case Type::String:
+    auto visitor = [this](const auto &value) -> T {
+        using U = std::decay_t<decltype(value)>;
+
+        if constexpr (std::is_same_v<U, Json::string_type>)
+        {
             try
             {
-                return String::Convert<T>(*(m_value.m_pString));
+                return String::Convert<T>(value);
             }
             catch (...)
             {
             }
+        }
+        else if constexpr (
+            std::is_same_v<U, Json::signed_type> ||
+            std::is_same_v<U, Json::unsigned_type> ||
+            std::is_same_v<U, Json::float_type>)
+        {
+            return static_cast<T>(value);
+        }
 
-            break;
+        throw JsonException(*this, "JSON is not numeric");
+    };
 
-        case Type::Signed:
-            return static_cast<T>(m_value.m_signed);
-
-        case Type::Unsigned:
-            return static_cast<T>(m_value.m_unsigned);
-
-        case Type::Float:
-            return static_cast<T>(m_value.m_float);
-
-        default:
-            break;
-    }
-
-    throw JsonException(
-        *this, String::Format("Type %s is not numeric", m_type));
-}
-
-//==============================================================================
-template <typename T, fly::if_string::enabled<T>>
-Json::Value::Value(const T &value) noexcept : m_pString(new string_type(value))
-{
-}
-
-//==============================================================================
-template <typename T, fly::if_map::enabled<T>>
-Json::Value::Value(const T &value) noexcept :
-    m_pObject(new object_type(value.begin(), value.end()))
-{
-}
-
-//==============================================================================
-template <typename T, fly::if_array::enabled<T>>
-Json::Value::Value(const T &value) noexcept :
-    m_pArray(new array_type(value.begin(), value.end()))
-{
-}
-
-//==============================================================================
-template <typename T, fly::if_boolean::enabled<T>>
-Json::Value::Value(const T &value) noexcept : m_boolean(value)
-{
-}
-
-//==============================================================================
-template <typename T, fly::if_signed_integer::enabled<T>>
-Json::Value::Value(const T &value) noexcept : m_signed(value)
-{
-}
-
-//==============================================================================
-template <typename T, fly::if_unsigned_integer::enabled<T>>
-Json::Value::Value(const T &value) noexcept : m_unsigned(value)
-{
-}
-
-//==============================================================================
-template <typename T, fly::if_floating_point::enabled<T>>
-Json::Value::Value(const T &value) noexcept : m_float(value)
-{
+    return std::visit(visitor, m_value);
 }
 
 } // namespace fly

--- a/fly/types/json.h
+++ b/fly/types/json.h
@@ -652,15 +652,7 @@ Json::operator T() const
     if (IsObject())
     {
         const object_type &value = std::get<object_type>(m_value);
-        T t {};
-
-        for (const auto &kv : value)
-        {
-            t.insert({typename T::key_type(kv.first),
-                      typename T::mapped_type(kv.second)});
-        }
-
-        return t;
+        return T(value.begin(), value.end());
     }
 
     throw JsonException(*this, "JSON type is not an object");

--- a/fly/types/json.h
+++ b/fly/types/json.h
@@ -580,6 +580,13 @@ public:
     /**
      * Constructor.
      *
+     * @param string Message indicating what error was encountered.
+     */
+    JsonException(const std::string &);
+
+    /**
+     * Constructor.
+     *
      * @param Json The Json instance for which the error was encountered.
      * @param string Message indicating what error was encountered.
      */
@@ -656,7 +663,7 @@ Json::operator T() const
         return t;
     }
 
-    throw JsonException(*this, "JSON is not an object");
+    throw JsonException(*this, "JSON type is not an object");
 }
 
 //==============================================================================
@@ -669,7 +676,7 @@ Json::operator T() const
         return T(value.begin(), value.end());
     }
 
-    throw JsonException(*this, "JSON is not an array");
+    throw JsonException(*this, "JSON type is not an array");
 }
 
 //==============================================================================
@@ -689,7 +696,7 @@ Json::operator std::array<T, N>() const
         return array;
     }
 
-    throw JsonException(*this, "JSON is not an array");
+    throw JsonException(*this, "JSON type is not an array");
 }
 
 //==============================================================================
@@ -748,7 +755,7 @@ Json::operator T() const
             return static_cast<T>(value);
         }
 
-        throw JsonException(*this, "JSON is not numeric");
+        throw JsonException(*this, "JSON type is not numeric");
     };
 
     return std::visit(visitor, m_value);

--- a/test/types/json.cpp
+++ b/test/types/json.cpp
@@ -369,17 +369,27 @@ TEST_F(JsonTest, ObjectConversionTest)
     json = "abc";
     EXPECT_THROW((std::map<std::string, fly::Json>(json)), fly::JsonException);
 
-    std::map<std::string, int> map = {{"a", 1}, {"b", 2}};
+    std::map<std::string, int> map = {};
     std::multimap<std::string, int> multimap(map.begin(), map.end());
     json = map;
-    EXPECT_EQ((std::map<std::string, int>(json)), map);
-    EXPECT_EQ((std::multimap<std::string, int>(json)), multimap);
+    EXPECT_EQ(decltype(map)(json), map);
+    EXPECT_EQ(decltype(multimap)(json), multimap);
 
-    std::map<std::string, int> empty = {};
-    std::multimap<std::string, int> multiempty(empty.begin(), empty.end());
-    json = empty;
-    EXPECT_EQ((std::map<std::string, int>(json)), empty);
-    EXPECT_EQ((std::multimap<std::string, int>(json)), multiempty);
+    map = {{"a", 1}, {"b", 2}};
+    multimap = decltype(multimap)(map.begin(), map.end());
+    json = map;
+    EXPECT_EQ(decltype(map)(json), map);
+    EXPECT_EQ(decltype(multimap)(json), multimap);
+
+    std::unordered_map<std::string, int> umap(map.begin(), map.end());
+    json = umap;
+    EXPECT_EQ(decltype(map)(json), map);
+    EXPECT_EQ(decltype(umap)(json), umap);
+
+    std::unordered_multimap<std::string, int> umultimap(map.begin(), map.end());
+    json = umap;
+    EXPECT_EQ(decltype(map)(json), map);
+    EXPECT_EQ(decltype(umultimap)(json), umultimap);
 
     json = {'7', 8};
     EXPECT_THROW((std::map<std::string, fly::Json>(json)), fly::JsonException);


### PR DESCRIPTION
Using std::variant is nicer as a type-safe union. Don't need to maintain type
(can query type at run time), and not limited to POD and pointer types.

This also increases stack size in the unit tests for Windows, otherwise a SEH
exception is raised in unit tests with very deep JSON nesting. This is probably
because object and array types are used directly in the std::variant, whereas
the union had pointers and dynamically allocated objects and arrays on the heap.