### PR TITLE
Move semantics and noexcept specifiers where appropriate

### DIFF
--- a/fly/config/config.cpp
+++ b/fly/config/config.cpp
@@ -3,13 +3,7 @@
 namespace fly {
 
 //==============================================================================
-std::string Config::GetName()
-{
-    return "Config";
-}
-
-//==============================================================================
-void Config::Update(const Json &values)
+void Config::Update(const Json &values) noexcept
 {
     std::unique_lock<std::shared_timed_mutex> lock(m_valuesMutex);
     m_values = values;

--- a/fly/config/config.h
+++ b/fly/config/config.h
@@ -10,25 +10,27 @@ namespace fly {
 /**
  * Class to hold a set of related configuration values.
  *
- * Classes may derive from this class and define helper getter functions for
- * each of its config values. Any derived class must define a static GetName()
- * method.
+ * Configuration classes must derive from this class and define helper getter
+ * functions for each of its config values. Any derived class must define a
+ * constexpr C-string named "identifier" to uniquely identify that class.
  *
  * @author Timothy Flynn (trflynn89@gmail.com)
  * @version July 18, 2016
  */
 class Config
 {
-public:
+protected:
+    friend class ConfigManager;
+
+    /**
+     * Constructor.
+     */
+    Config() noexcept = default;
+
     /**
      * Destructor.
      */
     virtual ~Config() = default;
-
-    /**
-     * Get the name to associate with this configuration.
-     */
-    static std::string GetName();
 
     /**
      * Get a value converted to a basic type, e.g. int or bool. If the value
@@ -43,12 +45,12 @@ public:
      * @return The converted value or the default value.
      */
     template <typename T>
-    T GetValue(const std::string &, T) const;
+    T GetValue(const std::string &, T) const noexcept;
 
     /**
      * Update this configuration with a new set of parsed values.
      */
-    void Update(const Json &);
+    void Update(const Json &) noexcept;
 
 private:
     mutable std::shared_timed_mutex m_valuesMutex;
@@ -57,7 +59,7 @@ private:
 
 //==============================================================================
 template <typename T>
-T Config::GetValue(const std::string &name, T def) const
+T Config::GetValue(const std::string &name, T def) const noexcept
 {
     std::shared_lock<std::shared_timed_mutex> lock(m_valuesMutex);
 

--- a/fly/config/config_manager.cpp
+++ b/fly/config/config_manager.cpp
@@ -16,7 +16,7 @@ namespace fly {
 ConfigManager::ConfigManager(
     const std::shared_ptr<SequencedTaskRunner> &spTaskRunner,
     ConfigFileType fileType,
-    const std::filesystem::path &path) :
+    const std::filesystem::path &path) noexcept :
     m_path(path),
     m_spTaskRunner(spTaskRunner)
 {
@@ -48,7 +48,7 @@ ConfigManager::~ConfigManager()
 }
 
 //==============================================================================
-ConfigManager::ConfigMap::size_type ConfigManager::GetSize()
+ConfigManager::ConfigMap::size_type ConfigManager::GetSize() noexcept
 {
     std::lock_guard<std::mutex> lock(m_configsMutex);
 
@@ -70,7 +70,7 @@ ConfigManager::ConfigMap::size_type ConfigManager::GetSize()
 }
 
 //==============================================================================
-bool ConfigManager::Start()
+bool ConfigManager::Start() noexcept
 {
     if (m_spParser)
     {
@@ -108,7 +108,7 @@ bool ConfigManager::Start()
 }
 
 //==============================================================================
-void ConfigManager::updateConfig()
+void ConfigManager::updateConfig() noexcept
 {
     std::lock_guard<std::mutex> lock(m_configsMutex);
 
@@ -148,14 +148,14 @@ void ConfigManager::updateConfig()
 
 //==============================================================================
 ConfigUpdateTask::ConfigUpdateTask(
-    const std::weak_ptr<ConfigManager> &wpConfigManager) :
+    std::weak_ptr<ConfigManager> wpConfigManager) noexcept :
     Task(),
     m_wpConfigManager(wpConfigManager)
 {
 }
 
 //==============================================================================
-void ConfigUpdateTask::Run()
+void ConfigUpdateTask::Run() noexcept
 {
     std::shared_ptr<ConfigManager> spConfigManager = m_wpConfigManager.lock();
 

--- a/fly/config/config_manager.h
+++ b/fly/config/config_manager.h
@@ -33,7 +33,7 @@ class ConfigManager : public std::enable_shared_from_this<ConfigManager>
     /**
      * Map of configuration group names to configuration objects.
      */
-    typedef std::map<std::string, std::weak_ptr<Config>> ConfigMap;
+    typedef std::map<const char *, std::weak_ptr<Config>> ConfigMap;
 
 public:
     /**

--- a/fly/logger/log.cpp
+++ b/fly/logger/log.cpp
@@ -7,27 +7,55 @@
 namespace fly {
 
 //==============================================================================
-Log::Log() : m_level(Level::NumLevels), m_time(-1.0), m_line(0), m_message()
+Log::Log() noexcept :
+    m_level(Level::NumLevels),
+    m_time(-1.0),
+    m_line(0),
+    m_message()
 {
-    ::memset(m_file, 0, sizeof(m_file));
-    ::memset(m_function, 0, sizeof(m_file));
+    std::memset(m_file, 0, sizeof(m_file));
+    std::memset(m_function, 0, sizeof(m_file));
+}
+
+//==============================================================================
+Log::Log(Log &&log) noexcept :
+    m_level(std::move(log.m_level)),
+    m_time(std::move(log.m_time)),
+    m_line(std::move(log.m_line)),
+    m_message(std::move(log.m_message))
+{
+    std::memmove(m_file, log.m_file, sizeof(m_file));
+    std::memmove(m_function, log.m_function, sizeof(m_file));
 }
 
 //==============================================================================
 Log::Log(
     const std::shared_ptr<LoggerConfig> &spConfig,
-    const std::string &message) :
+    const std::string &message) noexcept :
     m_level(Level::NumLevels),
     m_time(-1.0),
     m_line(0),
     m_message(message, 0, spConfig->MaxMessageSize())
 {
-    ::memset(m_file, 0, sizeof(m_file));
-    ::memset(m_function, 0, sizeof(m_file));
+    std::memset(m_file, 0, sizeof(m_file));
+    std::memset(m_function, 0, sizeof(m_file));
 }
 
 //==============================================================================
-std::ostream &operator<<(std::ostream &stream, const Log &log)
+Log &Log::operator=(Log &&log) noexcept
+{
+    m_level = std::move(log.m_level);
+    m_time = std::move(log.m_time);
+    std::memmove(m_file, log.m_file, sizeof(m_file));
+    std::memmove(m_function, log.m_function, sizeof(m_file));
+    m_line = std::move(log.m_line);
+    m_message = std::move(log.m_message);
+
+    return *this;
+}
+
+//==============================================================================
+std::ostream &operator<<(std::ostream &stream, const Log &log) noexcept
 {
     stream << log.m_level << '\t';
     stream << log.m_time << '\t';
@@ -40,7 +68,7 @@ std::ostream &operator<<(std::ostream &stream, const Log &log)
 }
 
 //==============================================================================
-std::ostream &operator<<(std::ostream &stream, const Log::Level &level)
+std::ostream &operator<<(std::ostream &stream, const Log::Level &level) noexcept
 {
     stream << static_cast<int>(level);
     return stream;

--- a/fly/logger/log.h
+++ b/fly/logger/log.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -27,7 +28,7 @@ struct Log
     /**
      * Enumeration to define the level of a log.
      */
-    enum class Level
+    enum class Level : std::uint8_t
     {
         Debug,
         Info,
@@ -40,7 +41,12 @@ struct Log
     /**
      * Default constructor.
      */
-    Log();
+    Log() noexcept;
+
+    /**
+     * Move constructor.
+     */
+    Log(Log &&) noexcept;
 
     /**
      * Constructor. Initialize with a message.
@@ -48,7 +54,12 @@ struct Log
      * @param LoggerConfig Reference to the logger config.
      * @param string Message to store.
      */
-    Log(const std::shared_ptr<LoggerConfig> &, const std::string &);
+    Log(const std::shared_ptr<LoggerConfig> &, const std::string &) noexcept;
+
+    /**
+     * Move assignment operator.
+     */
+    Log &operator=(Log &&) noexcept;
 
     Level m_level;
     double m_time;
@@ -57,9 +68,9 @@ struct Log
     unsigned int m_line;
     std::string m_message;
 
-    friend std::ostream &operator<<(std::ostream &, const Log &);
+    friend std::ostream &operator<<(std::ostream &, const Log &) noexcept;
 
-    friend std::ostream &operator<<(std::ostream &, const Level &);
+    friend std::ostream &operator<<(std::ostream &, const Level &) noexcept;
 };
 
 } // namespace fly

--- a/fly/logger/logger.h
+++ b/fly/logger/logger.h
@@ -91,19 +91,19 @@ public:
     Logger(
         const std::shared_ptr<SequencedTaskRunner> &,
         const std::shared_ptr<LoggerConfig> &,
-        const std::filesystem::path &);
+        const std::filesystem::path &) noexcept;
 
     /**
      * Set the logger instance so that the LOG* macros function.
      *
      * @param Logger The logger instance.
      */
-    static void SetInstance(const std::shared_ptr<Logger> &);
+    static void SetInstance(const std::shared_ptr<Logger> &) noexcept;
 
     /**
      * @return The logger instance.
      */
-    static std::shared_ptr<Logger> GetInstance();
+    static std::shared_ptr<Logger> GetInstance() noexcept;
 
     /**
      * Log to the console in a thread-safe manner.
@@ -111,7 +111,7 @@ public:
      * @param bool Whether to acquire lock before logging.
      * @param string The message to log.
      */
-    static void ConsoleLog(bool, const std::string &);
+    static void ConsoleLog(bool, const std::string &) noexcept;
 
     /**
      * Add a log to the static logger instance.
@@ -127,19 +127,19 @@ public:
         const char *,
         const char *,
         unsigned int,
-        const std::string &);
+        const std::string &) noexcept;
 
     /**
      * Create the logger's log file on disk and initialize the logger task.
      *
      * @return bool True if the logger is in a valid state.
      */
-    bool Start();
+    bool Start() noexcept;
 
     /**
      * @return path Path to the current log file.
      */
-    std::filesystem::path GetLogFilePath() const;
+    std::filesystem::path GetLogFilePath() const noexcept;
 
 private:
     /**
@@ -148,7 +148,7 @@ private:
      *
      * @return bool True if the current log file is still open and healthy.
      */
-    bool poll();
+    bool poll() noexcept;
 
     /**
      * Add a log to this logger instance.
@@ -164,14 +164,14 @@ private:
         const char *,
         const char *,
         unsigned int,
-        const std::string &);
+        const std::string &) noexcept;
 
     /**
      * Create the log file. If a log file is already open, close it.
      *
      * @return True if the log file could be opened.
      */
-    bool createLogFile();
+    bool createLogFile() noexcept;
 
     static std::weak_ptr<Logger> s_wpInstance;
     static std::mutex s_consoleMutex;
@@ -201,14 +201,14 @@ private:
 class LoggerTask : public Task
 {
 public:
-    LoggerTask(const std::weak_ptr<Logger> &);
+    LoggerTask(std::weak_ptr<Logger>) noexcept;
 
 protected:
     /**
      * Call back into the logger to check for new log entries. The task re-arms
      * itself.
      */
-    void Run() override;
+    void Run() noexcept override;
 
 private:
     std::weak_ptr<Logger> m_wpLogger;

--- a/fly/logger/logger_config.cpp
+++ b/fly/logger/logger_config.cpp
@@ -5,7 +5,7 @@
 namespace fly {
 
 //==============================================================================
-LoggerConfig::LoggerConfig() :
+LoggerConfig::LoggerConfig() noexcept :
     m_defaultMaxLogFileSize(U64(20 << 20)),
     m_defaultMaxMessageSize(U64(256)),
     m_defaultQueueWaitTime(I64(100))
@@ -13,26 +13,20 @@ LoggerConfig::LoggerConfig() :
 }
 
 //==============================================================================
-std::string LoggerConfig::GetName()
-{
-    return "logger";
-}
-
-//==============================================================================
-std::uintmax_t LoggerConfig::MaxLogFileSize() const
+std::uintmax_t LoggerConfig::MaxLogFileSize() const noexcept
 {
     return GetValue<std::uintmax_t>(
         "max_log_file_size", m_defaultMaxLogFileSize);
 }
 
 //==============================================================================
-size_t LoggerConfig::MaxMessageSize() const
+size_t LoggerConfig::MaxMessageSize() const noexcept
 {
     return GetValue<size_t>("max_message_size", m_defaultMaxMessageSize);
 }
 
 //==============================================================================
-std::chrono::milliseconds LoggerConfig::QueueWaitTime() const
+std::chrono::milliseconds LoggerConfig::QueueWaitTime() const noexcept
 {
     return std::chrono::milliseconds(GetValue<std::chrono::milliseconds::rep>(
         "queue_wait_time", m_defaultQueueWaitTime));

--- a/fly/logger/logger_config.h
+++ b/fly/logger/logger_config.h
@@ -4,7 +4,6 @@
 
 #include <chrono>
 #include <cstdint>
-#include <string>
 
 namespace fly {
 
@@ -17,30 +16,27 @@ namespace fly {
 class LoggerConfig : public Config
 {
 public:
+    static constexpr const char *identifier = "logger";
+
     /**
      * Constructor.
      */
-    LoggerConfig();
-
-    /**
-     * Get the name to associate with this configuration.
-     */
-    static std::string GetName();
+    LoggerConfig() noexcept;
 
     /**
      * @return Max log file size (in bytes) before rotating the log file.
      */
-    std::uintmax_t MaxLogFileSize() const;
+    std::uintmax_t MaxLogFileSize() const noexcept;
 
     /**
      * @return Max message size (in bytes) per log.
      */
-    size_t MaxMessageSize() const;
+    size_t MaxMessageSize() const noexcept;
 
     /**
      * @return Sleep time for logger IO thread.
      */
-    std::chrono::milliseconds QueueWaitTime() const;
+    std::chrono::milliseconds QueueWaitTime() const noexcept;
 
 protected:
     size_t m_defaultMaxLogFileSize;

--- a/fly/parser/exceptions.cpp
+++ b/fly/parser/exceptions.cpp
@@ -8,7 +8,9 @@
 namespace fly {
 
 //==============================================================================
-ParserException::ParserException(int line, const std::string &message) :
+ParserException::ParserException(
+    int line,
+    const std::string &message) noexcept :
     m_message(String::Format(
         "ParserException: Error parsing at [line %d]: %s",
         line,
@@ -21,7 +23,7 @@ ParserException::ParserException(int line, const std::string &message) :
 ParserException::ParserException(
     int line,
     int column,
-    const std::string &message) :
+    const std::string &message) noexcept :
     m_message(String::Format(
         "ParserException: Error parsing at [line %d, column %d]: %s",
         line,
@@ -41,13 +43,13 @@ const char *ParserException::what() const noexcept
 UnexpectedCharacterException::UnexpectedCharacterException(
     int line,
     int column,
-    int c) :
+    int c) noexcept :
     ParserException(
         line,
         column,
-        (std::isprint(c) ?
-             String::Format("Unexpected character '%c' (%x)", char(c), c) :
-             String::Format("Unexpected character '%x'", c)))
+        std::isprint(c) ?
+            String::Format("Unexpected character '%c' (%x)", char(c), c) :
+            String::Format("Unexpected character '%x'", c))
 {
 }
 
@@ -55,7 +57,7 @@ UnexpectedCharacterException::UnexpectedCharacterException(
 BadConversionException::BadConversionException(
     int line,
     int column,
-    const std::string &value) :
+    const std::string &value) noexcept :
     ParserException(
         line,
         column,

--- a/fly/parser/exceptions.h
+++ b/fly/parser/exceptions.h
@@ -20,7 +20,7 @@ public:
      * @param int Line number where error was encountered.
      * @param string Message indicating what error was encountered.
      */
-    ParserException(int, const std::string &);
+    ParserException(int, const std::string &) noexcept;
 
     /**
      * Constructor.
@@ -29,7 +29,7 @@ public:
      * @param int Column number in line where error was encountered.
      * @param string Message indicating what error was encountered.
      */
-    ParserException(int, int, const std::string &);
+    ParserException(int, int, const std::string &) noexcept;
 
     /**
      * @return A C-string representing this exception.
@@ -56,7 +56,7 @@ public:
      * @param int Column number in line where error was encountered.
      * @param int Unexpected character code.
      */
-    UnexpectedCharacterException(int, int, int);
+    UnexpectedCharacterException(int, int, int) noexcept;
 };
 
 /**
@@ -75,7 +75,7 @@ public:
      * @param int Column number in line where error was encountered.
      * @param string The unconvertable value.
      */
-    BadConversionException(int, int, const std::string &);
+    BadConversionException(int, int, const std::string &) noexcept;
 };
 
 } // namespace fly

--- a/fly/parser/ini_parser.cpp
+++ b/fly/parser/ini_parser.cpp
@@ -8,7 +8,7 @@
 namespace fly {
 
 //==============================================================================
-Json IniParser::ParseInternal(std::istream &stream)
+Json IniParser::ParseInternal(std::istream &stream) noexcept(false)
 {
     std::string line, section;
     Json values;
@@ -41,7 +41,7 @@ Json IniParser::ParseInternal(std::istream &stream)
 }
 
 //==============================================================================
-std::string IniParser::onSection(const std::string &line)
+std::string IniParser::onSection(const std::string &line) noexcept(false)
 {
     std::string section = line;
     String::Trim(section);
@@ -55,7 +55,7 @@ std::string IniParser::onSection(const std::string &line)
 }
 
 //==============================================================================
-void IniParser::onValue(Json &section, const std::string &line)
+void IniParser::onValue(Json &section, const std::string &line) noexcept(false)
 {
     static const size_t size = 2;
 
@@ -86,13 +86,14 @@ void IniParser::onValue(Json &section, const std::string &line)
 }
 
 //==============================================================================
-bool IniParser::trimValue(std::string &str, char ch) const
+bool IniParser::trimValue(std::string &str, char ch) const noexcept(false)
 {
     return trimValue(str, ch, ch);
 }
 
 //==============================================================================
 bool IniParser::trimValue(std::string &str, char start, char end) const
+    noexcept(false)
 {
     bool startsWithChar = String::StartsWith(str, start);
     bool endsWithChar = String::EndsWith(str, end);

--- a/fly/parser/ini_parser.h
+++ b/fly/parser/ini_parser.h
@@ -26,7 +26,7 @@ protected:
      *
      * @throws ParserException Thrown if an error occurs parsing the stream.
      */
-    Json ParseInternal(std::istream &) override;
+    Json ParseInternal(std::istream &) noexcept(false) override;
 
 private:
     /**
@@ -35,16 +35,21 @@ private:
      * @param string Line containing the section.
      *
      * @return The parsed section name.
+     *
+     * @throws ParserException Thrown if the section name is quoted.
      */
-    std::string onSection(const std::string &);
+    std::string onSection(const std::string &) noexcept(false);
 
     /**
      * Parse a line containing a name/value pair.
      *
      * @param Json Section containing the pair.
      * @param string Line containing the pair.
+     *
+     * @throws ParserException Thrown if the value name is quoted, or the line
+     *                         both a name and value are not found.
      */
-    void onValue(Json &, const std::string &);
+    void onValue(Json &, const std::string &) noexcept(false);
 
     /**
      * If the given string begins and ends with the given character, remove that
@@ -58,7 +63,7 @@ private:
      * @throws ParserException Thrown if the character was found at one end of
      *                         the string, but not the other.
      */
-    bool trimValue(std::string &, char) const;
+    bool trimValue(std::string &, char) const noexcept(false);
 
     /**
      * If the given string begins with the first given character and ends with
@@ -74,7 +79,7 @@ private:
      * @throws ParserException Thrown if the one of the start/end characters
      *                         was found, but not the other.
      */
-    bool trimValue(std::string &, char, char) const;
+    bool trimValue(std::string &, char, char) const noexcept(false);
 };
 
 } // namespace fly

--- a/fly/parser/json_parser.cpp
+++ b/fly/parser/json_parser.cpp
@@ -9,17 +9,19 @@
 namespace fly {
 
 //==============================================================================
-JsonParser::JsonParser() : Parser(), m_features(Features::Strict)
+JsonParser::JsonParser() noexcept : Parser(), m_features(Features::Strict)
 {
 }
 
 //==============================================================================
-JsonParser::JsonParser(Features features) : Parser(), m_features(features)
+JsonParser::JsonParser(Features features) noexcept :
+    Parser(),
+    m_features(features)
 {
 }
 
 //==============================================================================
-Json JsonParser::ParseInternal(std::istream &stream)
+Json JsonParser::ParseInternal(std::istream &stream) noexcept(false)
 {
     m_states = decltype(m_states)();
     m_states.push(State::NoState);
@@ -102,7 +104,7 @@ Json JsonParser::ParseInternal(std::istream &stream)
 }
 
 //==============================================================================
-void JsonParser::onWhitespace(Token token, int c)
+void JsonParser::onWhitespace(Token token, int c) noexcept(false)
 {
     if (m_parsingString)
     {
@@ -129,7 +131,7 @@ void JsonParser::onWhitespace(Token token, int c)
 }
 
 //==============================================================================
-void JsonParser::onStartBraceOrBracket(Token token, int c)
+void JsonParser::onStartBraceOrBracket(Token token, int c) noexcept(false)
 {
     switch (m_states.top())
     {
@@ -186,7 +188,7 @@ void JsonParser::onStartBraceOrBracket(Token token, int c)
 }
 
 //==============================================================================
-void JsonParser::onCloseBraceOrBracket(Token token, int c)
+void JsonParser::onCloseBraceOrBracket(Token token, int c) noexcept(false)
 {
     switch (m_states.top())
     {
@@ -243,7 +245,7 @@ void JsonParser::onCloseBraceOrBracket(Token token, int c)
 }
 
 //==============================================================================
-void JsonParser::onQuotation(int c)
+void JsonParser::onQuotation(int c) noexcept(false)
 {
     switch (m_states.top())
     {
@@ -294,7 +296,7 @@ void JsonParser::onQuotation(int c)
 }
 
 //==============================================================================
-void JsonParser::onColon(int c)
+void JsonParser::onColon(int c) noexcept(false)
 {
     switch (m_states.top())
     {
@@ -324,7 +326,7 @@ void JsonParser::onColon(int c)
 }
 
 //==============================================================================
-void JsonParser::onComma(int c)
+void JsonParser::onComma(int c) noexcept(false)
 {
     switch (m_states.top())
     {
@@ -374,7 +376,7 @@ void JsonParser::onComma(int c)
 }
 
 //==============================================================================
-void JsonParser::onSolidus(int c, std::istream &stream)
+void JsonParser::onSolidus(int c, std::istream &stream) noexcept(false)
 {
     if (m_parsingString)
     {
@@ -430,7 +432,8 @@ void JsonParser::onSolidus(int c, std::istream &stream)
 }
 
 //==============================================================================
-void JsonParser::onCharacter(Token token, int c, std::istream &stream)
+void JsonParser::onCharacter(Token token, int c, std::istream &stream) noexcept(
+    false)
 {
     if (std::isspace(c))
     {
@@ -474,7 +477,7 @@ void JsonParser::onCharacter(Token token, int c, std::istream &stream)
 }
 
 //==============================================================================
-void JsonParser::pushValue(int c)
+void JsonParser::pushValue(int c) noexcept(false)
 {
     if (m_parsingComplete)
     {
@@ -486,7 +489,7 @@ void JsonParser::pushValue(int c)
 }
 
 //==============================================================================
-std::string JsonParser::popValue()
+std::string JsonParser::popValue() noexcept
 {
     const std::string value = m_parsing.str();
 
@@ -498,7 +501,7 @@ std::string JsonParser::popValue()
 }
 
 //==============================================================================
-bool JsonParser::storeValue()
+bool JsonParser::storeValue() noexcept(false)
 {
     const std::string value = popValue();
 
@@ -570,7 +573,7 @@ bool JsonParser::storeValue()
 void JsonParser::validateNumber(
     const std::string &value,
     bool &isFloat,
-    bool &isSigned) const
+    bool &isSigned) const noexcept(false)
 {
     isSigned = (value[0] == '-');
 
@@ -619,13 +622,13 @@ void JsonParser::validateNumber(
 }
 
 //==============================================================================
-bool JsonParser::isFeatureAllowed(Features feature) const
+bool JsonParser::isFeatureAllowed(Features feature) const noexcept(false)
 {
     return (m_features & feature) != Features::Strict;
 }
 
 //==============================================================================
-JsonParser::Features operator&(JsonParser::Features a, JsonParser::Features b)
+JsonParser::Features operator&(JsonParser::Features a, JsonParser::Features b) noexcept
 {
     return static_cast<JsonParser::Features>(
         static_cast<std::underlying_type_t<JsonParser::Features>>(a) &
@@ -633,7 +636,7 @@ JsonParser::Features operator&(JsonParser::Features a, JsonParser::Features b)
 }
 
 //==============================================================================
-JsonParser::Features operator|(JsonParser::Features a, JsonParser::Features b)
+JsonParser::Features operator|(JsonParser::Features a, JsonParser::Features b) noexcept
 {
     return static_cast<JsonParser::Features>(
         static_cast<std::underlying_type_t<JsonParser::Features>>(a) |

--- a/fly/parser/json_parser.cpp
+++ b/fly/parser/json_parser.cpp
@@ -628,7 +628,8 @@ bool JsonParser::isFeatureAllowed(Features feature) const noexcept(false)
 }
 
 //==============================================================================
-JsonParser::Features operator&(JsonParser::Features a, JsonParser::Features b) noexcept
+JsonParser::Features
+operator&(JsonParser::Features a, JsonParser::Features b) noexcept
 {
     return static_cast<JsonParser::Features>(
         static_cast<std::underlying_type_t<JsonParser::Features>>(a) &
@@ -636,7 +637,8 @@ JsonParser::Features operator&(JsonParser::Features a, JsonParser::Features b) n
 }
 
 //==============================================================================
-JsonParser::Features operator|(JsonParser::Features a, JsonParser::Features b) noexcept
+JsonParser::Features
+operator|(JsonParser::Features a, JsonParser::Features b) noexcept
 {
     return static_cast<JsonParser::Features>(
         static_cast<std::underlying_type_t<JsonParser::Features>>(a) |

--- a/fly/parser/json_parser.h
+++ b/fly/parser/json_parser.h
@@ -20,7 +20,7 @@ namespace fly {
  */
 class JsonParser : public Parser
 {
-    enum class Token
+    enum class Token : std::uint8_t
     {
         Tab = 0x09, // \t
         NewLine = 0x0a, // \n
@@ -42,7 +42,7 @@ class JsonParser : public Parser
         ReverseSolidus = 0x5c, /* \ */
     };
 
-    enum class State
+    enum class State : std::uint8_t
     {
         NoState,
         ParsingObject,
@@ -57,7 +57,7 @@ public:
     /**
      * Optional parsing features. May be combined with bitwise and/or operators.
      */
-    enum class Features : uint8_t
+    enum class Features : std::uint8_t
     {
         // Strict compliance with http://www.json.org.
         Strict = 0,
@@ -76,14 +76,14 @@ public:
     /**
      * Constructor. Create a parser with strict http://www.json.org compliance.
      */
-    JsonParser();
+    JsonParser() noexcept;
 
     /**
      * Constructor. Create a parser with the specific features.
      *
      * @param Features The extra features to allow.
      */
-    JsonParser(Features);
+    JsonParser(Features) noexcept;
 
 protected:
     /**
@@ -97,7 +97,7 @@ protected:
      * @throws UnexpectedCharacterException A parsed character was unexpected.
      * @throws BadConversionException A parsed object was invalid.
      */
-    Json ParseInternal(std::istream &) override;
+    Json ParseInternal(std::istream &) noexcept(false) override;
 
 private:
     /**
@@ -108,7 +108,7 @@ private:
      *
      * @throws UnexpectedCharacterException A parsed character was unexpected.
      */
-    void onWhitespace(Token, int);
+    void onWhitespace(Token, int) noexcept(false);
 
     /**
      * Handle the start of an object or array.
@@ -118,7 +118,7 @@ private:
      *
      * @throws UnexpectedCharacterException A parsed character was unexpected.
      */
-    void onStartBraceOrBracket(Token, int);
+    void onStartBraceOrBracket(Token, int) noexcept(false);
 
     /**
      * Handle the end of an object or array.
@@ -129,7 +129,7 @@ private:
      * @throws UnexpectedCharacterException A parsed character was unexpected.
      * @throws BadConversionException A parsed object was invalid.
      */
-    void onCloseBraceOrBracket(Token, int);
+    void onCloseBraceOrBracket(Token, int) noexcept(false);
 
     /**
      * Handle the start or end of a string, for either a name or value.
@@ -138,7 +138,7 @@ private:
      *
      * @throws UnexpectedCharacterException A parsed character was unexpected.
      */
-    void onQuotation(int);
+    void onQuotation(int) noexcept(false);
 
     /**
      * Handle a colon between name-value pairs.
@@ -147,7 +147,7 @@ private:
      *
      * @throws UnexpectedCharacterException A parsed character was unexpected.
      */
-    void onColon(int);
+    void onColon(int) noexcept(false);
 
     /**
      * Handle a comma, either in an array or after an object.
@@ -157,7 +157,7 @@ private:
      * @throws UnexpectedCharacterException A parsed character was unexpected.
      * @throws BadConversionException A parsed object was invalid.
      */
-    void onComma(int);
+    void onComma(int) noexcept(false);
 
     /**
      * Handle the start of a comment, if comments are allowed. Consumes the
@@ -168,7 +168,7 @@ private:
      *
      * @throws UnexpectedCharacterException A parsed character was unexpected.
      */
-    void onSolidus(int, std::istream &);
+    void onSolidus(int, std::istream &) noexcept(false);
 
     /**
      * Handle any other character. If the character is a reverse solidus, accept
@@ -180,21 +180,23 @@ private:
      *
      * @throws UnexpectedCharacterException A parsed character was unexpected.
      */
-    void onCharacter(Token, int, std::istream &);
+    void onCharacter(Token, int, std::istream &) noexcept(false);
 
     /**
      * Push a parsed character onto the parsing stream.
      *
      * @param int The current parsed character.
+     *
+     * @throws UnexpectedCharacterException Any character was unexpected.
      */
-    void pushValue(int);
+    void pushValue(int) noexcept(false);
 
     /**
      * Retrieve and clear the current value of the parsing stream.
      *
      * @return string The current value of the parsing stream.
      */
-    std::string popValue();
+    std::string popValue() noexcept;
 
     /**
      * Store the current value of the parsing stream as a JSON object. Ensures
@@ -204,7 +206,7 @@ private:
      *
      * @throws BadConversionException A parsed object was invalid.
      */
-    bool storeValue();
+    bool storeValue() noexcept(false);
 
     /**
      * Validate that a parsed number is compliant with http://www.json.org.
@@ -215,7 +217,8 @@ private:
      *
      * @throws BadConversionException A parsed number was invalid.
      */
-    void validateNumber(const std::string &, bool &, bool &) const;
+    void validateNumber(const std::string &, bool &, bool &) const
+        noexcept(false);
 
     /**
      * Check if a feature has been allowed.
@@ -224,7 +227,7 @@ private:
      *
      * @return True if the feature is allowed.
      */
-    bool isFeatureAllowed(Features) const;
+    bool isFeatureAllowed(Features) const noexcept(false);
 
     Features m_features;
 
@@ -245,11 +248,11 @@ private:
 /**
  * Combine two Features instances into a single instance via bitwise-and.
  */
-JsonParser::Features operator&(JsonParser::Features, JsonParser::Features);
+JsonParser::Features operator&(JsonParser::Features, JsonParser::Features) noexcept;
 
 /**
  * Combine two Features instances into a single instance via bitwise-or.
  */
-JsonParser::Features operator|(JsonParser::Features, JsonParser::Features);
+JsonParser::Features operator|(JsonParser::Features, JsonParser::Features) noexcept;
 
 } // namespace fly

--- a/fly/parser/json_parser.h
+++ b/fly/parser/json_parser.h
@@ -248,11 +248,13 @@ private:
 /**
  * Combine two Features instances into a single instance via bitwise-and.
  */
-JsonParser::Features operator&(JsonParser::Features, JsonParser::Features) noexcept;
+JsonParser::Features
+operator&(JsonParser::Features, JsonParser::Features) noexcept;
 
 /**
  * Combine two Features instances into a single instance via bitwise-or.
  */
-JsonParser::Features operator|(JsonParser::Features, JsonParser::Features) noexcept;
+JsonParser::Features
+operator|(JsonParser::Features, JsonParser::Features) noexcept;
 
 } // namespace fly

--- a/fly/parser/parser.cpp
+++ b/fly/parser/parser.cpp
@@ -6,7 +6,7 @@
 namespace fly {
 
 //==============================================================================
-Json Parser::ParseString(const std::string &contents)
+Json Parser::ParseString(const std::string &contents) noexcept(false)
 {
     std::istringstream stream(contents);
 
@@ -18,7 +18,7 @@ Json Parser::ParseString(const std::string &contents)
 }
 
 //==============================================================================
-Json Parser::ParseFile(const std::filesystem::path &path)
+Json Parser::ParseFile(const std::filesystem::path &path) noexcept(false)
 {
     std::ifstream stream(path, std::ios::in);
 
@@ -30,7 +30,7 @@ Json Parser::ParseFile(const std::filesystem::path &path)
 }
 
 //==============================================================================
-void Parser::consumeByteOrderMark(std::istream &stream)
+void Parser::consumeByteOrderMark(std::istream &stream) const noexcept
 {
     if (stream && (stream.peek() != EOF))
     {

--- a/fly/parser/parser.h
+++ b/fly/parser/parser.h
@@ -32,7 +32,7 @@ public:
      *
      * @throws ParserException Thrown if an error occurs parsing the string.
      */
-    Json ParseString(const std::string &);
+    Json ParseString(const std::string &) noexcept(false);
 
     /**
      * Parse a file and retrieve parsed values.
@@ -43,7 +43,7 @@ public:
      *
      * @throws ParserException Thrown if an error occurs parsing the file.
      */
-    Json ParseFile(const std::filesystem::path &);
+    Json ParseFile(const std::filesystem::path &) noexcept(false);
 
 protected:
     /**
@@ -53,7 +53,7 @@ protected:
      *
      * @throws ParserException Thrown if an error occurs parsing the stream.
      */
-    virtual Json ParseInternal(std::istream &) = 0;
+    virtual Json ParseInternal(std::istream &) noexcept(false) = 0;
 
     int m_line;
     int m_column;
@@ -65,7 +65,7 @@ private:
      *
      * @param istream Stream holding the contents to parse.
      */
-    void consumeByteOrderMark(std::istream &);
+    void consumeByteOrderMark(std::istream &) const noexcept;
 };
 
 } // namespace fly

--- a/fly/path/nix/path_monitor_impl.cpp
+++ b/fly/path/nix/path_monitor_impl.cpp
@@ -24,7 +24,7 @@ namespace {
 //==============================================================================
 PathMonitorImpl::PathMonitorImpl(
     const std::shared_ptr<SequencedTaskRunner> &spTaskRunner,
-    const std::shared_ptr<PathConfig> &spConfig) :
+    const std::shared_ptr<PathConfig> &spConfig) noexcept :
     PathMonitor(spTaskRunner, spConfig),
     m_monitorDescriptor(::inotify_init1(s_initFlags))
 {
@@ -45,13 +45,13 @@ PathMonitorImpl::~PathMonitorImpl()
 }
 
 //==============================================================================
-bool PathMonitorImpl::IsValid() const
+bool PathMonitorImpl::IsValid() const noexcept
 {
     return m_monitorDescriptor != -1;
 }
 
 //==============================================================================
-void PathMonitorImpl::Poll(const std::chrono::milliseconds &timeout)
+void PathMonitorImpl::Poll(const std::chrono::milliseconds &timeout) noexcept
 {
     struct pollfd pollFd;
 
@@ -77,6 +77,7 @@ void PathMonitorImpl::Poll(const std::chrono::milliseconds &timeout)
 //==============================================================================
 std::shared_ptr<PathMonitor::PathInfo>
 PathMonitorImpl::CreatePathInfo(const std::filesystem::path &path) const
+    noexcept
 {
     std::shared_ptr<PathMonitor::PathInfo> spInfo;
 
@@ -89,7 +90,7 @@ PathMonitorImpl::CreatePathInfo(const std::filesystem::path &path) const
 }
 
 //==============================================================================
-bool PathMonitorImpl::readEvents() const
+bool PathMonitorImpl::readEvents() const noexcept
 {
     static const size_t eventSize = sizeof(struct inotify_event);
 
@@ -129,6 +130,7 @@ bool PathMonitorImpl::readEvents() const
 
 //==============================================================================
 void PathMonitorImpl::handleEvent(const struct inotify_event *pEvent) const
+    noexcept
 {
     auto it = std::find_if(
         m_pathInfo.begin(),
@@ -165,7 +167,7 @@ void PathMonitorImpl::handleEvent(const struct inotify_event *pEvent) const
 }
 
 //==============================================================================
-PathMonitor::PathEvent PathMonitorImpl::convertToEvent(int mask) const
+PathMonitor::PathEvent PathMonitorImpl::convertToEvent(int mask) const noexcept
 {
     PathMonitor::PathEvent event = PathMonitor::PathEvent::None;
 
@@ -188,7 +190,7 @@ PathMonitor::PathEvent PathMonitorImpl::convertToEvent(int mask) const
 //==============================================================================
 PathMonitorImpl::PathInfoImpl::PathInfoImpl(
     int monitorDescriptor,
-    const std::filesystem::path &path) :
+    const std::filesystem::path &path) noexcept :
     PathMonitorImpl::PathInfo(),
     m_monitorDescriptor(monitorDescriptor),
     m_watchDescriptor(-1)
@@ -213,7 +215,7 @@ PathMonitorImpl::PathInfoImpl::~PathInfoImpl()
 }
 
 //==============================================================================
-bool PathMonitorImpl::PathInfoImpl::IsValid() const
+bool PathMonitorImpl::PathInfoImpl::IsValid() const noexcept
 {
     return m_watchDescriptor != -1;
 }

--- a/fly/path/nix/path_monitor_impl.h
+++ b/fly/path/nix/path_monitor_impl.h
@@ -28,7 +28,7 @@ public:
      */
     PathMonitorImpl(
         const std::shared_ptr<SequencedTaskRunner> &,
-        const std::shared_ptr<PathConfig> &);
+        const std::shared_ptr<PathConfig> &) noexcept;
 
     /**
      * Destructor. Close the path monitor's inotify handle.
@@ -41,7 +41,7 @@ protected:
      *
      * @return bool True if the inotify handle is valid.
      */
-    bool IsValid() const override;
+    bool IsValid() const noexcept override;
 
     /**
      * Check if the path monitor's inotify handle has any events to be read,
@@ -49,10 +49,10 @@ protected:
      *
      * @param milliseconds Max time allow for an event to be readable.
      */
-    void Poll(const std::chrono::milliseconds &) override;
+    void Poll(const std::chrono::milliseconds &) noexcept override;
 
     std::shared_ptr<PathMonitor::PathInfo>
-    CreatePathInfo(const std::filesystem::path &) const override;
+    CreatePathInfo(const std::filesystem::path &) const noexcept override;
 
 private:
     /**
@@ -62,13 +62,13 @@ private:
      */
     struct PathInfoImpl : PathMonitor::PathInfo
     {
-        PathInfoImpl(int, const std::filesystem::path &);
+        PathInfoImpl(int, const std::filesystem::path &) noexcept;
         ~PathInfoImpl() override;
 
         /**
          * @return bool True if initialization was sucessful.
          */
-        bool IsValid() const override;
+        bool IsValid() const noexcept override;
 
         int m_monitorDescriptor;
         int m_watchDescriptor;
@@ -79,14 +79,14 @@ private:
      *
      * @return bool True if any events were read.
      */
-    bool readEvents() const;
+    bool readEvents() const noexcept;
 
     /**
      * Handle a single inotify event. Find a monitored path that corresponds
      * to the event and trigger its callback. If no path was found, drop the
      * event.
      */
-    void handleEvent(const struct inotify_event *) const;
+    void handleEvent(const struct inotify_event *) const noexcept;
 
     /**
      * Convert an inotify event mask to a PathEvent.
@@ -95,7 +95,7 @@ private:
      *
      * @return PathEvent A PathEvent that matches the event mask.
      */
-    PathMonitor::PathEvent convertToEvent(int) const;
+    PathMonitor::PathEvent convertToEvent(int) const noexcept;
 
     int m_monitorDescriptor;
 };

--- a/fly/path/path_config.cpp
+++ b/fly/path/path_config.cpp
@@ -5,18 +5,12 @@
 namespace fly {
 
 //==============================================================================
-PathConfig::PathConfig() : m_defaultPollInterval(I64(1000))
+PathConfig::PathConfig() noexcept : m_defaultPollInterval(I64(1000))
 {
 }
 
 //==============================================================================
-std::string PathConfig::GetName()
-{
-    return "path";
-}
-
-//==============================================================================
-std::chrono::milliseconds PathConfig::PollInterval() const
+std::chrono::milliseconds PathConfig::PollInterval() const noexcept
 {
     return std::chrono::milliseconds(GetValue<std::chrono::milliseconds::rep>(
         "poll_interval", m_defaultPollInterval));

--- a/fly/path/path_config.h
+++ b/fly/path/path_config.h
@@ -3,7 +3,6 @@
 #include "fly/config/config.h"
 
 #include <chrono>
-#include <string>
 
 namespace fly {
 
@@ -16,20 +15,17 @@ namespace fly {
 class PathConfig : public Config
 {
 public:
+    static constexpr const char *identifier = "path";
+
     /**
      * Constructor.
      */
-    PathConfig();
-
-    /**
-     * Get the name to associate with this configuration.
-     */
-    static std::string GetName();
+    PathConfig() noexcept;
 
     /**
      * @return Delay between path monitor poll intervals.
      */
-    virtual std::chrono::milliseconds PollInterval() const;
+    virtual std::chrono::milliseconds PollInterval() const noexcept;
 
 protected:
     std::chrono::milliseconds::rep m_defaultPollInterval;

--- a/fly/path/path_monitor.cpp
+++ b/fly/path/path_monitor.cpp
@@ -11,7 +11,7 @@ namespace fly {
 //==============================================================================
 PathMonitor::PathMonitor(
     const std::shared_ptr<SequencedTaskRunner> &spTaskRunner,
-    const std::shared_ptr<PathConfig> &spConfig) :
+    const std::shared_ptr<PathConfig> &spConfig) noexcept :
     m_spTaskRunner(spTaskRunner),
     m_spConfig(spConfig)
 {
@@ -24,7 +24,7 @@ PathMonitor::~PathMonitor()
 }
 
 //==============================================================================
-bool PathMonitor::Start()
+bool PathMonitor::Start() noexcept
 {
     if (IsValid())
     {
@@ -42,7 +42,7 @@ bool PathMonitor::Start()
 //==============================================================================
 bool PathMonitor::AddPath(
     const std::filesystem::path &path,
-    PathEventCallback callback)
+    PathEventCallback callback) noexcept
 {
     std::error_code error;
 
@@ -72,7 +72,7 @@ bool PathMonitor::AddPath(
 }
 
 //==============================================================================
-bool PathMonitor::RemovePath(const std::filesystem::path &path)
+bool PathMonitor::RemovePath(const std::filesystem::path &path) noexcept
 {
     std::lock_guard<std::mutex> lock(m_mutex);
     auto it = m_pathInfo.find(path);
@@ -90,7 +90,7 @@ bool PathMonitor::RemovePath(const std::filesystem::path &path)
 }
 
 //==============================================================================
-void PathMonitor::RemoveAllPaths()
+void PathMonitor::RemoveAllPaths() noexcept
 {
     std::lock_guard<std::mutex> lock(m_mutex);
 
@@ -101,7 +101,7 @@ void PathMonitor::RemoveAllPaths()
 //==============================================================================
 bool PathMonitor::AddFile(
     const std::filesystem::path &file,
-    PathEventCallback callback)
+    PathEventCallback callback) noexcept
 {
     std::error_code error;
 
@@ -136,7 +136,7 @@ bool PathMonitor::AddFile(
 }
 
 //==============================================================================
-bool PathMonitor::RemoveFile(const std::filesystem::path &file)
+bool PathMonitor::RemoveFile(const std::filesystem::path &file) noexcept
 {
     bool removePath = false;
     {
@@ -169,7 +169,7 @@ bool PathMonitor::RemoveFile(const std::filesystem::path &file)
 
 //==============================================================================
 std::shared_ptr<PathMonitor::PathInfo>
-PathMonitor::getOrCreatePathInfo(const std::filesystem::path &path)
+PathMonitor::getOrCreatePathInfo(const std::filesystem::path &path) noexcept
 {
     std::shared_ptr<PathInfo> spInfo;
 
@@ -197,7 +197,7 @@ PathMonitor::getOrCreatePathInfo(const std::filesystem::path &path)
 }
 
 //==============================================================================
-std::ostream &operator<<(std::ostream &stream, PathMonitor::PathEvent event)
+std::ostream &operator<<(std::ostream &stream, PathMonitor::PathEvent event) noexcept
 {
     switch (event)
     {
@@ -223,14 +223,14 @@ std::ostream &operator<<(std::ostream &stream, PathMonitor::PathEvent event)
 
 //==============================================================================
 PathMonitorTask::PathMonitorTask(
-    const std::weak_ptr<PathMonitor> &wpPathMonitor) :
+    std::weak_ptr<PathMonitor> wpPathMonitor) noexcept :
     Task(),
     m_wpPathMonitor(wpPathMonitor)
 {
 }
 
 //==============================================================================
-void PathMonitorTask::Run()
+void PathMonitorTask::Run() noexcept
 {
     std::shared_ptr<PathMonitor> spPathMonitor = m_wpPathMonitor.lock();
 

--- a/fly/path/path_monitor.cpp
+++ b/fly/path/path_monitor.cpp
@@ -197,7 +197,8 @@ PathMonitor::getOrCreatePathInfo(const std::filesystem::path &path) noexcept
 }
 
 //==============================================================================
-std::ostream &operator<<(std::ostream &stream, PathMonitor::PathEvent event) noexcept
+std::ostream &
+operator<<(std::ostream &stream, PathMonitor::PathEvent event) noexcept
 {
     switch (event)
     {

--- a/fly/path/path_monitor.h
+++ b/fly/path/path_monitor.h
@@ -3,6 +3,7 @@
 #include "fly/fly.h"
 #include "fly/task/task.h"
 
+#include <cstdint>
 #include <filesystem>
 #include <functional>
 #include <map>
@@ -32,7 +33,7 @@ public:
     /**
      * Enumerated list of path events.
      */
-    enum class PathEvent
+    enum class PathEvent : std::uint8_t
     {
         None,
         Created,
@@ -54,7 +55,7 @@ public:
      */
     PathMonitor(
         const std::shared_ptr<SequencedTaskRunner> &,
-        const std::shared_ptr<PathConfig> &);
+        const std::shared_ptr<PathConfig> &) noexcept;
 
     /**
      * Destructor. Remove all paths from the path monitor.
@@ -66,7 +67,7 @@ public:
      *
      * @return bool True if the path monitor is in a valid state.
      */
-    bool Start();
+    bool Start() noexcept;
 
     /**
      * Monitor for changes to all files under a directory. Callbacks registered
@@ -77,7 +78,7 @@ public:
      *
      * @return bool True if the directory could be added.
      */
-    bool AddPath(const std::filesystem::path &, PathEventCallback);
+    bool AddPath(const std::filesystem::path &, PathEventCallback) noexcept;
 
     /**
      * Stop monitoring for changes to all files under a directory.
@@ -86,12 +87,12 @@ public:
      *
      * @return bool True if the directory was removed.
      */
-    bool RemovePath(const std::filesystem::path &);
+    bool RemovePath(const std::filesystem::path &) noexcept;
 
     /**
      * Stop monitoring all paths.
      */
-    void RemoveAllPaths();
+    void RemoveAllPaths() noexcept;
 
     /**
      * Monitor for changes to a single file. Callbacks registered with AddFile
@@ -102,7 +103,7 @@ public:
      *
      * @return bool True if the file could be added.
      */
-    bool AddFile(const std::filesystem::path &, PathEventCallback);
+    bool AddFile(const std::filesystem::path &, PathEventCallback) noexcept;
 
     /**
      * Stop monitoring for changes to a single file. If there are no more files
@@ -113,7 +114,7 @@ public:
      *
      * @return bool True if the file was removed.
      */
-    bool RemoveFile(const std::filesystem::path &);
+    bool RemoveFile(const std::filesystem::path &) noexcept;
 
 protected:
     /**
@@ -133,7 +134,7 @@ protected:
          *
          * @return bool True if the monitored path is healthy.
          */
-        virtual bool IsValid() const = 0;
+        virtual bool IsValid() const noexcept = 0;
 
         PathEventCallback m_pathHandler;
         std::map<std::filesystem::path, PathEventCallback> m_fileHandlers;
@@ -153,14 +154,14 @@ protected:
      * @return PathInfo Up-casted shared pointer to the PathInfo struct.
      */
     virtual std::shared_ptr<PathInfo>
-    CreatePathInfo(const std::filesystem::path &) const = 0;
+    CreatePathInfo(const std::filesystem::path &) const noexcept = 0;
 
     /**
      * Check if the path monitor implementation is valid.
      *
      * @return bool True if the implementation is valid.
      */
-    virtual bool IsValid() const = 0;
+    virtual bool IsValid() const noexcept = 0;
 
     /**
      * Check the path monitor implementation for any changes to the monitored
@@ -168,7 +169,7 @@ protected:
      *
      * @param milliseconds Max time allow for an event to be occur.
      */
-    virtual void Poll(const std::chrono::milliseconds &) = 0;
+    virtual void Poll(const std::chrono::milliseconds &) noexcept = 0;
 
     mutable std::mutex m_mutex;
     PathInfoMap m_pathInfo;
@@ -183,12 +184,12 @@ private:
      * @return PathInfo Shared pointer to the PathInfo struct.
      */
     std::shared_ptr<PathInfo>
-    getOrCreatePathInfo(const std::filesystem::path &);
+    getOrCreatePathInfo(const std::filesystem::path &) noexcept;
 
     /**
      * Stream the name of a Json instance's type.
      */
-    friend std::ostream &operator<<(std::ostream &, PathEvent);
+    friend std::ostream &operator<<(std::ostream &, PathEvent) noexcept;
 
     std::shared_ptr<SequencedTaskRunner> m_spTaskRunner;
     std::shared_ptr<Task> m_spTask;
@@ -205,7 +206,7 @@ private:
 class PathMonitorTask : public Task
 {
 public:
-    PathMonitorTask(const std::weak_ptr<PathMonitor> &);
+    PathMonitorTask(std::weak_ptr<PathMonitor>) noexcept;
 
 protected:
     /**
@@ -213,7 +214,7 @@ protected:
      * paths. If the path monitor implementation is still valid, the task
      * re-arms itself.
      */
-    void Run() override;
+    void Run() noexcept override;
 
 private:
     std::weak_ptr<PathMonitor> m_wpPathMonitor;

--- a/fly/path/win/path_monitor_impl.cpp
+++ b/fly/path/win/path_monitor_impl.cpp
@@ -31,7 +31,7 @@ namespace {
 //==============================================================================
 PathMonitorImpl::PathMonitorImpl(
     const std::shared_ptr<SequencedTaskRunner> &spTaskRunner,
-    const std::shared_ptr<PathConfig> &spConfig) :
+    const std::shared_ptr<PathConfig> &spConfig) noexcept :
     PathMonitor(spTaskRunner, spConfig),
     m_iocp(::CreateIoCompletionPort(INVALID_HANDLE_VALUE, NULL, 0, 0))
 {
@@ -52,13 +52,13 @@ PathMonitorImpl::~PathMonitorImpl()
 }
 
 //==============================================================================
-bool PathMonitorImpl::IsValid() const
+bool PathMonitorImpl::IsValid() const noexcept
 {
     return m_iocp != NULL;
 }
 
 //==============================================================================
-void PathMonitorImpl::Poll(const std::chrono::milliseconds &timeout)
+void PathMonitorImpl::Poll(const std::chrono::milliseconds &timeout) noexcept
 {
     DWORD bytes = 0;
     ULONG_PTR pKey = NULL;
@@ -101,6 +101,7 @@ void PathMonitorImpl::Poll(const std::chrono::milliseconds &timeout)
 //==============================================================================
 std::shared_ptr<PathMonitor::PathInfo>
 PathMonitorImpl::CreatePathInfo(const std::filesystem::path &path) const
+    noexcept
 {
     std::shared_ptr<PathMonitor::PathInfo> spInfo;
 
@@ -115,7 +116,7 @@ PathMonitorImpl::CreatePathInfo(const std::filesystem::path &path) const
 //==============================================================================
 void PathMonitorImpl::handleEvents(
     const std::shared_ptr<PathInfoImpl> &spInfo,
-    const std::filesystem::path &path) const
+    const std::filesystem::path &path) const noexcept
 {
     PFILE_NOTIFY_INFORMATION pInfo = spInfo->m_pInfo;
 
@@ -159,6 +160,7 @@ void PathMonitorImpl::handleEvents(
 
 //==============================================================================
 PathMonitor::PathEvent PathMonitorImpl::convertToEvent(DWORD action) const
+    noexcept
 {
     PathMonitor::PathEvent event = PathMonitor::PathEvent::None;
 
@@ -188,7 +190,7 @@ PathMonitor::PathEvent PathMonitorImpl::convertToEvent(DWORD action) const
 //==============================================================================
 PathMonitorImpl::PathInfoImpl::PathInfoImpl(
     HANDLE iocp,
-    const std::filesystem::path &path) :
+    const std::filesystem::path &path) noexcept :
     PathMonitorImpl::PathInfo(),
     m_valid(false),
     m_handle(INVALID_HANDLE_VALUE),
@@ -241,13 +243,14 @@ PathMonitorImpl::PathInfoImpl::~PathInfoImpl()
 }
 
 //==============================================================================
-bool PathMonitorImpl::PathInfoImpl::IsValid() const
+bool PathMonitorImpl::PathInfoImpl::IsValid() const noexcept
 {
     return m_valid && (m_handle != INVALID_HANDLE_VALUE);
 }
 
 //==============================================================================
-bool PathMonitorImpl::PathInfoImpl::Refresh(const std::filesystem::path &path)
+bool PathMonitorImpl::PathInfoImpl::Refresh(
+    const std::filesystem::path &path) noexcept
 {
     static const DWORD size = (s_buffSize * sizeof(FILE_NOTIFY_INFORMATION));
     DWORD bytes = 0;

--- a/fly/path/win/path_monitor_impl.h
+++ b/fly/path/win/path_monitor_impl.h
@@ -28,7 +28,7 @@ public:
      */
     PathMonitorImpl(
         const std::shared_ptr<SequencedTaskRunner> &,
-        const std::shared_ptr<PathConfig> &);
+        const std::shared_ptr<PathConfig> &) noexcept;
 
     /**
      * Destructor. Close the path monitor's IOCP.
@@ -41,7 +41,7 @@ protected:
      *
      * @return bool True if the IOCP is valid.
      */
-    bool IsValid() const override;
+    bool IsValid() const noexcept override;
 
     /**
      * Check if the path monitor's IOCP has any posted completions, and handle
@@ -49,10 +49,10 @@ protected:
      *
      * @param milliseconds Max time allow for a completion to be posted.
      */
-    void Poll(const std::chrono::milliseconds &) override;
+    void Poll(const std::chrono::milliseconds &) noexcept override;
 
     std::shared_ptr<PathMonitor::PathInfo>
-    CreatePathInfo(const std::filesystem::path &) const override;
+    CreatePathInfo(const std::filesystem::path &) const noexcept override;
 
 private:
     /**
@@ -62,13 +62,13 @@ private:
      */
     struct PathInfoImpl : public PathMonitor::PathInfo
     {
-        PathInfoImpl(HANDLE, const std::filesystem::path &);
+        PathInfoImpl(HANDLE, const std::filesystem::path &) noexcept;
         ~PathInfoImpl() override;
 
         /**
          * @return bool True if initialization was sucessful.
          */
-        bool IsValid() const override;
+        bool IsValid() const noexcept override;
 
         /**
          * Call the ReadDirectoryChangesW API for this path. Should be called
@@ -77,7 +77,7 @@ private:
          *
          * @param path Name of the monitored path.
          */
-        bool Refresh(const std::filesystem::path &);
+        bool Refresh(const std::filesystem::path &) noexcept;
 
         bool m_valid;
         HANDLE m_handle;
@@ -93,7 +93,7 @@ private:
      */
     void handleEvents(
         const std::shared_ptr<PathInfoImpl> &,
-        const std::filesystem::path &) const;
+        const std::filesystem::path &) const noexcept;
 
     /**
      * Convert a FILE_NOTIFY_INFORMATION event to a PathEvent.
@@ -102,7 +102,7 @@ private:
      *
      * @return PathEvent A PathEvent that matches the given event.
      */
-    PathMonitor::PathEvent convertToEvent(DWORD) const;
+    PathMonitor::PathEvent convertToEvent(DWORD) const noexcept;
 
     HANDLE m_iocp;
 };

--- a/fly/socket/async_request.cpp
+++ b/fly/socket/async_request.cpp
@@ -10,7 +10,7 @@ namespace {
 } // namespace
 
 //==============================================================================
-AsyncRequest::AsyncRequest() :
+AsyncRequest::AsyncRequest() noexcept :
     m_socketId(s_invalidId),
     m_requestOffset(0),
     m_request(),
@@ -20,7 +20,18 @@ AsyncRequest::AsyncRequest() :
 }
 
 //==============================================================================
-AsyncRequest::AsyncRequest(int socketId, const std::string &request) :
+AsyncRequest::AsyncRequest(AsyncRequest &&request) noexcept :
+    m_socketId(std::move(request.m_socketId)),
+    m_requestOffset(std::move(request.m_requestOffset)),
+    m_request(std::move(request.m_request)),
+    m_address(std::move(request.m_address)),
+    m_port(std::move(request.m_port))
+{
+    request.m_socketId = s_invalidId;
+}
+
+//==============================================================================
+AsyncRequest::AsyncRequest(int socketId, std::string &&request) noexcept :
     m_socketId(socketId),
     m_requestOffset(0),
     m_request(request),
@@ -32,9 +43,9 @@ AsyncRequest::AsyncRequest(int socketId, const std::string &request) :
 //==============================================================================
 AsyncRequest::AsyncRequest(
     int socketId,
-    const std::string &request,
+    std::string &&request,
     address_type address,
-    port_type port) :
+    port_type port) noexcept :
     m_socketId(socketId),
     m_requestOffset(0),
     m_request(request),
@@ -44,43 +55,58 @@ AsyncRequest::AsyncRequest(
 }
 
 //==============================================================================
-bool AsyncRequest::IsValid() const
+AsyncRequest &AsyncRequest::operator=(AsyncRequest &&request) noexcept
+{
+    m_socketId = std::move(request.m_socketId);
+    m_requestOffset = std::move(request.m_requestOffset);
+    m_request = std::move(request.m_request);
+    m_address = std::move(request.m_address);
+    m_port = std::move(request.m_port);
+
+    request.m_socketId = s_invalidId;
+
+    return *this;
+}
+
+//==============================================================================
+bool AsyncRequest::IsValid() const noexcept
 {
     return m_socketId != s_invalidId;
 }
 
 //==============================================================================
-int AsyncRequest::GetSocketId() const
+int AsyncRequest::GetSocketId() const noexcept
 {
     return m_socketId;
 }
 
 //==============================================================================
-void AsyncRequest::IncrementRequestOffset(std::string::size_type offset)
+void AsyncRequest::IncrementRequestOffset(
+    std::string::size_type offset) noexcept
 {
     m_requestOffset += offset;
 }
 
 //==============================================================================
-const std::string &AsyncRequest::GetRequest() const
+const std::string &AsyncRequest::GetRequest() const noexcept
 {
     return m_request;
 }
 
 //==============================================================================
-std::string AsyncRequest::GetRequestRemaining() const
+std::string AsyncRequest::GetRequestRemaining() const noexcept
 {
     return m_request.substr(m_requestOffset, std::string::npos);
 }
 
 //==============================================================================
-address_type AsyncRequest::GetAddress() const
+address_type AsyncRequest::GetAddress() const noexcept
 {
     return m_address;
 }
 
 //==============================================================================
-port_type AsyncRequest::GetPort() const
+port_type AsyncRequest::GetPort() const noexcept
 {
     return m_port;
 }

--- a/fly/socket/async_request.h
+++ b/fly/socket/async_request.h
@@ -22,34 +22,38 @@ public:
      * Default constructor to set the socket ID to an invalid value and the
      * request message to an empty string.
      */
-    AsyncRequest();
+    AsyncRequest() noexcept;
+
+    /**
+     * Move constructor. The moved request is invalidated.
+     */
+    AsyncRequest(AsyncRequest &&) noexcept;
 
     /**
      * Constructor to set the ID of the owning socket and the request message.
      */
-    AsyncRequest(int, const std::string &);
+    AsyncRequest(int, std::string &&) noexcept;
 
     /**
      * Constructor to set the ID of the owning socket, the request message, and
      * the address and port of the owning socket.
      */
-    AsyncRequest(int, const std::string &, address_type, port_type);
+    AsyncRequest(int, std::string &&, address_type, port_type) noexcept;
 
     /**
-     * Constructor to set the ID of the owning socket, the request message, and
-     * the address and port of the owning socket.
+     * Move assignment operator. The moved request is invalidated.
      */
-    AsyncRequest(int, const std::string &, const std::string &, port_type);
+    AsyncRequest &operator=(AsyncRequest &&) noexcept;
 
     /**
      * @return True if the socket ID is valid (i.e. has been explicitly set).
      */
-    bool IsValid() const;
+    bool IsValid() const noexcept;
 
     /**
      * @return The ID of the socket who owns this structure.
      */
-    int GetSocketId() const;
+    int GetSocketId() const noexcept;
 
     /**
      * Increase the current offset into the request message to mark how much
@@ -57,27 +61,27 @@ public:
      *
      * @param string::size_type The offset to set.
      */
-    void IncrementRequestOffset(std::string::size_type);
+    void IncrementRequestOffset(std::string::size_type) noexcept;
 
     /**
      * @return The request message - the message to be sent or received.
      */
-    const std::string &GetRequest() const;
+    const std::string &GetRequest() const noexcept;
 
     /**
      * @return The request message starting at its current offset.
      */
-    std::string GetRequestRemaining() const;
+    std::string GetRequestRemaining() const noexcept;
 
     /**
      * @return The request address (for UDP sockets).
      */
-    address_type GetAddress() const;
+    address_type GetAddress() const noexcept;
 
     /**
      * @return The request port (for UDP sockets).
      */
-    port_type GetPort() const;
+    port_type GetPort() const noexcept;
 
 private:
     int m_socketId;

--- a/fly/socket/nix/socket_impl.cpp
+++ b/fly/socket/nix/socket_impl.cpp
@@ -17,7 +17,8 @@ namespace fly {
 
 namespace {
 
-    struct sockaddr_in CreateSocketAddress(address_type address, port_type port)
+    struct sockaddr_in
+    CreateSocketAddress(address_type address, port_type port) noexcept
     {
         struct sockaddr_in socketAddress;
         memset(&socketAddress, 0, sizeof(socketAddress));
@@ -34,7 +35,7 @@ namespace {
 //==============================================================================
 SocketImpl::SocketImpl(
     Protocol protocol,
-    const std::shared_ptr<SocketConfig> &spConfig) :
+    const std::shared_ptr<SocketConfig> &spConfig) noexcept :
     Socket(protocol, spConfig)
 {
     switch (m_protocol)
@@ -58,7 +59,7 @@ SocketImpl::~SocketImpl()
 //==============================================================================
 bool SocketImpl::HostnameToAddress(
     const std::string &hostname,
-    address_type &address)
+    address_type &address) noexcept
 {
     struct hostent *ipAddress = ::gethostbyname(hostname.c_str());
 
@@ -76,19 +77,19 @@ bool SocketImpl::HostnameToAddress(
 }
 
 //==============================================================================
-address_type SocketImpl::InAddrAny()
+address_type SocketImpl::InAddrAny() noexcept
 {
     return INADDR_ANY;
 }
 
 //==============================================================================
-socket_type SocketImpl::InvalidSocket()
+socket_type SocketImpl::InvalidSocket() noexcept
 {
     return -1;
 }
 
 //==============================================================================
-void SocketImpl::Close()
+void SocketImpl::Close() noexcept
 {
     if (IsValid())
     {
@@ -98,7 +99,7 @@ void SocketImpl::Close()
 }
 
 //==============================================================================
-bool SocketImpl::IsErrorFree()
+bool SocketImpl::IsErrorFree() noexcept
 {
     int opt = -1;
     socklen_t len = sizeof(opt);
@@ -112,7 +113,7 @@ bool SocketImpl::IsErrorFree()
 }
 
 //==============================================================================
-bool SocketImpl::SetAsync()
+bool SocketImpl::SetAsync() noexcept
 {
     int flags = ::fcntl(m_socketHandle, F_GETFL, 0);
 
@@ -132,8 +133,10 @@ bool SocketImpl::SetAsync()
 }
 
 //==============================================================================
-bool SocketImpl::Bind(address_type address, port_type port, BindOption option)
-    const
+bool SocketImpl::Bind(
+    address_type address,
+    port_type port,
+    BindOption option) const noexcept
 {
     static const int bindForReuseOption = 1;
     static const socklen_t bindForReuseOptionLength =
@@ -172,7 +175,7 @@ bool SocketImpl::Bind(address_type address, port_type port, BindOption option)
 }
 
 //==============================================================================
-bool SocketImpl::Listen()
+bool SocketImpl::Listen() noexcept
 {
     if (::listen(m_socketHandle, 100) == -1)
     {
@@ -185,7 +188,7 @@ bool SocketImpl::Listen()
 }
 
 //==============================================================================
-bool SocketImpl::Connect(address_type address, port_type port)
+bool SocketImpl::Connect(address_type address, port_type port) noexcept
 {
     struct sockaddr_in socketAddress = CreateSocketAddress(address, port);
     auto *pSocketAddress = reinterpret_cast<sockaddr *>(&socketAddress);
@@ -208,7 +211,7 @@ bool SocketImpl::Connect(address_type address, port_type port)
 }
 
 //==============================================================================
-std::shared_ptr<Socket> SocketImpl::Accept() const
+std::shared_ptr<Socket> SocketImpl::Accept() const noexcept
 {
     auto ret = std::make_shared<SocketImpl>(m_protocol, m_spConfig);
 
@@ -243,6 +246,7 @@ std::shared_ptr<Socket> SocketImpl::Accept() const
 
 //==============================================================================
 size_t SocketImpl::Send(const std::string &message, bool &wouldBlock) const
+    noexcept
 {
     static const std::string eom(1, m_socketEoM);
     std::string toSend = message + eom;
@@ -290,7 +294,7 @@ size_t SocketImpl::SendTo(
     const std::string &message,
     address_type address,
     port_type port,
-    bool &wouldBlock) const
+    bool &wouldBlock) const noexcept
 {
     static const std::string eom(1, m_socketEoM);
     std::string toSend = message + eom;
@@ -342,7 +346,7 @@ size_t SocketImpl::SendTo(
 }
 
 //==============================================================================
-std::string SocketImpl::Recv(bool &wouldBlock, bool &isComplete) const
+std::string SocketImpl::Recv(bool &wouldBlock, bool &isComplete) const noexcept
 {
     std::string ret;
 
@@ -385,6 +389,7 @@ std::string SocketImpl::Recv(bool &wouldBlock, bool &isComplete) const
 
 //==============================================================================
 std::string SocketImpl::RecvFrom(bool &wouldBlock, bool &isComplete) const
+    noexcept
 {
     std::string ret;
 

--- a/fly/socket/nix/socket_impl.cpp
+++ b/fly/socket/nix/socket_impl.cpp
@@ -133,10 +133,8 @@ bool SocketImpl::SetAsync() noexcept
 }
 
 //==============================================================================
-bool SocketImpl::Bind(
-    address_type address,
-    port_type port,
-    BindOption option) const noexcept
+bool SocketImpl::Bind(address_type address, port_type port, BindOption option)
+    const noexcept
 {
     static const int bindForReuseOption = 1;
     static const socklen_t bindForReuseOptionLength =

--- a/fly/socket/nix/socket_impl.h
+++ b/fly/socket/nix/socket_impl.h
@@ -19,36 +19,36 @@ class SocketConfig;
 class SocketImpl : public Socket
 {
 public:
-    SocketImpl(Protocol, const std::shared_ptr<SocketConfig> &);
+    SocketImpl(Protocol, const std::shared_ptr<SocketConfig> &) noexcept;
     ~SocketImpl() override;
 
-    static bool HostnameToAddress(const std::string &, address_type &);
+    static bool HostnameToAddress(const std::string &, address_type &) noexcept;
 
-    static address_type InAddrAny();
+    static address_type InAddrAny() noexcept;
 
-    static socket_type InvalidSocket();
+    static socket_type InvalidSocket() noexcept;
 
-    void Close() override;
+    void Close() noexcept override;
 
-    bool IsErrorFree() override;
+    bool IsErrorFree() noexcept override;
 
-    bool SetAsync() override;
+    bool SetAsync() noexcept override;
 
-    bool Bind(address_type, port_type, BindOption) const override;
+    bool Bind(address_type, port_type, BindOption) const noexcept override;
 
-    bool Listen() override;
+    bool Listen() noexcept override;
 
-    bool Connect(address_type, port_type) override;
+    bool Connect(address_type, port_type) noexcept override;
 
-    std::shared_ptr<Socket> Accept() const override;
+    std::shared_ptr<Socket> Accept() const noexcept override;
 
 protected:
-    size_t Send(const std::string &, bool &) const override;
-    size_t
-    SendTo(const std::string &, address_type, port_type, bool &) const override;
+    size_t Send(const std::string &, bool &) const noexcept override;
+    size_t SendTo(const std::string &, address_type, port_type, bool &) const
+        noexcept override;
 
-    std::string Recv(bool &, bool &) const override;
-    std::string RecvFrom(bool &, bool &) const override;
+    std::string Recv(bool &, bool &) const noexcept override;
+    std::string RecvFrom(bool &, bool &) const noexcept override;
 };
 
 } // namespace fly

--- a/fly/socket/nix/socket_manager_impl.cpp
+++ b/fly/socket/nix/socket_manager_impl.cpp
@@ -11,13 +11,13 @@ namespace fly {
 //==============================================================================
 SocketManagerImpl::SocketManagerImpl(
     const std::shared_ptr<SequencedTaskRunner> &spTaskRunner,
-    const std::shared_ptr<SocketConfig> &spConfig) :
+    const std::shared_ptr<SocketConfig> &spConfig) noexcept :
     SocketManager(spTaskRunner, spConfig)
 {
 }
 
 //==============================================================================
-void SocketManagerImpl::Poll(const std::chrono::microseconds &timeout)
+void SocketManagerImpl::Poll(const std::chrono::microseconds &timeout) noexcept
 {
     fd_set readFd, writeFd;
 
@@ -41,8 +41,9 @@ void SocketManagerImpl::Poll(const std::chrono::microseconds &timeout)
 }
 
 //==============================================================================
-socket_type
-SocketManagerImpl::setReadAndWriteMasks(fd_set *readFd, fd_set *writeFd)
+socket_type SocketManagerImpl::setReadAndWriteMasks(
+    fd_set *readFd,
+    fd_set *writeFd) noexcept
 {
     socket_type maxFd = -1;
 
@@ -66,7 +67,7 @@ SocketManagerImpl::setReadAndWriteMasks(fd_set *readFd, fd_set *writeFd)
 }
 
 //==============================================================================
-void SocketManagerImpl::handleSocketIO(fd_set *readFd, fd_set *writeFd)
+void SocketManagerImpl::handleSocketIO(fd_set *readFd, fd_set *writeFd) noexcept
 {
     SocketList newClients, connectedClients, closedClients;
 

--- a/fly/socket/nix/socket_manager_impl.h
+++ b/fly/socket/nix/socket_manager_impl.h
@@ -23,14 +23,14 @@ class SocketManagerImpl : public SocketManager
 public:
     SocketManagerImpl(
         const std::shared_ptr<SequencedTaskRunner> &,
-        const std::shared_ptr<SocketConfig> &);
+        const std::shared_ptr<SocketConfig> &) noexcept;
 
 protected:
-    void Poll(const std::chrono::microseconds &) override;
+    void Poll(const std::chrono::microseconds &) noexcept override;
 
 private:
-    socket_type setReadAndWriteMasks(fd_set *, fd_set *);
-    void handleSocketIO(fd_set *, fd_set *);
+    socket_type setReadAndWriteMasks(fd_set *, fd_set *) noexcept;
+    void handleSocketIO(fd_set *, fd_set *) noexcept;
 };
 
 } // namespace fly

--- a/fly/socket/socket.h
+++ b/fly/socket/socket.h
@@ -28,7 +28,7 @@ public:
      * @param Protocol The communication protocol of the socket.
      * @param SocketConfig Reference to the socket configuration.
      */
-    Socket(Protocol, const std::shared_ptr<SocketConfig> &);
+    Socket(Protocol, const std::shared_ptr<SocketConfig> &) noexcept;
 
     /**
      * Destructor.
@@ -44,7 +44,7 @@ public:
      *
      * @return bool True if the hostname/address string could be converted.
      */
-    static bool HostnameToAddress(const std::string &, address_type &);
+    static bool HostnameToAddress(const std::string &, address_type &) noexcept;
 
     /**
      * INADDR_ANY may be different depending on the OS. This function will
@@ -52,7 +52,7 @@ public:
      *
      * @return INADDR_ANY for the target system.
      */
-    static address_type InAddrAny();
+    static address_type InAddrAny() noexcept;
 
     /**
      * Invalid socket handles may be different depending on the OS. This
@@ -60,81 +60,81 @@ public:
      *
      * @return Invalid socket handle for the target system.
      */
-    static socket_type InvalidSocket();
+    static socket_type InvalidSocket() noexcept;
 
     /**
      * A socket is valid if it's handle has been properly set.
      *
      * @return True if this is a valid socket, false otherwise.
      */
-    bool IsValid() const;
+    bool IsValid() const noexcept;
 
     /**
      * Check if there is any errors on the socket.
      */
-    virtual bool IsErrorFree() = 0;
+    virtual bool IsErrorFree() noexcept = 0;
 
     /**
      * Close this socket's handle.
      */
-    virtual void Close() = 0;
+    virtual void Close() noexcept = 0;
 
     /**
      * Set the socket to be asynchronous.
      *
      * @return True if the operation was successful.
      */
-    virtual bool SetAsync() = 0;
+    virtual bool SetAsync() noexcept = 0;
 
     /**
      * @return Return this socket's handle.
      */
-    socket_type GetHandle() const;
+    socket_type GetHandle() const noexcept;
 
     /**
      * @return Return the client IP this socket is connected to.
      */
-    address_type GetClientIp() const;
+    address_type GetClientIp() const noexcept;
 
     /**
      * @return Return the client port this socket is connected to.
      */
-    port_type GetClientPort() const;
+    port_type GetClientPort() const noexcept;
 
     /**
      * @return This socket's ID.
      */
-    int GetSocketId() const;
+    int GetSocketId() const noexcept;
 
     /**
      * @return True if this is a TCP socket, false otherwise.
      */
-    bool IsTcp() const;
+    bool IsTcp() const noexcept;
 
     /**
      * @return True if this is a UDP socket, false otherwise.
      */
-    bool IsUdp() const;
+    bool IsUdp() const noexcept;
 
     /**
      * @return True if this is an asynchronous socket, false otherwise.
      */
-    bool IsAsync() const;
+    bool IsAsync() const noexcept;
 
     /**
      * @return True if this socket is a listener socket.
      */
-    bool IsListening() const;
+    bool IsListening() const noexcept;
 
     /**
      * @return True if this socket is connecting to a remote endpoint.
      */
-    bool IsConnecting() const;
+    bool IsConnecting() const noexcept;
 
     /**
      * @return True if this socket is connected to a remote endpoint.
      */
-    bool IsConnected() const;
+    bool IsConnected() const noexcept;
 
     /**
      * Bind this socket to an address.
@@ -144,7 +144,7 @@ public:
      *
      * @return True if the binding was successful.
      */
-    virtual bool Bind(address_type, port_type, BindOption) const = 0;
+    virtual bool Bind(address_type, port_type, BindOption) const noexcept = 0;
 
     /**
      * Bind this socket to an address.
@@ -154,12 +154,12 @@ public:
      *
      * @return True if the binding was successful.
      */
-    bool Bind(const std::string &, port_type, BindOption) const;
+    bool Bind(const std::string &, port_type, BindOption) const noexcept;
 
     /**
      * Allow socket to listen for incoming connections.
      */
-    virtual bool Listen() = 0;
+    virtual bool Listen() noexcept = 0;
 
     /**
      * Connect to a listening socket.
@@ -169,7 +169,7 @@ public:
      *
      * @param bool True if the connection was successful, false otherwise.
      */
-    virtual bool Connect(address_type, port_type) = 0;
+    virtual bool Connect(address_type, port_type) noexcept = 0;
 
     /**
      * Connect to a listening socket.
@@ -179,7 +179,7 @@ public:
      *
      * @param bool True if the connection was successful, false otherwise.
      */
-    bool Connect(const std::string &, port_type);
+    bool Connect(const std::string &, port_type) noexcept;
 
     /**
      * Asynchronously connect to a listening socket. The connect may finish
@@ -191,7 +191,7 @@ public:
      *
      * @return The connection state (not connected, connecting, or connected).
      */
-    ConnectedState ConnectAsync(address_type, port_type);
+    ConnectedState ConnectAsync(address_type, port_type) noexcept;
 
     /**
      * Asynchronously connect to a listening socket. The connect may finish
@@ -203,7 +203,7 @@ public:
      *
      * @return The connection state (not connected, connecting, or connected).
      */
-    ConnectedState ConnectAsync(const std::string &, port_type);
+    ConnectedState ConnectAsync(const std::string &, port_type) noexcept;
 
     /**
      * After an asynchronous socket in a connecting state becomes available for
@@ -211,14 +211,14 @@ public:
      *
      * @return True if the socket is healthy and connected.
      */
-    bool FinishConnect();
+    bool FinishConnect() noexcept;
 
     /**
      * Accept an incoming client connection.
      *
      * @return A Socket on which the actual connection is made.
      */
-    virtual std::shared_ptr<Socket> Accept() const = 0;
+    virtual std::shared_ptr<Socket> Accept() const noexcept = 0;
 
     /**
      * Write data on the socket.
@@ -227,7 +227,7 @@ public:
      *
      * @return The number of bytes sent.
      */
-    size_t Send(const std::string &) const;
+    size_t Send(const std::string &) const noexcept;
 
     /**
      * Write data on the socket.
@@ -238,7 +238,7 @@ public:
      *
      * @return The number of bytes sent.
      */
-    size_t SendTo(const std::string &, address_type, port_type) const;
+    size_t SendTo(const std::string &, address_type, port_type) const noexcept;
 
     /**
      * Write data on the socket.
@@ -249,7 +249,8 @@ public:
      *
      * @return The number of bytes sent.
      */
-    size_t SendTo(const std::string &, const std::string &, port_type) const;
+    size_t SendTo(const std::string &, const std::string &, port_type) const
+        noexcept;
 
     /**
      * Request data to be written on the socket asynchronously. If this is not
@@ -259,7 +260,7 @@ public:
      *
      * @return True if the request was made.
      */
-    bool SendAsync(const std::string &);
+    bool SendAsync(std::string &&) noexcept;
 
     /**
      * Request data to be written on the socket asynchronously. If this is not
@@ -271,7 +272,7 @@ public:
      *
      * @return True if the request was made.
      */
-    bool SendToAsync(const std::string &, address_type, port_type);
+    bool SendToAsync(std::string &&, address_type, port_type) noexcept;
 
     /**
      * Request data to be written on the socket asynchronously. If this is not
@@ -283,21 +284,21 @@ public:
      *
      * @return True if the request was made.
      */
-    bool SendToAsync(const std::string &, const std::string &, port_type);
+    bool SendToAsync(std::string &&, const std::string &, port_type) noexcept;
 
     /**
      * Read data on this socket until the end-of-message character is received.
      *
      * @return The data received.
      */
-    std::string Recv() const;
+    std::string Recv() const noexcept;
 
     /**
      * Read data on this socket until the end-of-message character is received.
      *
      * @return The data received.
      */
-    std::string RecvFrom() const;
+    std::string RecvFrom() const noexcept;
 
     /**
      * Iterate thru all pending asynchronous sends. Service each request until
@@ -306,7 +307,7 @@ public:
      *
      * @param RequestQueue Queue of completed sends to post to on success.
      */
-    void ServiceSendRequests(AsyncRequest::RequestQueue &);
+    void ServiceSendRequests(AsyncRequest::RequestQueue &) noexcept;
 
     /**
      * Read on this socket until a read would block, or some other error occurs
@@ -314,7 +315,7 @@ public:
      *
      * @param RequestQueue Queue of completed received to post to on success.
      */
-    void ServiceRecvRequests(AsyncRequest::RequestQueue &);
+    void ServiceRecvRequests(AsyncRequest::RequestQueue &) noexcept;
 
 protected:
     /**
@@ -325,7 +326,7 @@ protected:
      *
      * @return The number of bytes sent.
      */
-    virtual size_t Send(const std::string &, bool &) const = 0;
+    virtual size_t Send(const std::string &, bool &) const noexcept = 0;
 
     /**
      * Write data on the socket.
@@ -338,7 +339,8 @@ protected:
      * @return The number of bytes sent.
      */
     virtual size_t
-    SendTo(const std::string &, address_type, port_type, bool &) const = 0;
+    SendTo(const std::string &, address_type, port_type, bool &) const
+        noexcept = 0;
 
     /**
      * Write data on the socket.
@@ -351,7 +353,8 @@ protected:
      * @return The number of bytes sent.
      */
     size_t
-    SendTo(const std::string &, const std::string &, port_type, bool &) const;
+    SendTo(const std::string &, const std::string &, port_type, bool &) const
+        noexcept;
 
     /**
      * Read data on this socket until the end-of-message character is received.
@@ -361,7 +364,7 @@ protected:
      *
      * @return The data received.
      */
-    virtual std::string Recv(bool &, bool &) const = 0;
+    virtual std::string Recv(bool &, bool &) const noexcept = 0;
 
     /**
      * Read data on this socket until the end-of-message character is received.
@@ -371,7 +374,7 @@ protected:
      *
      * @return The data received.
      */
-    virtual std::string RecvFrom(bool &, bool &) const = 0;
+    virtual std::string RecvFrom(bool &, bool &) const noexcept = 0;
 
     // Socket protocol
     Protocol m_protocol;

--- a/fly/socket/socket_config.cpp
+++ b/fly/socket/socket_config.cpp
@@ -5,7 +5,7 @@
 namespace fly {
 
 //==============================================================================
-SocketConfig::SocketConfig() :
+SocketConfig::SocketConfig() noexcept :
     m_defaultIoWaitTime(I64(10000)),
     m_defaultEndOfMessage(0x04),
     m_defaultPacketSize(4096)
@@ -13,26 +13,20 @@ SocketConfig::SocketConfig() :
 }
 
 //==============================================================================
-std::string SocketConfig::GetName()
-{
-    return "socket";
-}
-
-//==============================================================================
-std::chrono::microseconds SocketConfig::IoWaitTime() const
+std::chrono::microseconds SocketConfig::IoWaitTime() const noexcept
 {
     return std::chrono::microseconds(GetValue<std::chrono::microseconds::rep>(
         "io_wait_time", m_defaultIoWaitTime));
 }
 
 //==============================================================================
-char SocketConfig::EndOfMessage() const
+char SocketConfig::EndOfMessage() const noexcept
 {
     return GetValue<char>("end_of_message", m_defaultEndOfMessage);
 }
 
 //==============================================================================
-size_t SocketConfig::PacketSize() const
+size_t SocketConfig::PacketSize() const noexcept
 {
     return GetValue<size_t>("packet_size", m_defaultPacketSize);
 }

--- a/fly/socket/socket_config.h
+++ b/fly/socket/socket_config.h
@@ -3,7 +3,6 @@
 #include "fly/config/config.h"
 
 #include <chrono>
-#include <string>
 
 namespace fly {
 
@@ -16,30 +15,27 @@ namespace fly {
 class SocketConfig : public Config
 {
 public:
+    static constexpr const char *identifier = "socket";
+
     /**
      * Constructor.
      */
-    SocketConfig();
-
-    /**
-     * Get the name to associate with this configuration.
-     */
-    static std::string GetName();
+    SocketConfig() noexcept;
 
     /**
      * @return Sleep time for socket IO thread.
      */
-    std::chrono::microseconds IoWaitTime() const;
+    std::chrono::microseconds IoWaitTime() const noexcept;
 
     /**
      * @return Character signifying the end of a message received over a socket.
      */
-    char EndOfMessage() const;
+    char EndOfMessage() const noexcept;
 
     /**
      * Size of packet to use for send/receive operations.
      */
-    size_t PacketSize() const;
+    size_t PacketSize() const noexcept;
 
 protected:
     std::chrono::microseconds::rep m_defaultIoWaitTime;

--- a/fly/socket/socket_manager.cpp
+++ b/fly/socket/socket_manager.cpp
@@ -12,7 +12,7 @@ namespace fly {
 //==============================================================================
 SocketManager::SocketManager(
     const std::shared_ptr<SequencedTaskRunner> &spTaskRunner,
-    const std::shared_ptr<SocketConfig> &spConfig) :
+    const std::shared_ptr<SocketConfig> &spConfig) noexcept :
     m_spTaskRunner(spTaskRunner),
     m_spConfig(spConfig),
     m_newClientCallback(nullptr),
@@ -30,7 +30,7 @@ SocketManager::~SocketManager()
 }
 
 //==============================================================================
-void SocketManager::Start()
+void SocketManager::Start() noexcept
 {
     std::shared_ptr<SocketManager> spSocketManager = shared_from_this();
 
@@ -41,7 +41,7 @@ void SocketManager::Start()
 //==============================================================================
 void SocketManager::SetClientCallbacks(
     SocketCallback newClient,
-    SocketCallback closedClient)
+    SocketCallback closedClient) noexcept
 {
     std::lock_guard<std::mutex> lock(m_callbackMutex);
 
@@ -50,13 +50,13 @@ void SocketManager::SetClientCallbacks(
 }
 
 //==============================================================================
-void SocketManager::ClearClientCallbacks()
+void SocketManager::ClearClientCallbacks() noexcept
 {
     SetClientCallbacks(nullptr, nullptr);
 }
 
 //==============================================================================
-std::shared_ptr<Socket> SocketManager::CreateSocket(Protocol protocol)
+std::shared_ptr<Socket> SocketManager::CreateSocket(Protocol protocol) noexcept
 {
     auto spSocket = std::make_shared<SocketImpl>(protocol, m_spConfig);
 
@@ -69,7 +69,8 @@ std::shared_ptr<Socket> SocketManager::CreateSocket(Protocol protocol)
 }
 
 //==============================================================================
-std::weak_ptr<Socket> SocketManager::CreateAsyncSocket(Protocol protocol)
+std::weak_ptr<Socket>
+SocketManager::CreateAsyncSocket(Protocol protocol) noexcept
 {
     auto spSocket = CreateSocket(protocol);
 
@@ -92,7 +93,7 @@ std::weak_ptr<Socket> SocketManager::CreateAsyncSocket(Protocol protocol)
 //==============================================================================
 void SocketManager::HandleNewAndClosedSockets(
     const SocketList &newSockets,
-    const SocketList &closedSockets)
+    const SocketList &closedSockets) noexcept
 {
     // Add new sockets to the socket system
     m_aioSockets.insert(
@@ -114,7 +115,7 @@ void SocketManager::HandleNewAndClosedSockets(
 //==============================================================================
 void SocketManager::TriggerCallbacks(
     const SocketList &connectedClients,
-    const SocketList &closedClients)
+    const SocketList &closedClients) noexcept
 {
     if (!connectedClients.empty() || !closedClients.empty())
     {
@@ -140,14 +141,14 @@ void SocketManager::TriggerCallbacks(
 
 //==============================================================================
 SocketManagerTask::SocketManagerTask(
-    const std::weak_ptr<SocketManager> &wpSocketManager) :
+    std::weak_ptr<SocketManager> wpSocketManager) noexcept :
     Task(),
     m_wpSocketManager(wpSocketManager)
 {
 }
 
 //==============================================================================
-void SocketManagerTask::Run()
+void SocketManagerTask::Run() noexcept
 {
     std::shared_ptr<SocketManager> spSocketManager = m_wpSocketManager.lock();
 

--- a/fly/socket/socket_manager.h
+++ b/fly/socket/socket_manager.h
@@ -44,7 +44,7 @@ public:
      */
     SocketManager(
         const std::shared_ptr<SequencedTaskRunner> &,
-        const std::shared_ptr<SocketConfig> &);
+        const std::shared_ptr<SocketConfig> &) noexcept;
 
     /**
      * Destructor. Close all asynchronous sockets.
@@ -54,7 +54,7 @@ public:
     /**
      * Initialize the socket manager task.
      */
-    void Start();
+    void Start() noexcept;
 
     /**
      * Set callbacks for when a client connects or disconnects.
@@ -62,12 +62,12 @@ public:
      * @param SocketCallback Callback for when a new client connects.
      * @param SocketCallback Callback for when a client disconnects.
      */
-    void SetClientCallbacks(SocketCallback, SocketCallback);
+    void SetClientCallbacks(SocketCallback, SocketCallback) noexcept;
 
     /**
      * Remove the callbacks for when a client connects or disconnects.
      */
-    void ClearClientCallbacks();
+    void ClearClientCallbacks() noexcept;
 
     /**
      * Create and initialize a synchronous socket.
@@ -76,7 +76,7 @@ public:
      *
      * @return Shared pointer to the socket.
      */
-    std::shared_ptr<Socket> CreateSocket(Protocol);
+    std::shared_ptr<Socket> CreateSocket(Protocol) noexcept;
 
     /**
      * Create and initialize an asynchronous socket. The socket manager will own
@@ -86,7 +86,7 @@ public:
      *
      * @return Weak pointer to the socket.
      */
-    std::weak_ptr<Socket> CreateAsyncSocket(Protocol);
+    std::weak_ptr<Socket> CreateAsyncSocket(Protocol) noexcept;
 
     /**
      * Wait for an asynchronous read to complete.
@@ -97,7 +97,9 @@ public:
      * @return True if a completed receive was found in the given duration.
      */
     template <typename R, typename P>
-    bool WaitForCompletedReceive(AsyncRequest &, std::chrono::duration<R, P>);
+    bool WaitForCompletedReceive(
+        AsyncRequest &,
+        std::chrono::duration<R, P>) noexcept;
 
     /**
      * Wait for an asynchronous send to complete.
@@ -108,7 +110,8 @@ public:
      * @return True if a completed send was found in the given duration.
      */
     template <typename R, typename P>
-    bool WaitForCompletedSend(AsyncRequest &, std::chrono::duration<R, P>);
+    bool
+    WaitForCompletedSend(AsyncRequest &, std::chrono::duration<R, P>) noexcept;
 
 protected:
     /**
@@ -116,7 +119,7 @@ protected:
      *
      * @param microseconds Max time to allow for a socket to be available.
      */
-    virtual void Poll(const std::chrono::microseconds &) = 0;
+    virtual void Poll(const std::chrono::microseconds &) noexcept = 0;
 
     /**
      * Add new sockets to and remove closed sockets from the socket system.
@@ -124,7 +127,8 @@ protected:
      * @param SocketList Newly added sockets.
      * @param SocketList Newly closed sockets.
      */
-    void HandleNewAndClosedSockets(const SocketList &, const SocketList &);
+    void
+    HandleNewAndClosedSockets(const SocketList &, const SocketList &) noexcept;
 
     /**
      * Trigger the connected and closed client callbacks.
@@ -132,7 +136,7 @@ protected:
      * @param SocketList Newly connected clients.
      * @param SocketList Newly closed clients.
      */
-    void TriggerCallbacks(const SocketList &, const SocketList &);
+    void TriggerCallbacks(const SocketList &, const SocketList &) noexcept;
 
     std::mutex m_aioSocketsMutex;
     SocketList m_aioSockets;
@@ -160,14 +164,14 @@ private:
 class SocketManagerTask : public Task
 {
 public:
-    SocketManagerTask(const std::weak_ptr<SocketManager> &);
+    SocketManagerTask(std::weak_ptr<SocketManager>) noexcept;
 
 protected:
     /**
      * Call back into the socket manager to check if any asynchronous sockets
      * are available for IO. The task re-arms itself.
      */
-    void Run() override;
+    void Run() noexcept override;
 
 private:
     std::weak_ptr<SocketManager> m_wpSocketManager;
@@ -177,7 +181,7 @@ private:
 template <typename R, typename P>
 bool SocketManager::WaitForCompletedReceive(
     AsyncRequest &request,
-    std::chrono::duration<R, P> waitTime)
+    std::chrono::duration<R, P> waitTime) noexcept
 {
     return m_completedReceives.Pop(request, waitTime);
 }
@@ -186,7 +190,7 @@ bool SocketManager::WaitForCompletedReceive(
 template <typename R, typename P>
 bool SocketManager::WaitForCompletedSend(
     AsyncRequest &request,
-    std::chrono::duration<R, P> waitTime)
+    std::chrono::duration<R, P> waitTime) noexcept
 {
     return m_completedSends.Pop(request, waitTime);
 }

--- a/fly/socket/win/socket_impl.cpp
+++ b/fly/socket/win/socket_impl.cpp
@@ -11,7 +11,8 @@ namespace fly {
 
 namespace {
 
-    struct sockaddr_in CreateSocketAddress(address_type address, port_type port)
+    struct sockaddr_in
+    CreateSocketAddress(address_type address, port_type port) noexcept
     {
         struct sockaddr_in socketAddress;
         memset(&socketAddress, 0, sizeof(socketAddress));
@@ -28,7 +29,7 @@ namespace {
 //==============================================================================
 SocketImpl::SocketImpl(
     Protocol protocol,
-    const std::shared_ptr<SocketConfig> &spConfig) :
+    const std::shared_ptr<SocketConfig> &spConfig) noexcept :
     Socket(protocol, spConfig)
 {
     switch (m_protocol)
@@ -52,7 +53,7 @@ SocketImpl::~SocketImpl()
 //==============================================================================
 bool SocketImpl::HostnameToAddress(
     const std::string &hostname,
-    address_type &address)
+    address_type &address) noexcept
 {
     struct hostent *ipAddress = ::gethostbyname(hostname.c_str());
 
@@ -70,19 +71,19 @@ bool SocketImpl::HostnameToAddress(
 }
 
 //==============================================================================
-address_type SocketImpl::InAddrAny()
+address_type SocketImpl::InAddrAny() noexcept
 {
     return INADDR_ANY;
 }
 
 //==============================================================================
-socket_type SocketImpl::InvalidSocket()
+socket_type SocketImpl::InvalidSocket() noexcept
 {
     return INVALID_SOCKET;
 }
 
 //==============================================================================
-void SocketImpl::Close()
+void SocketImpl::Close() noexcept
 {
     if (IsValid())
     {
@@ -92,7 +93,7 @@ void SocketImpl::Close()
 }
 
 //==============================================================================
-bool SocketImpl::IsErrorFree()
+bool SocketImpl::IsErrorFree() noexcept
 {
     int opt = 0;
     int len = sizeof(opt);
@@ -109,7 +110,7 @@ bool SocketImpl::IsErrorFree()
 }
 
 //==============================================================================
-bool SocketImpl::SetAsync()
+bool SocketImpl::SetAsync() noexcept
 {
     unsigned long nonZero = 1;
 
@@ -124,8 +125,10 @@ bool SocketImpl::SetAsync()
 }
 
 //==============================================================================
-bool SocketImpl::Bind(address_type address, port_type port, BindOption option)
-    const
+bool SocketImpl::Bind(
+    address_type address,
+    port_type port,
+    BindOption option) const noexcept
 {
     static const char bindForReuseOption = 1;
     static const int bindForReuseOptionLength =
@@ -166,7 +169,7 @@ bool SocketImpl::Bind(address_type address, port_type port, BindOption option)
 }
 
 //==============================================================================
-bool SocketImpl::Listen()
+bool SocketImpl::Listen() noexcept
 {
     if (::listen(m_socketHandle, 100) == SOCKET_ERROR)
     {
@@ -179,7 +182,7 @@ bool SocketImpl::Listen()
 }
 
 //==============================================================================
-bool SocketImpl::Connect(address_type address, port_type port)
+bool SocketImpl::Connect(address_type address, port_type port) noexcept
 {
     struct sockaddr_in socketAddress = CreateSocketAddress(address, port);
     auto *pSocketAddress = reinterpret_cast<sockaddr *>(&socketAddress);
@@ -204,7 +207,7 @@ bool SocketImpl::Connect(address_type address, port_type port)
 }
 
 //==============================================================================
-std::shared_ptr<Socket> SocketImpl::Accept() const
+std::shared_ptr<Socket> SocketImpl::Accept() const noexcept
 {
     auto ret = std::make_shared<SocketImpl>(m_protocol, m_spConfig);
 
@@ -239,6 +242,7 @@ std::shared_ptr<Socket> SocketImpl::Accept() const
 
 //==============================================================================
 size_t SocketImpl::Send(const std::string &message, bool &wouldBlock) const
+    noexcept
 {
     static const std::string eom(1, m_socketEoM);
     std::string toSend = message + eom;
@@ -290,7 +294,7 @@ size_t SocketImpl::SendTo(
     const std::string &message,
     address_type address,
     port_type port,
-    bool &wouldBlock) const
+    bool &wouldBlock) const noexcept
 {
     static const std::string eom(1, m_socketEoM);
     std::string toSend = message + eom;
@@ -342,7 +346,7 @@ size_t SocketImpl::SendTo(
 }
 
 //==============================================================================
-std::string SocketImpl::Recv(bool &wouldBlock, bool &isComplete) const
+std::string SocketImpl::Recv(bool &wouldBlock, bool &isComplete) const noexcept
 {
     std::string ret;
 
@@ -387,6 +391,7 @@ std::string SocketImpl::Recv(bool &wouldBlock, bool &isComplete) const
 
 //==============================================================================
 std::string SocketImpl::RecvFrom(bool &wouldBlock, bool &isComplete) const
+    noexcept
 {
     std::string ret;
 

--- a/fly/socket/win/socket_impl.cpp
+++ b/fly/socket/win/socket_impl.cpp
@@ -125,10 +125,8 @@ bool SocketImpl::SetAsync() noexcept
 }
 
 //==============================================================================
-bool SocketImpl::Bind(
-    address_type address,
-    port_type port,
-    BindOption option) const noexcept
+bool SocketImpl::Bind(address_type address, port_type port, BindOption option)
+    const noexcept
 {
     static const char bindForReuseOption = 1;
     static const int bindForReuseOptionLength =

--- a/fly/socket/win/socket_impl.h
+++ b/fly/socket/win/socket_impl.h
@@ -19,36 +19,36 @@ class SocketConfig;
 class SocketImpl : public Socket
 {
 public:
-    SocketImpl(Protocol, const std::shared_ptr<SocketConfig> &);
+    SocketImpl(Protocol, const std::shared_ptr<SocketConfig> &) noexcept;
     ~SocketImpl() override;
 
-    static bool HostnameToAddress(const std::string &, address_type &);
+    static bool HostnameToAddress(const std::string &, address_type &) noexcept;
 
-    static address_type InAddrAny();
+    static address_type InAddrAny() noexcept;
 
-    static socket_type InvalidSocket();
+    static socket_type InvalidSocket() noexcept;
 
-    void Close() override;
+    void Close() noexcept override;
 
-    bool IsErrorFree() override;
+    bool IsErrorFree() noexcept override;
 
-    bool SetAsync() override;
+    bool SetAsync() noexcept override;
 
-    bool Bind(address_type, port_type, BindOption) const override;
+    bool Bind(address_type, port_type, BindOption) const noexcept override;
 
-    bool Listen() override;
+    bool Listen() noexcept override;
 
-    bool Connect(address_type, port_type) override;
+    bool Connect(address_type, port_type) noexcept override;
 
-    std::shared_ptr<Socket> Accept() const override;
+    std::shared_ptr<Socket> Accept() const noexcept override;
 
 protected:
-    size_t Send(const std::string &, bool &) const override;
-    size_t
-    SendTo(const std::string &, address_type, port_type, bool &) const override;
+    size_t Send(const std::string &, bool &) const noexcept override;
+    size_t SendTo(const std::string &, address_type, port_type, bool &) const
+        noexcept override;
 
-    std::string Recv(bool &, bool &) const override;
-    std::string RecvFrom(bool &, bool &) const override;
+    std::string Recv(bool &, bool &) const noexcept override;
+    std::string RecvFrom(bool &, bool &) const noexcept override;
 };
 
 } // namespace fly

--- a/fly/socket/win/socket_manager_impl.cpp
+++ b/fly/socket/win/socket_manager_impl.cpp
@@ -14,7 +14,7 @@ std::atomic_int SocketManagerImpl::s_socketManagerCount(0);
 SocketManagerImpl::SocketManagerImpl(
     const std::shared_ptr<SequencedTaskRunner> &spTaskRunner,
     const std::shared_ptr<SocketConfig> &spConfig) :
-    SocketManager(spTaskRunner, spConfig)
+    SocketManager(spTaskRunner, spConfig) noexcept
 {
     if (s_socketManagerCount.fetch_add(1) == 0)
     {
@@ -38,7 +38,7 @@ SocketManagerImpl::~SocketManagerImpl()
 }
 
 //==============================================================================
-void SocketManagerImpl::Poll(const std::chrono::microseconds &timeout)
+void SocketManagerImpl::Poll(const std::chrono::microseconds &timeout) noexcept
 {
     fd_set readFd, writeFd;
     struct timeval tv = {0, static_cast<long>(timeout.count())};
@@ -61,7 +61,9 @@ void SocketManagerImpl::Poll(const std::chrono::microseconds &timeout)
 }
 
 //==============================================================================
-bool SocketManagerImpl::setReadAndWriteMasks(fd_set *readFd, fd_set *writeFd)
+bool SocketManagerImpl::setReadAndWriteMasks(
+    fd_set *readFd,
+    fd_set *writeFd) noexcept
 {
     bool anyMasksSet = false;
 
@@ -85,7 +87,7 @@ bool SocketManagerImpl::setReadAndWriteMasks(fd_set *readFd, fd_set *writeFd)
 }
 
 //==============================================================================
-void SocketManagerImpl::handleSocketIO(fd_set *readFd, fd_set *writeFd)
+void SocketManagerImpl::handleSocketIO(fd_set *readFd, fd_set *writeFd) noexcept
 {
     SocketList newClients, connectedClients, closedClients;
 

--- a/fly/socket/win/socket_manager_impl.cpp
+++ b/fly/socket/win/socket_manager_impl.cpp
@@ -13,8 +13,8 @@ std::atomic_int SocketManagerImpl::s_socketManagerCount(0);
 //==============================================================================
 SocketManagerImpl::SocketManagerImpl(
     const std::shared_ptr<SequencedTaskRunner> &spTaskRunner,
-    const std::shared_ptr<SocketConfig> &spConfig) :
-    SocketManager(spTaskRunner, spConfig) noexcept
+    const std::shared_ptr<SocketConfig> &spConfig) noexcept :
+    SocketManager(spTaskRunner, spConfig)
 {
     if (s_socketManagerCount.fetch_add(1) == 0)
     {

--- a/fly/socket/win/socket_manager_impl.h
+++ b/fly/socket/win/socket_manager_impl.h
@@ -23,15 +23,15 @@ class SocketManagerImpl : public SocketManager
 public:
     SocketManagerImpl(
         const std::shared_ptr<SequencedTaskRunner> &,
-        const std::shared_ptr<SocketConfig> &);
+        const std::shared_ptr<SocketConfig> &) noexcept;
     ~SocketManagerImpl() override;
 
 protected:
-    void Poll(const std::chrono::microseconds &) override;
+    void Poll(const std::chrono::microseconds &) noexcept override;
 
 private:
-    bool setReadAndWriteMasks(fd_set *, fd_set *);
-    void handleSocketIO(fd_set *, fd_set *);
+    bool setReadAndWriteMasks(fd_set *, fd_set *) noexcept;
+    void handleSocketIO(fd_set *, fd_set *) noexcept;
 
     static std::atomic_int s_socketManagerCount;
 };

--- a/fly/system/nix/system_impl.cpp
+++ b/fly/system/nix/system_impl.cpp
@@ -10,7 +10,7 @@
 namespace fly {
 
 //==============================================================================
-void SystemImpl::PrintBacktrace()
+void SystemImpl::PrintBacktrace() noexcept
 {
     void *trace[10];
     int traceSize = ::backtrace(trace, 10);
@@ -18,7 +18,7 @@ void SystemImpl::PrintBacktrace()
 }
 
 //==============================================================================
-std::string SystemImpl::LocalTime(const std::string &fmt)
+std::string SystemImpl::LocalTime(const std::string &fmt) noexcept
 {
     auto sys = std::chrono::system_clock::now();
     time_t now = std::chrono::system_clock::to_time_t(sys);
@@ -40,19 +40,19 @@ std::string SystemImpl::LocalTime(const std::string &fmt)
 }
 
 //==============================================================================
-int SystemImpl::GetErrorCode()
+int SystemImpl::GetErrorCode() noexcept
 {
     return errno;
 }
 
 //==============================================================================
-std::string SystemImpl::GetErrorString(int code)
+std::string SystemImpl::GetErrorString(int code) noexcept
 {
     return "(" + std::to_string(code) + ") " + ::strerror(code);
 }
 
 //==============================================================================
-std::vector<int> SystemImpl::GetSignals()
+std::vector<int> SystemImpl::GetSignals() noexcept
 {
     return {SIGINT, SIGTERM, SIGSYS, SIGBUS, SIGILL, SIGFPE, SIGABRT, SIGSEGV};
 }

--- a/fly/system/nix/system_impl.h
+++ b/fly/system/nix/system_impl.h
@@ -14,11 +14,11 @@ namespace fly {
 class SystemImpl
 {
 public:
-    static void PrintBacktrace();
-    static std::string LocalTime(const std::string &);
-    static int GetErrorCode();
-    static std::string GetErrorString(int);
-    static std::vector<int> GetSignals();
+    static void PrintBacktrace() noexcept;
+    static std::string LocalTime(const std::string &) noexcept;
+    static int GetErrorCode() noexcept;
+    static std::string GetErrorString(int) noexcept;
+    static std::vector<int> GetSignals() noexcept;
 };
 
 } // namespace fly

--- a/fly/system/nix/system_monitor_impl.cpp
+++ b/fly/system/nix/system_monitor_impl.cpp
@@ -29,7 +29,7 @@ namespace {
 //==============================================================================
 SystemMonitorImpl::SystemMonitorImpl(
     const std::shared_ptr<SequencedTaskRunner> &spTaskRunner,
-    const std::shared_ptr<SystemConfig> &spConfig) :
+    const std::shared_ptr<SystemConfig> &spConfig) noexcept :
     SystemMonitor(spTaskRunner, spConfig),
     m_prevSystemUserTime(0),
     m_prevSystemNiceTime(0),
@@ -43,7 +43,7 @@ SystemMonitorImpl::SystemMonitorImpl(
 }
 
 //==============================================================================
-void SystemMonitorImpl::UpdateSystemCpuCount()
+void SystemMonitorImpl::UpdateSystemCpuCount() noexcept
 {
     std::ifstream stream(s_procStatFile, std::ios::in);
     std::string contents, line;
@@ -74,7 +74,7 @@ void SystemMonitorImpl::UpdateSystemCpuCount()
 }
 
 //==============================================================================
-void SystemMonitorImpl::UpdateSystemCpuUsage()
+void SystemMonitorImpl::UpdateSystemCpuUsage() noexcept
 {
     std::ifstream stream(s_procStatFile, std::ios::in);
     std::string line;
@@ -112,7 +112,7 @@ void SystemMonitorImpl::UpdateSystemCpuUsage()
 }
 
 //==============================================================================
-void SystemMonitorImpl::UpdateProcessCpuUsage()
+void SystemMonitorImpl::UpdateProcessCpuUsage() noexcept
 {
     struct tms sample;
     clock_t now = ::times(&sample);
@@ -140,7 +140,7 @@ void SystemMonitorImpl::UpdateProcessCpuUsage()
 }
 
 //==============================================================================
-void SystemMonitorImpl::UpdateSystemMemoryUsage()
+void SystemMonitorImpl::UpdateSystemMemoryUsage() noexcept
 {
     struct sysinfo info;
 
@@ -159,7 +159,7 @@ void SystemMonitorImpl::UpdateSystemMemoryUsage()
 }
 
 //==============================================================================
-void SystemMonitorImpl::UpdateProcessMemoryUsage()
+void SystemMonitorImpl::UpdateProcessMemoryUsage() noexcept
 {
     std::ifstream stream(s_selfStatusFile, std::ios::in);
     std::string contents, line;

--- a/fly/system/nix/system_monitor_impl.h
+++ b/fly/system/nix/system_monitor_impl.h
@@ -25,15 +25,15 @@ public:
      */
     SystemMonitorImpl(
         const std::shared_ptr<SequencedTaskRunner> &,
-        const std::shared_ptr<SystemConfig> &);
+        const std::shared_ptr<SystemConfig> &) noexcept;
 
 protected:
-    void UpdateSystemCpuCount() override;
-    void UpdateSystemCpuUsage() override;
-    void UpdateProcessCpuUsage() override;
+    void UpdateSystemCpuCount() noexcept override;
+    void UpdateSystemCpuUsage() noexcept override;
+    void UpdateProcessCpuUsage() noexcept override;
 
-    void UpdateSystemMemoryUsage() override;
-    void UpdateProcessMemoryUsage() override;
+    void UpdateSystemMemoryUsage() noexcept override;
+    void UpdateProcessMemoryUsage() noexcept override;
 
 private:
     uint64_t m_prevSystemUserTime;

--- a/fly/system/system.cpp
+++ b/fly/system/system.cpp
@@ -10,37 +10,37 @@
 namespace fly {
 
 //==============================================================================
-void System::PrintBacktrace()
+void System::PrintBacktrace() noexcept
 {
     SystemImpl::PrintBacktrace();
 }
 
 //==============================================================================
-std::string System::LocalTime()
+std::string System::LocalTime() noexcept
 {
     return SystemImpl::LocalTime("%m-%d-%Y %H:%M:%S");
 }
 
 //==============================================================================
-int System::GetErrorCode()
+int System::GetErrorCode() noexcept
 {
     return SystemImpl::GetErrorCode();
 }
 
 //==============================================================================
-std::string System::GetErrorString()
+std::string System::GetErrorString() noexcept
 {
     return GetErrorString(GetErrorCode());
 }
 
 //==============================================================================
-std::string System::GetErrorString(int code)
+std::string System::GetErrorString(int code) noexcept
 {
     return SystemImpl::GetErrorString(code);
 }
 
 //==============================================================================
-void System::SetSignalHandler(SignalHandler handler)
+void System::SetSignalHandler(SignalHandler handler) noexcept
 {
     static std::vector<int> signals = SystemImpl::GetSignals();
 

--- a/fly/system/system.h
+++ b/fly/system/system.h
@@ -19,22 +19,22 @@ public:
     /**
      * Print the backtrace to stderr.
      */
-    static void PrintBacktrace();
+    static void PrintBacktrace() noexcept;
 
     /**
      * @return The local time formatted as a string.
      */
-    static std::string LocalTime();
+    static std::string LocalTime() noexcept;
 
     /**
      * @return The last system error code.
      */
-    static int GetErrorCode();
+    static int GetErrorCode() noexcept;
 
     /**
      * @return The last system error code as a string.
      */
-    static std::string GetErrorString();
+    static std::string GetErrorString() noexcept;
 
     /**
      * Convert a system error code to a string.
@@ -43,14 +43,14 @@ public:
      *
      * @return The given system error code as a string.
      */
-    static std::string GetErrorString(int);
+    static std::string GetErrorString(int) noexcept;
 
     /**
      * Set a signal handler for all terminal signals.
      *
      * @param SignalHandler The signal handler function to set.
      */
-    static void SetSignalHandler(SignalHandler);
+    static void SetSignalHandler(SignalHandler) noexcept;
 };
 
 } // namespace fly

--- a/fly/system/system_config.cpp
+++ b/fly/system/system_config.cpp
@@ -5,18 +5,11 @@
 namespace fly {
 
 //==============================================================================
-SystemConfig::SystemConfig() : m_defaultPollInterval(I64(1000))
+SystemConfig::SystemConfig() noexcept : m_defaultPollInterval(I64(1000))
 {
 }
-
 //==============================================================================
-std::string SystemConfig::GetName()
-{
-    return "system";
-}
-
-//==============================================================================
-std::chrono::milliseconds SystemConfig::PollInterval() const
+std::chrono::milliseconds SystemConfig::PollInterval() const noexcept
 {
     return std::chrono::milliseconds(GetValue<std::chrono::milliseconds::rep>(
         "poll_interval", m_defaultPollInterval));

--- a/fly/system/system_config.h
+++ b/fly/system/system_config.h
@@ -3,7 +3,6 @@
 #include "fly/config/config.h"
 
 #include <chrono>
-#include <string>
 
 namespace fly {
 
@@ -16,20 +15,17 @@ namespace fly {
 class SystemConfig : public Config
 {
 public:
+    static constexpr const char *identifier = "system";
+
     /**
      * Constructor.
      */
-    SystemConfig();
-
-    /**
-     * Get the name to associate with this configuration.
-     */
-    static std::string GetName();
+    SystemConfig() noexcept;
 
     /**
      * @return Delay between system monitor poll intervals.
      */
-    virtual std::chrono::milliseconds PollInterval() const;
+    virtual std::chrono::milliseconds PollInterval() const noexcept;
 
 protected:
     std::chrono::milliseconds::rep m_defaultPollInterval;

--- a/fly/system/system_monitor.cpp
+++ b/fly/system/system_monitor.cpp
@@ -11,7 +11,7 @@ namespace fly {
 //==============================================================================
 SystemMonitor::SystemMonitor(
     const std::shared_ptr<SequencedTaskRunner> &spTaskRunner,
-    const std::shared_ptr<SystemConfig> &spConfig) :
+    const std::shared_ptr<SystemConfig> &spConfig) noexcept :
     m_systemCpuCount(0),
     m_systemCpuUsage(0.0),
     m_processCpuUsage(0.0),
@@ -24,7 +24,7 @@ SystemMonitor::SystemMonitor(
 }
 
 //==============================================================================
-bool SystemMonitor::Start()
+bool SystemMonitor::Start() noexcept
 {
     if (isValid())
     {
@@ -40,49 +40,49 @@ bool SystemMonitor::Start()
 }
 
 //==============================================================================
-uint32_t SystemMonitor::GetSystemCpuCount() const
+uint32_t SystemMonitor::GetSystemCpuCount() const noexcept
 {
     return m_systemCpuCount.load();
 }
 
 //==============================================================================
-double SystemMonitor::GetSystemCpuUsage() const
+double SystemMonitor::GetSystemCpuUsage() const noexcept
 {
     return m_systemCpuUsage.load();
 }
 
 //==============================================================================
-double SystemMonitor::GetProcessCpuUsage() const
+double SystemMonitor::GetProcessCpuUsage() const noexcept
 {
     return m_processCpuUsage.load();
 }
 
 //==============================================================================
-uint64_t SystemMonitor::GetTotalSystemMemory() const
+uint64_t SystemMonitor::GetTotalSystemMemory() const noexcept
 {
     return m_totalSystemMemory.load();
 }
 
 //==============================================================================
-uint64_t SystemMonitor::GetSystemMemoryUsage() const
+uint64_t SystemMonitor::GetSystemMemoryUsage() const noexcept
 {
     return m_systemMemoryUsage.load();
 }
 
 //==============================================================================
-uint64_t SystemMonitor::GetProcessMemoryUsage() const
+uint64_t SystemMonitor::GetProcessMemoryUsage() const noexcept
 {
     return m_processMemoryUsage.load();
 }
 
 //==============================================================================
-bool SystemMonitor::isValid() const
+bool SystemMonitor::isValid() const noexcept
 {
     return GetSystemCpuCount() > 0;
 }
 
 //==============================================================================
-void SystemMonitor::poll()
+void SystemMonitor::poll() noexcept
 {
     UpdateSystemCpuCount();
     UpdateSystemCpuUsage();
@@ -94,14 +94,14 @@ void SystemMonitor::poll()
 
 //==============================================================================
 SystemMonitorTask::SystemMonitorTask(
-    const std::weak_ptr<SystemMonitor> &wpSystemMonitor) :
+    std::weak_ptr<SystemMonitor> wpSystemMonitor) noexcept :
     Task(),
     m_wpSystemMonitor(wpSystemMonitor)
 {
 }
 
 //==============================================================================
-void SystemMonitorTask::Run()
+void SystemMonitorTask::Run() noexcept
 {
     std::shared_ptr<SystemMonitor> spSystemMonitor = m_wpSystemMonitor.lock();
 

--- a/fly/system/system_monitor.h
+++ b/fly/system/system_monitor.h
@@ -34,7 +34,7 @@ public:
      */
     SystemMonitor(
         const std::shared_ptr<SequencedTaskRunner> &,
-        const std::shared_ptr<SystemConfig> &);
+        const std::shared_ptr<SystemConfig> &) noexcept;
 
     /**
      * Destructor.
@@ -46,75 +46,75 @@ public:
      *
      * @return bool True if the path monitor is in a valid state.
      */
-    bool Start();
+    bool Start() noexcept;
 
     /**
      * Get the system's CPU count.
      *
      * @return uint32_t System CPU count.
      */
-    uint32_t GetSystemCpuCount() const;
+    uint32_t GetSystemCpuCount() const noexcept;
 
     /**
      * Get the system's CPU usage percentage (0-100%) over the last second.
      *
      * @return double Current system CPU usage.
      */
-    double GetSystemCpuUsage() const;
+    double GetSystemCpuUsage() const noexcept;
 
     /**
      * Get the process's CPU usage percentage (0-100%) over the last second.
      *
      * @return double Current process CPU usage.
      */
-    double GetProcessCpuUsage() const;
+    double GetProcessCpuUsage() const noexcept;
 
     /**
      * Get the system's total physical memory available in bytes.
      *
      * @return uint64_t Total system memory.
      */
-    uint64_t GetTotalSystemMemory() const;
+    uint64_t GetTotalSystemMemory() const noexcept;
 
     /**
      * Get the system's physical memory usage in bytes.
      *
      * @return uint64_t Current system memory usage.
      */
-    uint64_t GetSystemMemoryUsage() const;
+    uint64_t GetSystemMemoryUsage() const noexcept;
 
     /**
      * Get the process's physical memory usage in bytes.
      *
      * @return uint64_t Current process memory usage.
      */
-    uint64_t GetProcessMemoryUsage() const;
+    uint64_t GetProcessMemoryUsage() const noexcept;
 
 protected:
     /**
      * Update the system's current CPU count.
      */
-    virtual void UpdateSystemCpuCount() = 0;
+    virtual void UpdateSystemCpuCount() noexcept = 0;
 
     /**
      * Update the system's current CPU usage.
      */
-    virtual void UpdateSystemCpuUsage() = 0;
+    virtual void UpdateSystemCpuUsage() noexcept = 0;
 
     /**
      * Update the process's current CPU usage.
      */
-    virtual void UpdateProcessCpuUsage() = 0;
+    virtual void UpdateProcessCpuUsage() noexcept = 0;
 
     /**
      * Update the system's current memory usage.
      */
-    virtual void UpdateSystemMemoryUsage() = 0;
+    virtual void UpdateSystemMemoryUsage() noexcept = 0;
 
     /**
      * Update the process's current memory usage.
      */
-    virtual void UpdateProcessMemoryUsage() = 0;
+    virtual void UpdateProcessMemoryUsage() noexcept = 0;
 
     std::atomic<uint32_t> m_systemCpuCount;
     std::atomic<double> m_systemCpuUsage;
@@ -130,12 +130,12 @@ private:
      *
      * @return bool True if the CPU count is valid.
      */
-    bool isValid() const;
+    bool isValid() const noexcept;
 
     /**
      * Update the system-level resources.
      */
-    void poll();
+    void poll() noexcept;
 
     std::shared_ptr<SequencedTaskRunner> m_spTaskRunner;
     std::shared_ptr<Task> m_spTask;
@@ -152,7 +152,7 @@ private:
 class SystemMonitorTask : public Task
 {
 public:
-    SystemMonitorTask(const std::weak_ptr<SystemMonitor> &);
+    SystemMonitorTask(std::weak_ptr<SystemMonitor>) noexcept;
 
 protected:
     /**
@@ -160,7 +160,7 @@ protected:
      * the system monitor implementation is still valid, the task re-arms
      * itself.
      */
-    void Run() override;
+    void Run() noexcept override;
 
 private:
     std::weak_ptr<SystemMonitor> m_wpSystemMonitor;

--- a/fly/system/win/system_impl.cpp
+++ b/fly/system/win/system_impl.cpp
@@ -22,7 +22,7 @@ namespace {
 } // namespace
 
 //==============================================================================
-void SystemImpl::PrintBacktrace()
+void SystemImpl::PrintBacktrace() noexcept
 {
     void *trace[10];
     const USHORT traceSize = ::CaptureStackBackTrace(0, 10, trace, NULL);
@@ -34,7 +34,7 @@ void SystemImpl::PrintBacktrace()
 }
 
 //==============================================================================
-std::string SystemImpl::LocalTime(const std::string &fmt)
+std::string SystemImpl::LocalTime(const std::string &fmt) noexcept
 {
     auto sys = std::chrono::system_clock::now();
     time_t now = std::chrono::system_clock::to_time_t(sys);
@@ -56,13 +56,13 @@ std::string SystemImpl::LocalTime(const std::string &fmt)
 }
 
 //==============================================================================
-int SystemImpl::GetErrorCode()
+int SystemImpl::GetErrorCode() noexcept
 {
     return ::WSAGetLastError();
 }
 
 //==============================================================================
-std::string SystemImpl::GetErrorString(int code)
+std::string SystemImpl::GetErrorString(int code) noexcept
 {
     LPTSTR str = NULL;
     std::string ret;
@@ -85,7 +85,7 @@ std::string SystemImpl::GetErrorString(int code)
 }
 
 //==============================================================================
-std::vector<int> SystemImpl::GetSignals()
+std::vector<int> SystemImpl::GetSignals() noexcept
 {
     return {SIGINT, SIGTERM, SIGILL, SIGFPE, SIGABRT, SIGSEGV};
 }

--- a/fly/system/win/system_impl.h
+++ b/fly/system/win/system_impl.h
@@ -14,11 +14,11 @@ namespace fly {
 class SystemImpl
 {
 public:
-    static void PrintBacktrace();
-    static std::string LocalTime(const std::string &);
-    static int GetErrorCode();
-    static std::string GetErrorString(int);
-    static std::vector<int> GetSignals();
+    static void PrintBacktrace() noexcept;
+    static std::string LocalTime(const std::string &) noexcept;
+    static int GetErrorCode() noexcept;
+    static std::string GetErrorString(int) noexcept;
+    static std::vector<int> GetSignals() noexcept;
 };
 
 } // namespace fly

--- a/fly/system/win/system_monitor_impl.cpp
+++ b/fly/system/win/system_monitor_impl.cpp
@@ -19,7 +19,7 @@ namespace {
 //==============================================================================
 SystemMonitorImpl::SystemMonitorImpl(
     const std::shared_ptr<SequencedTaskRunner> &spTaskRunner,
-    const std::shared_ptr<SystemConfig> &spConfig) :
+    const std::shared_ptr<SystemConfig> &spConfig) noexcept :
     SystemMonitor(spTaskRunner, spConfig),
     m_process(::GetCurrentProcess()),
     m_cpuQuery(NULL),
@@ -63,7 +63,7 @@ SystemMonitorImpl::~SystemMonitorImpl()
 }
 
 //==============================================================================
-void SystemMonitorImpl::UpdateSystemCpuCount()
+void SystemMonitorImpl::UpdateSystemCpuCount() noexcept
 {
     SYSTEM_INFO info;
     ::GetSystemInfo(&info);
@@ -79,7 +79,7 @@ void SystemMonitorImpl::UpdateSystemCpuCount()
 }
 
 //==============================================================================
-void SystemMonitorImpl::UpdateSystemCpuUsage()
+void SystemMonitorImpl::UpdateSystemCpuUsage() noexcept
 {
     PDH_FMT_COUNTERVALUE value;
 
@@ -102,7 +102,7 @@ void SystemMonitorImpl::UpdateSystemCpuUsage()
 }
 
 //==============================================================================
-void SystemMonitorImpl::UpdateProcessCpuUsage()
+void SystemMonitorImpl::UpdateProcessCpuUsage() noexcept
 {
     ULARGE_INTEGER now, system, user;
     FILETIME fnow, fsystem, fuser;
@@ -133,7 +133,7 @@ void SystemMonitorImpl::UpdateProcessCpuUsage()
 }
 
 //==============================================================================
-void SystemMonitorImpl::UpdateSystemMemoryUsage()
+void SystemMonitorImpl::UpdateSystemMemoryUsage() noexcept
 {
     MEMORYSTATUSEX info;
     info.dwLength = sizeof(MEMORYSTATUSEX);
@@ -150,7 +150,7 @@ void SystemMonitorImpl::UpdateSystemMemoryUsage()
 }
 
 //==============================================================================
-void SystemMonitorImpl::UpdateProcessMemoryUsage()
+void SystemMonitorImpl::UpdateProcessMemoryUsage() noexcept
 {
     PROCESS_MEMORY_COUNTERS pmc;
 

--- a/fly/system/win/system_monitor_impl.h
+++ b/fly/system/win/system_monitor_impl.h
@@ -26,7 +26,7 @@ public:
      */
     SystemMonitorImpl(
         const std::shared_ptr<SequencedTaskRunner> &,
-        const std::shared_ptr<SystemConfig> &);
+        const std::shared_ptr<SystemConfig> &) noexcept;
 
     /**
      * Destructor. Close the system monitor's CPU query.
@@ -34,12 +34,12 @@ public:
     ~SystemMonitorImpl() override;
 
 protected:
-    void UpdateSystemCpuCount() override;
-    void UpdateSystemCpuUsage() override;
-    void UpdateProcessCpuUsage() override;
+    void UpdateSystemCpuCount() noexcept override;
+    void UpdateSystemCpuUsage() noexcept override;
+    void UpdateProcessCpuUsage() noexcept override;
 
-    void UpdateSystemMemoryUsage() override;
-    void UpdateProcessMemoryUsage() override;
+    void UpdateSystemMemoryUsage() noexcept override;
+    void UpdateProcessMemoryUsage() noexcept override;
 
 private:
     HANDLE m_process;

--- a/fly/task/task.h
+++ b/fly/task/task.h
@@ -25,7 +25,7 @@ protected:
      * Classes which inherit from this class should implement this method to
      * perform the work required by the task.
      */
-    virtual void Run() = 0;
+    virtual void Run() noexcept = 0;
 };
 
 } // namespace fly

--- a/fly/task/task_manager.cpp
+++ b/fly/task/task_manager.cpp
@@ -15,14 +15,14 @@ namespace {
 } // namespace
 
 //==============================================================================
-TaskManager::TaskManager(int numWorkers) :
+TaskManager::TaskManager(int numWorkers) noexcept :
     m_aKeepRunning(false),
     m_numWorkers(numWorkers)
 {
 }
 
 //==============================================================================
-bool TaskManager::Start()
+bool TaskManager::Start() noexcept
 {
     bool expected = false;
 
@@ -47,7 +47,7 @@ bool TaskManager::Start()
 }
 
 //==============================================================================
-bool TaskManager::Stop()
+bool TaskManager::Stop() noexcept
 {
     bool expected = true;
 
@@ -71,28 +71,28 @@ bool TaskManager::Stop()
 
 //==============================================================================
 void TaskManager::postTask(
-    const std::weak_ptr<Task> &wpTask,
-    const std::weak_ptr<TaskRunner> &wpTaskRunner)
+    std::weak_ptr<Task> wpTask,
+    std::weak_ptr<TaskRunner> wpTaskRunner) noexcept
 {
     TaskHolder task {wpTask, wpTaskRunner, std::chrono::steady_clock::now()};
-    m_tasks.Push(task);
+    m_tasks.Push(std::move(task));
 }
 
 //==============================================================================
 void TaskManager::postTaskWithDelay(
-    const std::weak_ptr<Task> &wpTask,
-    const std::weak_ptr<TaskRunner> &wpTaskRunner,
-    std::chrono::milliseconds delay)
+    std::weak_ptr<Task> wpTask,
+    std::weak_ptr<TaskRunner> wpTaskRunner,
+    std::chrono::milliseconds delay) noexcept
 {
     auto schedule = std::chrono::steady_clock::now() + delay;
     TaskHolder task {wpTask, wpTaskRunner, schedule};
 
     std::unique_lock<std::mutex> lock(m_delayedTasksMutex);
-    m_delayedTasks.push_back(task);
+    m_delayedTasks.push_back(std::move(task));
 }
 
 //==============================================================================
-void TaskManager::workerThread()
+void TaskManager::workerThread() noexcept
 {
     TaskHolder task;
 
@@ -117,7 +117,7 @@ void TaskManager::workerThread()
 }
 
 //==============================================================================
-void TaskManager::timerThread()
+void TaskManager::timerThread() noexcept
 {
     while (m_aKeepRunning.load())
     {

--- a/fly/task/task_manager.h
+++ b/fly/task/task_manager.h
@@ -38,14 +38,14 @@ public:
      *
      * @param int Number of worker threads to create.
      */
-    TaskManager(int);
+    TaskManager(int) noexcept;
 
     /**
      * Create the worker threads and timer thread.
      *
      * @return bool True if the threads were created in this invocation.
      */
-    bool Start();
+    bool Start() noexcept;
 
     /**
      * Destroy the worker threads and timer thread, blocking until the threads
@@ -53,7 +53,7 @@ public:
      *
      * @return bool True if the threads were destroyed in this invocation.
      */
-    bool Stop();
+    bool Stop() noexcept;
 
     /**
      * Create a task runner, holding a weak reference to this task manager.
@@ -63,7 +63,7 @@ public:
      * @return SequencedTaskRunner The created task runner.
      */
     template <typename TaskRunnerType>
-    std::shared_ptr<TaskRunnerType> CreateTaskRunner();
+    std::shared_ptr<TaskRunnerType> CreateTaskRunner() noexcept;
 
 private:
     /**
@@ -83,8 +83,7 @@ private:
      * @param Task Weak reference to the task the be executed.
      * @param TaskRunner Weak reference to the task runner posting the task.
      */
-    void
-    postTask(const std::weak_ptr<Task> &, const std::weak_ptr<TaskRunner> &);
+    void postTask(std::weak_ptr<Task>, std::weak_ptr<TaskRunner>) noexcept;
 
     /**
      * Schedule a task to be posted for execution after some delay.
@@ -94,19 +93,19 @@ private:
      * @param milliseconds Delay before posting the task.
      */
     void postTaskWithDelay(
-        const std::weak_ptr<Task> &,
-        const std::weak_ptr<TaskRunner> &,
-        std::chrono::milliseconds);
+        std::weak_ptr<Task>,
+        std::weak_ptr<TaskRunner>,
+        std::chrono::milliseconds) noexcept;
 
     /**
      * Worker thread for executing tasks.
      */
-    void workerThread();
+    void workerThread() noexcept;
 
     /**
      * Timer thread for holding delayed tasks until their scheduled time.
      */
-    void timerThread();
+    void timerThread() noexcept;
 
     ConcurrentQueue<TaskHolder> m_tasks;
 
@@ -122,11 +121,9 @@ private:
 
 //==============================================================================
 template <typename TaskRunnerType>
-std::shared_ptr<TaskRunnerType> TaskManager::CreateTaskRunner()
+std::shared_ptr<TaskRunnerType> TaskManager::CreateTaskRunner() noexcept
 {
-    static_assert(
-        std::is_base_of<TaskRunner, TaskRunnerType>::value,
-        "Given type is not a task runner");
+    static_assert(std::is_base_of_v<TaskRunner, TaskRunnerType>);
 
     const std::shared_ptr<TaskManager> spTaskManager = shared_from_this();
     return std::shared_ptr<TaskRunnerType>(new TaskRunnerType(spTaskManager));

--- a/fly/task/task_runner.cpp
+++ b/fly/task/task_runner.cpp
@@ -7,15 +7,15 @@
 namespace fly {
 
 //==============================================================================
-TaskRunner::TaskRunner(const std::weak_ptr<TaskManager> &wpTaskManager) :
+TaskRunner::TaskRunner(std::weak_ptr<TaskManager> wpTaskManager) noexcept :
     m_wpTaskManager(wpTaskManager)
 {
 }
 
 //==============================================================================
 bool TaskRunner::PostTaskWithDelay(
-    const std::weak_ptr<Task> &wpTask,
-    std::chrono::milliseconds delay)
+    std::weak_ptr<Task> wpTask,
+    std::chrono::milliseconds delay) noexcept
 {
     std::shared_ptr<TaskManager> spTaskManager = m_wpTaskManager.lock();
 
@@ -31,7 +31,7 @@ bool TaskRunner::PostTaskWithDelay(
 }
 
 //==============================================================================
-bool TaskRunner::PostTaskToTaskManager(const std::weak_ptr<Task> &wpTask)
+bool TaskRunner::PostTaskToTaskManager(std::weak_ptr<Task> wpTask) noexcept
 {
     std::shared_ptr<TaskManager> spTaskManager = m_wpTaskManager.lock();
 
@@ -48,46 +48,46 @@ bool TaskRunner::PostTaskToTaskManager(const std::weak_ptr<Task> &wpTask)
 
 //==============================================================================
 ParallelTaskRunner::ParallelTaskRunner(
-    const std::weak_ptr<TaskManager> &wpTaskManager) :
+    std::weak_ptr<TaskManager> wpTaskManager) noexcept :
     TaskRunner(wpTaskManager)
 {
 }
 
 //==============================================================================
-bool ParallelTaskRunner::PostTask(const std::weak_ptr<Task> &wpTask)
+bool ParallelTaskRunner::PostTask(std::weak_ptr<Task> wpTask) noexcept
 {
     return PostTaskToTaskManager(wpTask);
 }
 
 //==============================================================================
-void ParallelTaskRunner::TaskComplete(const std::shared_ptr<Task> &)
+void ParallelTaskRunner::TaskComplete(const std::shared_ptr<Task> &) noexcept
 {
 }
 
 //==============================================================================
 SequencedTaskRunner::SequencedTaskRunner(
-    const std::weak_ptr<TaskManager> &wpTaskManager) :
+    std::weak_ptr<TaskManager> wpTaskManager) noexcept :
     TaskRunner(wpTaskManager),
     m_aHasRunningTask(false)
 {
 }
 
 //==============================================================================
-bool SequencedTaskRunner::PostTask(const std::weak_ptr<Task> &wpTask)
+bool SequencedTaskRunner::PostTask(std::weak_ptr<Task> wpTask) noexcept
 {
-    m_pendingTasks.Push(wpTask);
+    m_pendingTasks.Push(std::move(wpTask));
     return maybePostTask();
 }
 
 //==============================================================================
-void SequencedTaskRunner::TaskComplete(const std::shared_ptr<Task> &)
+void SequencedTaskRunner::TaskComplete(const std::shared_ptr<Task> &) noexcept
 {
     m_aHasRunningTask.store(false);
     maybePostTask();
 }
 
 //==============================================================================
-bool SequencedTaskRunner::maybePostTask()
+bool SequencedTaskRunner::maybePostTask() noexcept
 {
     static std::chrono::seconds wait(0);
     bool expected = false;

--- a/fly/task/task_runner.h
+++ b/fly/task/task_runner.h
@@ -40,7 +40,7 @@ public:
      *
      * @return bool True if the task was posted for execution.
      */
-    virtual bool PostTask(const std::weak_ptr<Task> &) = 0;
+    virtual bool PostTask(std::weak_ptr<Task>) noexcept = 0;
 
     /**
      * Schedule a task to be posted after a delay. The task is given to the
@@ -57,8 +57,9 @@ public:
      *
      * @return bool True if the task was posted for delayed execution.
      */
-    bool
-    PostTaskWithDelay(const std::weak_ptr<Task> &, std::chrono::milliseconds);
+    bool PostTaskWithDelay(
+        std::weak_ptr<Task>,
+        std::chrono::milliseconds) noexcept;
 
 protected:
     /**
@@ -67,7 +68,7 @@ protected:
      *
      * @param TaskManager Weak reference to the task manager.
      */
-    TaskRunner(const std::weak_ptr<TaskManager> &);
+    TaskRunner(std::weak_ptr<TaskManager>) noexcept;
 
     /**
      * Completion notification triggered by the task manager that a task has
@@ -75,7 +76,7 @@ protected:
      *
      * @param Task The (possibly NULL) task that was executed or skipped.
      */
-    virtual void TaskComplete(const std::shared_ptr<Task> &) = 0;
+    virtual void TaskComplete(const std::shared_ptr<Task> &) noexcept = 0;
 
     /**
      * Forward a task to the task manager to be executed as soon as a worker
@@ -85,14 +86,14 @@ protected:
      *
      * @return bool True if the task was posted for execution.
      */
-    bool PostTaskToTaskManager(const std::weak_ptr<Task> &);
+    bool PostTaskToTaskManager(std::weak_ptr<Task>) noexcept;
 
 private:
     std::weak_ptr<TaskManager> m_wpTaskManager;
 };
 
 /**
- * Task runner implementation for executing a task in parallel. Tasks posted to
+ * Task runner implementation for executing tasks in parallel. Tasks posted to
  * this task runner may be executed in any order.
  *
  * @author Timothy Flynn (trflynn89@gmail.com)
@@ -103,21 +104,21 @@ class ParallelTaskRunner : public TaskRunner
     friend class TaskManager;
 
 public:
-    bool PostTask(const std::weak_ptr<Task> &) override;
+    bool PostTask(std::weak_ptr<Task>) noexcept override;
 
 protected:
-    ParallelTaskRunner(const std::weak_ptr<TaskManager> &);
+    ParallelTaskRunner(std::weak_ptr<TaskManager>) noexcept;
 
     /**
      * This implementation does nothing.
      *
      * @param Task The (possibly NULL) task that was executed or skipped.
      */
-    void TaskComplete(const std::shared_ptr<Task> &) override;
+    void TaskComplete(const std::shared_ptr<Task> &) noexcept override;
 };
 
 /**
- * Task runner implementation for executing a task in sequence. Only one task
+ * Task runner implementation for executing tasks in sequence. Only one task
  * posted to this task runner will execute at a time. Tasks are executed in a
  * FIFO manner; once one task completes, the next task in line will be posted
  * for execution.
@@ -134,17 +135,17 @@ class SequencedTaskRunner : public TaskRunner
     friend class TaskManager;
 
 public:
-    bool PostTask(const std::weak_ptr<Task> &) override;
+    bool PostTask(std::weak_ptr<Task>) noexcept override;
 
 protected:
-    SequencedTaskRunner(const std::weak_ptr<TaskManager> &);
+    SequencedTaskRunner(std::weak_ptr<TaskManager>) noexcept;
 
     /**
      * When a task is complete, post the next task in the pending queue.
      *
      * @param Task The (possibly NULL) task that was executed or skipped.
      */
-    void TaskComplete(const std::shared_ptr<Task> &) override;
+    void TaskComplete(const std::shared_ptr<Task> &) noexcept override;
 
 private:
     /**
@@ -154,7 +155,7 @@ private:
      * @return bool True if the task was posted for execution or added to the
      *              pending queue.
      */
-    bool maybePostTask();
+    bool maybePostTask() noexcept;
 
     ConcurrentQueue<std::weak_ptr<Task>> m_pendingTasks;
     std::atomic_bool m_aHasRunningTask;

--- a/fly/traits/traits.h
+++ b/fly/traits/traits.h
@@ -38,7 +38,7 @@
  * @param Type The type to be tested.
  * @param functor The function to test for.
  */
-#define DECLARATION_TESTS(label, Type, functor)                                \
+#define FLY_DECLARATION_TESTS(label, Type, functor)                            \
     struct if_##label                                                          \
     {                                                                          \
         struct __##label                                                       \
@@ -50,17 +50,18 @@
             static constexpr auto test_##label(...) -> std::false_type;        \
                                                                                \
             template <typename Type>                                           \
-            using is_undefined = std::                                         \
-                is_same<decltype(test_##label<Type>(0)), std::false_type>;     \
+            inline static constexpr bool is_undefined = std::is_same<          \
+                decltype(test_##label<Type>(0)),                               \
+                std::false_type>::value;                                       \
         };                                                                     \
                                                                                \
         template <typename Type>                                               \
         using enabled =                                                        \
-            std::enable_if_t<!__##label::is_undefined<Type>::value, bool>;     \
+            std::enable_if_t<!__##label::is_undefined<Type>, bool>;            \
                                                                                \
         template <typename Type>                                               \
         using disabled =                                                       \
-            std::enable_if_t<__##label::is_undefined<Type>::value, bool>;      \
+            std::enable_if_t<__##label::is_undefined<Type>, bool>;             \
     };
 
 /**
@@ -79,17 +80,17 @@ struct if_string
     struct __
     {
         template <typename T>
-        using is_string = std::bool_constant<
-            std::is_same<char *, std::decay_t<T>>::value ||
-            std::is_same<char const *, std::decay_t<T>>::value ||
-            std::is_same<std::string, std::decay_t<T>>::value>;
+        inline static constexpr bool is_string = std::bool_constant<
+            std::is_same_v<char *, std::decay_t<T>> ||
+            std::is_same_v<char const *, std::decay_t<T>> ||
+            std::is_same_v<std::string, std::decay_t<T>>>::value;
     };
 
     template <typename T>
-    using enabled = std::enable_if_t<__::is_string<T>::value, bool>;
+    using enabled = std::enable_if_t<__::is_string<T>, bool>;
 
     template <typename T>
-    using disabled = std::enable_if_t<!__::is_string<T>::value, bool>;
+    using disabled = std::enable_if_t<!__::is_string<T>, bool>;
 };
 
 /**
@@ -100,17 +101,17 @@ struct if_signed_integer
     struct __
     {
         template <typename T>
-        using is_signed_integer = std::bool_constant<
-            std::is_integral<std::decay_t<T>>::value &&
-            std::is_signed<std::decay_t<T>>::value &&
-            !std::is_same<bool, std::decay_t<T>>::value>;
+        inline static constexpr bool is_signed_integer = std::bool_constant<
+            std::is_integral_v<std::decay_t<T>> &&
+            std::is_signed_v<std::decay_t<T>> &&
+            !std::is_same_v<bool, std::decay_t<T>>>::value;
     };
 
     template <typename T>
-    using enabled = std::enable_if_t<__::is_signed_integer<T>::value, bool>;
+    using enabled = std::enable_if_t<__::is_signed_integer<T>, bool>;
 
     template <typename T>
-    using disabled = std::enable_if_t<!__::is_signed_integer<T>::value, bool>;
+    using disabled = std::enable_if_t<!__::is_signed_integer<T>, bool>;
 };
 
 /**
@@ -121,17 +122,17 @@ struct if_unsigned_integer
     struct __
     {
         template <typename T>
-        using is_unsigned_integer = std::bool_constant<
-            std::is_integral<std::decay_t<T>>::value &&
-            std::is_unsigned<std::decay_t<T>>::value &&
-            !std::is_same<bool, std::decay_t<T>>::value>;
+        inline static constexpr bool is_unsigned_integer = std::bool_constant<
+            std::is_integral_v<std::decay_t<T>> &&
+            std::is_unsigned_v<std::decay_t<T>> &&
+            !std::is_same_v<bool, std::decay_t<T>>>::value;
     };
 
     template <typename T>
-    using enabled = std::enable_if_t<__::is_unsigned_integer<T>::value, bool>;
+    using enabled = std::enable_if_t<__::is_unsigned_integer<T>, bool>;
 
     template <typename T>
-    using disabled = std::enable_if_t<!__::is_unsigned_integer<T>::value, bool>;
+    using disabled = std::enable_if_t<!__::is_unsigned_integer<T>, bool>;
 };
 
 /**
@@ -142,15 +143,15 @@ struct if_floating_point
     struct __
     {
         template <typename T>
-        using is_floating_point =
-            std::bool_constant<std::is_floating_point<std::decay_t<T>>::value>;
+        inline static constexpr bool is_floating_point = std::bool_constant<
+            std::is_floating_point_v<std::decay_t<T>>>::value;
     };
 
     template <typename T>
-    using enabled = std::enable_if_t<__::is_floating_point<T>::value, bool>;
+    using enabled = std::enable_if_t<__::is_floating_point<T>, bool>;
 
     template <typename T>
-    using disabled = std::enable_if_t<!__::is_floating_point<T>::value, bool>;
+    using disabled = std::enable_if_t<!__::is_floating_point<T>, bool>;
 };
 
 /**
@@ -161,16 +162,16 @@ struct if_numeric
     struct __
     {
         template <typename T>
-        using is_numeric = std::bool_constant<
-            std::is_arithmetic<std::decay_t<T>>::value &&
-            !std::is_same<bool, std::decay_t<T>>::value>;
+        inline static constexpr bool is_numeric = std::bool_constant<
+            std::is_arithmetic_v<std::decay_t<T>> &&
+            !std::is_same_v<bool, std::decay_t<T>>>::value;
     };
 
     template <typename T>
-    using enabled = std::enable_if_t<__::is_numeric<T>::value, bool>;
+    using enabled = std::enable_if_t<__::is_numeric<T>, bool>;
 
     template <typename T>
-    using disabled = std::enable_if_t<!__::is_numeric<T>::value, bool>;
+    using disabled = std::enable_if_t<!__::is_numeric<T>, bool>;
 };
 
 /**
@@ -181,15 +182,15 @@ struct if_boolean
     struct __
     {
         template <typename T>
-        using is_boolean =
-            std::bool_constant<std::is_same<bool, std::decay_t<T>>::value>;
+        inline static constexpr bool is_boolean =
+            std::bool_constant<std::is_same_v<bool, std::decay_t<T>>>::value;
     };
 
     template <typename T>
-    using enabled = std::enable_if_t<__::is_boolean<T>::value, bool>;
+    using enabled = std::enable_if_t<__::is_boolean<T>, bool>;
 
     template <typename T>
-    using disabled = std::enable_if_t<!__::is_boolean<T>::value, bool>;
+    using disabled = std::enable_if_t<!__::is_boolean<T>, bool>;
 };
 
 /**
@@ -300,7 +301,7 @@ struct if_array
 /**
  * Tests for whether a type defines operator<<.
  */
-DECLARATION_TESTS(
+FLY_DECLARATION_TESTS(
     ostream,
     T,
     std::declval<std::ostream &>() << std::declval<const T &>());

--- a/fly/types/concurrent_queue.h
+++ b/fly/types/concurrent_queue.h
@@ -16,20 +16,20 @@ template <typename T>
 class ConcurrentQueue : public ConcurrentContainer<T, std::queue<T>>
 {
 protected:
-    void push(const T &) override;
-    void pop(T &) override;
+    void push(T &&) noexcept override;
+    void pop(T &) noexcept override;
 };
 
 //==============================================================================
 template <typename T>
-void ConcurrentQueue<T>::push(const T &item)
+void ConcurrentQueue<T>::push(T &&item) noexcept
 {
     this->m_container.push(std::move(item));
 }
 
 //==============================================================================
 template <typename T>
-void ConcurrentQueue<T>::pop(T &item)
+void ConcurrentQueue<T>::pop(T &item) noexcept
 {
     item = std::move(this->m_container.front());
     this->m_container.pop();

--- a/fly/types/concurrent_stack.h
+++ b/fly/types/concurrent_stack.h
@@ -16,20 +16,20 @@ template <typename T>
 class ConcurrentStack : public ConcurrentContainer<T, std::stack<T>>
 {
 protected:
-    void push(const T &) override;
-    void pop(T &) override;
+    void push(T &&) noexcept override;
+    void pop(T &) noexcept override;
 };
 
 //==============================================================================
 template <typename T>
-void ConcurrentStack<T>::push(const T &item)
+void ConcurrentStack<T>::push(T &&item) noexcept
 {
     this->m_container.push(std::move(item));
 }
 
 //==============================================================================
 template <typename T>
-void ConcurrentStack<T>::pop(T &item)
+void ConcurrentStack<T>::pop(T &item) noexcept
 {
     item = std::move(this->m_container.top());
     this->m_container.pop();

--- a/fly/types/json.cpp
+++ b/fly/types/json.cpp
@@ -55,25 +55,25 @@ Json::Json(const std::initializer_list<Json> &initializer) noexcept : m_value()
 }
 
 //==============================================================================
-bool Json::IsNull() const
+bool Json::IsNull() const noexcept
 {
     return std::holds_alternative<null_type>(m_value);
 }
 
 //==============================================================================
-bool Json::IsString() const
+bool Json::IsString() const noexcept
 {
     return std::holds_alternative<string_type>(m_value);
 }
 
 //==============================================================================
-bool Json::IsObject() const
+bool Json::IsObject() const noexcept
 {
     return std::holds_alternative<object_type>(m_value);
 }
 
 //==============================================================================
-bool Json::IsObjectLike() const
+bool Json::IsObjectLike() const noexcept
 {
     const array_type *value = std::get_if<array_type>(&m_value);
 
@@ -82,31 +82,31 @@ bool Json::IsObjectLike() const
 }
 
 //==============================================================================
-bool Json::IsArray() const
+bool Json::IsArray() const noexcept
 {
     return std::holds_alternative<array_type>(m_value);
 }
 
 //==============================================================================
-bool Json::IsBoolean() const
+bool Json::IsBoolean() const noexcept
 {
     return std::holds_alternative<boolean_type>(m_value);
 }
 
 //==============================================================================
-bool Json::IsSignedInteger() const
+bool Json::IsSignedInteger() const noexcept
 {
     return std::holds_alternative<signed_type>(m_value);
 }
 
 //==============================================================================
-bool Json::IsUnsignedInteger() const
+bool Json::IsUnsignedInteger() const noexcept
 {
     return std::holds_alternative<unsigned_type>(m_value);
 }
 
 //==============================================================================
-bool Json::IsFloat() const
+bool Json::IsFloat() const noexcept
 {
     return std::holds_alternative<float_type>(m_value);
 }
@@ -119,7 +119,7 @@ Json &Json::operator=(Json json) noexcept
 }
 
 //==============================================================================
-Json::operator null_type() const
+Json::operator null_type() const noexcept(false)
 {
     if (IsNull())
     {
@@ -132,7 +132,7 @@ Json::operator null_type() const
 }
 
 //==============================================================================
-Json::operator string_type() const
+Json::operator string_type() const noexcept(false)
 {
     if (IsString())
     {
@@ -148,7 +148,8 @@ Json::operator string_type() const
 }
 
 //==============================================================================
-Json &Json::operator[](const typename object_type::key_type &key)
+Json &Json::
+operator[](const typename object_type::key_type &key) noexcept(false)
 {
     if (IsNull())
     {
@@ -168,6 +169,7 @@ Json &Json::operator[](const typename object_type::key_type &key)
 
 //==============================================================================
 const Json &Json::operator[](const typename object_type::key_type &key) const
+    noexcept(false)
 {
     if (IsObject())
     {
@@ -189,7 +191,8 @@ const Json &Json::operator[](const typename object_type::key_type &key) const
 }
 
 //==============================================================================
-Json &Json::operator[](const typename array_type::size_type &index)
+Json &Json::
+operator[](const typename array_type::size_type &index) noexcept(false)
 {
     if (IsNull())
     {
@@ -213,6 +216,7 @@ Json &Json::operator[](const typename array_type::size_type &index)
 
 //==============================================================================
 const Json &Json::operator[](const typename array_type::size_type &index) const
+    noexcept(false)
 {
     if (IsArray())
     {
@@ -231,7 +235,7 @@ const Json &Json::operator[](const typename array_type::size_type &index) const
 }
 
 //==============================================================================
-std::size_t Json::Size() const
+std::size_t Json::Size() const noexcept
 {
     auto visitor = [](const auto &value) -> std::size_t {
         using U = std::decay_t<decltype(value)>;
@@ -257,7 +261,7 @@ std::size_t Json::Size() const
 }
 
 //==============================================================================
-bool operator==(const Json &json1, const Json &json2)
+bool operator==(const Json &json1, const Json &json2) noexcept
 {
     auto is_numeric = [](const Json &json) {
         return json.IsSignedInteger() || json.IsUnsignedInteger() ||
@@ -282,13 +286,13 @@ bool operator==(const Json &json1, const Json &json2)
 }
 
 //==============================================================================
-bool operator!=(const Json &json1, const Json &json2)
+bool operator!=(const Json &json1, const Json &json2) noexcept
 {
     return !(json1 == json2);
 }
 
 //==============================================================================
-std::ostream &operator<<(std::ostream &stream, const Json &json)
+std::ostream &operator<<(std::ostream &stream, const Json &json) noexcept
 {
     auto visitor = [&stream](const auto &value) {
         using U = std::decay_t<decltype(value)>;
@@ -349,6 +353,7 @@ std::ostream &operator<<(std::ostream &stream, const Json &json)
 
 //==============================================================================
 Json::string_type Json::validateString(const string_type &str) const
+    noexcept(false)
 {
     stream_type stream;
 
@@ -378,7 +383,7 @@ Json::string_type Json::validateString(const string_type &str) const
 void Json::readEscapedCharacter(
     stream_type &stream,
     string_type::const_iterator &it,
-    const string_type::const_iterator &end) const
+    const string_type::const_iterator &end) const noexcept(false)
 {
     if (++it == end)
     {
@@ -427,7 +432,7 @@ void Json::readEscapedCharacter(
 void Json::readUnicodeCharacter(
     stream_type &stream,
     string_type::const_iterator &it,
-    const string_type::const_iterator &end) const
+    const string_type::const_iterator &end) const noexcept(false)
 {
     auto is_high_surrogate = [](int c) -> bool {
         return (c >= 0xd800) && (c <= 0xdbff);
@@ -502,7 +507,7 @@ void Json::readUnicodeCharacter(
 //==============================================================================
 int Json::readUnicodeCodepoint(
     string_type::const_iterator &it,
-    const string_type::const_iterator &end) const
+    const string_type::const_iterator &end) const noexcept(false)
 {
     int codepoint = 0;
 
@@ -542,7 +547,7 @@ int Json::readUnicodeCodepoint(
 void Json::validateCharacter(
     stream_type &stream,
     string_type::const_iterator &it,
-    const string_type::const_iterator &end) const
+    const string_type::const_iterator &end) const noexcept(false)
 {
     unsigned char c = *it;
 
@@ -691,13 +696,15 @@ void Json::validateCharacter(
 }
 
 //==============================================================================
-JsonException::JsonException(const std::string &message) :
+JsonException::JsonException(const std::string &message) noexcept :
     m_message(String::Format("JsonException: %s", message))
 {
 }
 
 //==============================================================================
-JsonException::JsonException(const Json &json, const std::string &message) :
+JsonException::JsonException(
+    const Json &json,
+    const std::string &message) noexcept :
     m_message(String::Format("JsonException: %s (%s)", message, json))
 {
 }

--- a/fly/types/json.h
+++ b/fly/types/json.h
@@ -114,7 +114,7 @@ public:
      * @throws JsonException If the string-like value is not valid.
      */
     template <typename T, fly::if_string::enabled<T> = 0>
-    Json(const T &);
+    Json(const T &) noexcept(false);
 
     /**
      * Object constructor. Intializes the Json instance to an object's values.
@@ -221,17 +221,17 @@ public:
     /**
      * @return bool True if the Json instance is null.
      */
-    bool IsNull() const;
+    bool IsNull() const noexcept;
 
     /**
      * @return bool True if the Json instance is a string.
      */
-    bool IsString() const;
+    bool IsString() const noexcept;
 
     /**
      * @return bool True if the Json instance is an object.
      */
-    bool IsObject() const;
+    bool IsObject() const noexcept;
 
     /**
      * Determine if the Json instance is object-like. This is mostly useful for
@@ -241,32 +241,32 @@ public:
      *
      * @return bool True if the Json instance is object-like.
      */
-    bool IsObjectLike() const;
+    bool IsObjectLike() const noexcept;
 
     /**
      * @return bool True if the Json instance is an array.
      */
-    bool IsArray() const;
+    bool IsArray() const noexcept;
 
     /**
      * @return bool True if the Json instance is a boolean.
      */
-    bool IsBoolean() const;
+    bool IsBoolean() const noexcept;
 
     /**
      * @return bool True if the Json instance is a signed integer.
      */
-    bool IsSignedInteger() const;
+    bool IsSignedInteger() const noexcept;
 
     /**
      * @return bool True if the Json instance is an unsigned integer.
      */
-    bool IsUnsignedInteger() const;
+    bool IsUnsignedInteger() const noexcept;
 
     /**
      * @return bool True if the Json instance is a float.
      */
-    bool IsFloat() const;
+    bool IsFloat() const noexcept;
 
     /**
      * Assignment operator. Intializes the Json instance with the type and value
@@ -285,7 +285,7 @@ public:
      *
      * @return null_type The Json instance as a number.
      */
-    explicit operator null_type() const;
+    explicit operator null_type() const noexcept(false);
 
     /**
      * String conversion operator. Converts the Json instance to a string. Note
@@ -295,7 +295,7 @@ public:
      *
      * @return string_type The Json instance as a string.
      */
-    explicit operator string_type() const;
+    explicit operator string_type() const noexcept(false);
 
     /**
      * Object conversion operator. Converts the Json instance to an object. The
@@ -309,7 +309,7 @@ public:
      * @return T The Json instance as the object-like type.
      */
     template <typename T, fly::if_map::enabled<T> = 0>
-    explicit operator T() const;
+    explicit operator T() const noexcept(false);
 
     /**
      * Array conversion operator. Converts the Json instance to an array. The
@@ -325,7 +325,7 @@ public:
      * @return T The Json instance as the array-like type.
      */
     template <typename T, fly::if_array::enabled<T> = 0>
-    explicit operator T() const;
+    explicit operator T() const noexcept(false);
 
     /**
      * Array conversion operator. Converts the Json instance to a std::array. If
@@ -341,7 +341,7 @@ public:
      * @return T The Json instance as a std::array.
      */
     template <typename T, std::size_t N>
-    explicit operator std::array<T, N>() const;
+    explicit operator std::array<T, N>() const noexcept(false);
 
     /**
      * Boolean conversion operator. Converts the Json instance to a boolean. For
@@ -355,7 +355,7 @@ public:
      * @param T The Json instance as a boolean.
      */
     template <typename T, fly::if_boolean::enabled<T> = 0>
-    explicit operator T() const;
+    explicit operator T() const noexcept(false);
 
     /**
      * Numeric conversion operator. Converts the Json instance to a numeric
@@ -372,7 +372,7 @@ public:
      * @return T The Json instance as the numeric type.
      */
     template <typename T, fly::if_numeric::enabled<T> = 0>
-    explicit operator T() const;
+    explicit operator T() const noexcept(false);
 
     /**
      * Object access operator.
@@ -390,7 +390,7 @@ public:
      *
      * @return Json A reference to the Json instance at the key value.
      */
-    Json &operator[](const typename object_type::key_type &);
+    Json &operator[](const typename object_type::key_type &) noexcept(false);
 
     /**
      * Object read-only access operator.
@@ -405,7 +405,8 @@ public:
      *
      * @return Json A reference to the Json instance at the key value.
      */
-    const Json &operator[](const typename object_type::key_type &) const;
+    const Json &operator[](const typename object_type::key_type &) const
+        noexcept(false);
 
     /**
      * Array access operator.
@@ -422,7 +423,7 @@ public:
      *
      * @return Json A reference to the Json instance at the index.
      */
-    Json &operator[](const typename array_type::size_type &);
+    Json &operator[](const typename array_type::size_type &) noexcept(false);
 
     /**
      * Array read-only access operator.
@@ -437,7 +438,8 @@ public:
      *
      * @return Json A reference to the Json instance at the index.
      */
-    const Json &operator[](const typename array_type::size_type &) const;
+    const Json &operator[](const typename array_type::size_type &) const
+        noexcept(false);
 
     /**
      * Get the size of the Json instance.
@@ -453,7 +455,7 @@ public:
      *
      * @return size_t The size of the Json instance.
      */
-    std::size_t Size() const;
+    std::size_t Size() const noexcept;
 
     /**
      * Equality operator. Compares two Json instances for equality. They are
@@ -466,7 +468,7 @@ public:
      *
      * @return bool True if the two Json instances are equal.
      */
-    friend bool operator==(const Json &, const Json &);
+    friend bool operator==(const Json &, const Json &) noexcept;
 
     /**
      * Unequality operator. Compares two Json instances for unequality. They are
@@ -474,7 +476,7 @@ public:
      *
      * @return bool True if the two Json instances are unequal.
      */
-    friend bool operator!=(const Json &, const Json &);
+    friend bool operator!=(const Json &, const Json &) noexcept;
 
     /**
      * Stream operator. Stream the Json instance into an output stream.
@@ -484,7 +486,7 @@ public:
      *
      * @return ostream A reference to the output stream.
      */
-    friend std::ostream &operator<<(std::ostream &, const Json &);
+    friend std::ostream &operator<<(std::ostream &, const Json &) noexcept;
 
 private:
     /**
@@ -498,7 +500,7 @@ private:
      *
      * @throws JsonException If the string value is not valid.
      */
-    string_type validateString(const string_type &) const;
+    string_type validateString(const string_type &) const noexcept(false);
 
     /**
      * After reading a reverse solidus character, read the escaped character
@@ -515,7 +517,7 @@ private:
     void readEscapedCharacter(
         stream_type &,
         string_type::const_iterator &,
-        const string_type::const_iterator &) const;
+        const string_type::const_iterator &) const noexcept(false);
 
     /**
      * After determining the escaped character is a unicode encoding, read the
@@ -533,7 +535,7 @@ private:
     void readUnicodeCharacter(
         stream_type &,
         string_type::const_iterator &,
-        const string_type::const_iterator &) const;
+        const string_type::const_iterator &) const noexcept(false);
 
     /**
      * Read a single 4-byte unicode encoding.
@@ -548,7 +550,7 @@ private:
      */
     int readUnicodeCodepoint(
         string_type::const_iterator &,
-        const string_type::const_iterator &) const;
+        const string_type::const_iterator &) const noexcept(false);
 
     /**
      * Validate a single non-escaped character is compliant.
@@ -562,7 +564,7 @@ private:
     void validateCharacter(
         stream_type &,
         string_type::const_iterator &,
-        const string_type::const_iterator &) const;
+        const string_type::const_iterator &) const noexcept(false);
 
     json_type m_value;
 };
@@ -582,7 +584,7 @@ public:
      *
      * @param string Message indicating what error was encountered.
      */
-    JsonException(const std::string &);
+    JsonException(const std::string &) noexcept;
 
     /**
      * Constructor.
@@ -590,7 +592,7 @@ public:
      * @param Json The Json instance for which the error was encountered.
      * @param string Message indicating what error was encountered.
      */
-    JsonException(const Json &, const std::string &);
+    JsonException(const Json &, const std::string &) noexcept;
 
     /**
      * @return A C-string representing this exception.
@@ -603,7 +605,7 @@ private:
 
 //==============================================================================
 template <typename T, fly::if_string::enabled<T>>
-Json::Json(const T &value) : m_value(validateString(value))
+Json::Json(const T &value) noexcept(false) : m_value(validateString(value))
 {
 }
 
@@ -647,7 +649,7 @@ Json::Json(const T &value) noexcept : m_value(static_cast<float_type>(value))
 
 //==============================================================================
 template <typename T, fly::if_map::enabled<T>>
-Json::operator T() const
+Json::operator T() const noexcept(false)
 {
     if (IsObject())
     {
@@ -660,7 +662,7 @@ Json::operator T() const
 
 //==============================================================================
 template <typename T, fly::if_array::enabled<T>>
-Json::operator T() const
+Json::operator T() const noexcept(false)
 {
     if (IsArray())
     {
@@ -673,7 +675,7 @@ Json::operator T() const
 
 //==============================================================================
 template <typename T, std::size_t N>
-Json::operator std::array<T, N>() const
+Json::operator std::array<T, N>() const noexcept(false)
 {
     if (IsArray())
     {
@@ -693,7 +695,7 @@ Json::operator std::array<T, N>() const
 
 //==============================================================================
 template <typename T, fly::if_boolean::enabled<T>>
-Json::operator T() const
+Json::operator T() const noexcept(false)
 {
     auto visitor = [](const auto &value) -> T {
         using U = std::decay_t<decltype(value)>;
@@ -724,7 +726,7 @@ Json::operator T() const
 
 //==============================================================================
 template <typename T, fly::if_numeric::enabled<T>>
-Json::operator T() const
+Json::operator T() const noexcept(false)
 {
     auto visitor = [this](const auto &value) -> T {
         using U = std::decay_t<decltype(value)>;

--- a/fly/types/string.cpp
+++ b/fly/types/string.cpp
@@ -19,14 +19,15 @@ namespace {
 } // namespace
 
 //==============================================================================
-std::vector<std::string> String::Split(const std::string &input, char delim)
+std::vector<std::string>
+String::Split(const std::string &input, char delim) noexcept
 {
     return Split(input, delim, 0);
 }
 
 //==============================================================================
 std::vector<std::string>
-String::Split(const std::string &input, char delim, size_t max)
+String::Split(const std::string &input, char delim, size_t max) noexcept
 {
     std::string item;
     std::stringstream ss(input);
@@ -53,7 +54,7 @@ String::Split(const std::string &input, char delim, size_t max)
 }
 
 //==============================================================================
-void String::Trim(std::string &str)
+void String::Trim(std::string &str) noexcept
 {
     auto is_non_space = [](int ch) { return !std::isspace(ch); };
 
@@ -69,7 +70,7 @@ void String::Trim(std::string &str)
 void String::ReplaceAll(
     std::string &target,
     const std::string &search,
-    const char &replace)
+    const char &replace) noexcept
 {
     size_t pos = target.find(search);
 
@@ -84,7 +85,7 @@ void String::ReplaceAll(
 void String::ReplaceAll(
     std::string &target,
     const std::string &search,
-    const std::string &replace)
+    const std::string &replace) noexcept
 {
     size_t pos = target.find(search);
 
@@ -96,13 +97,13 @@ void String::ReplaceAll(
 }
 
 //==============================================================================
-void String::RemoveAll(std::string &target, const std::string &search)
+void String::RemoveAll(std::string &target, const std::string &search) noexcept
 {
     ReplaceAll(target, search, std::string());
 }
 
 //==============================================================================
-std::string String::GenerateRandomString(const size_t len)
+std::string String::GenerateRandomString(const size_t len) noexcept
 {
     typedef std::uniform_int_distribution<short> short_distribution;
 
@@ -127,7 +128,7 @@ std::string String::GenerateRandomString(const size_t len)
 }
 
 //==============================================================================
-bool String::StartsWith(const std::string &source, const char &search)
+bool String::StartsWith(const std::string &source, const char &search) noexcept
 {
     bool ret = false;
 
@@ -140,7 +141,9 @@ bool String::StartsWith(const std::string &source, const char &search)
 }
 
 //==============================================================================
-bool String::StartsWith(const std::string &source, const std::string &search)
+bool String::StartsWith(
+    const std::string &source,
+    const std::string &search) noexcept
 {
     bool ret = false;
 
@@ -156,7 +159,7 @@ bool String::StartsWith(const std::string &source, const std::string &search)
 }
 
 //==============================================================================
-bool String::EndsWith(const std::string &source, const char &search)
+bool String::EndsWith(const std::string &source, const char &search) noexcept
 {
     bool ret = false;
 
@@ -171,7 +174,9 @@ bool String::EndsWith(const std::string &source, const char &search)
 }
 
 //==============================================================================
-bool String::EndsWith(const std::string &source, const std::string &search)
+bool String::EndsWith(
+    const std::string &source,
+    const std::string &search) noexcept
 {
     bool ret = false;
 
@@ -187,7 +192,9 @@ bool String::EndsWith(const std::string &source, const std::string &search)
 }
 
 //==============================================================================
-bool String::WildcardMatch(const std::string &source, const std::string &search)
+bool String::WildcardMatch(
+    const std::string &source,
+    const std::string &search) noexcept
 {
     static const char wildcard = '*';
     bool ret = !search.empty();
@@ -222,14 +229,14 @@ bool String::WildcardMatch(const std::string &source, const std::string &search)
 
 //==============================================================================
 template <>
-std::string String::Convert(const std::string &value)
+std::string String::Convert(const std::string &value) noexcept
 {
     return value;
 }
 
 //==============================================================================
 template <>
-bool String::Convert(const std::string &value)
+bool String::Convert(const std::string &value) noexcept(false)
 {
     static const long long min = std::numeric_limits<bool>::min();
     static const long long max = std::numeric_limits<bool>::max();
@@ -251,7 +258,7 @@ bool String::Convert(const std::string &value)
 
 //==============================================================================
 template <>
-char String::Convert(const std::string &value)
+char String::Convert(const std::string &value) noexcept(false)
 {
     static const long long min = std::numeric_limits<char>::min();
     static const long long max = std::numeric_limits<char>::max();
@@ -273,7 +280,7 @@ char String::Convert(const std::string &value)
 
 //==============================================================================
 template <>
-unsigned char String::Convert(const std::string &value)
+unsigned char String::Convert(const std::string &value) noexcept(false)
 {
     static const long long min = std::numeric_limits<unsigned char>::min();
     static const long long max = std::numeric_limits<unsigned char>::max();
@@ -295,7 +302,7 @@ unsigned char String::Convert(const std::string &value)
 
 //==============================================================================
 template <>
-short String::Convert(const std::string &value)
+short String::Convert(const std::string &value) noexcept(false)
 {
     static const long long min = std::numeric_limits<short>::min();
     static const long long max = std::numeric_limits<short>::max();
@@ -317,7 +324,7 @@ short String::Convert(const std::string &value)
 
 //==============================================================================
 template <>
-unsigned short String::Convert(const std::string &value)
+unsigned short String::Convert(const std::string &value) noexcept(false)
 {
     static const long long min = std::numeric_limits<unsigned short>::min();
     static const long long max = std::numeric_limits<unsigned short>::max();
@@ -339,7 +346,7 @@ unsigned short String::Convert(const std::string &value)
 
 //==============================================================================
 template <>
-int String::Convert(const std::string &value)
+int String::Convert(const std::string &value) noexcept(false)
 {
     std::size_t index = 0;
     int result = std::stoi(value, &index);
@@ -354,7 +361,7 @@ int String::Convert(const std::string &value)
 
 //==============================================================================
 template <>
-unsigned int String::Convert(const std::string &value)
+unsigned int String::Convert(const std::string &value) noexcept(false)
 {
     static const long long min = std::numeric_limits<unsigned int>::min();
     static const long long max = std::numeric_limits<unsigned int>::max();
@@ -376,7 +383,7 @@ unsigned int String::Convert(const std::string &value)
 
 //==============================================================================
 template <>
-long String::Convert(const std::string &value)
+long String::Convert(const std::string &value) noexcept(false)
 {
     std::size_t index = 0;
     long result = std::stol(value, &index);
@@ -391,7 +398,7 @@ long String::Convert(const std::string &value)
 
 //==============================================================================
 template <>
-unsigned long String::Convert(const std::string &value)
+unsigned long String::Convert(const std::string &value) noexcept(false)
 {
     std::size_t index = 0;
     unsigned long result = std::stoul(value, &index);
@@ -406,7 +413,7 @@ unsigned long String::Convert(const std::string &value)
 
 //==============================================================================
 template <>
-long long String::Convert(const std::string &value)
+long long String::Convert(const std::string &value) noexcept(false)
 {
     std::size_t index = 0;
     long long result = std::stoll(value, &index);
@@ -421,7 +428,7 @@ long long String::Convert(const std::string &value)
 
 //==============================================================================
 template <>
-unsigned long long String::Convert(const std::string &value)
+unsigned long long String::Convert(const std::string &value) noexcept(false)
 {
     std::size_t index = 0;
     unsigned long long result = std::stoull(value, &index);
@@ -436,7 +443,7 @@ unsigned long long String::Convert(const std::string &value)
 
 //==============================================================================
 template <>
-float String::Convert(const std::string &value)
+float String::Convert(const std::string &value) noexcept(false)
 {
     std::size_t index = 0;
     float result = std::stof(value, &index);
@@ -451,7 +458,7 @@ float String::Convert(const std::string &value)
 
 //==============================================================================
 template <>
-double String::Convert(const std::string &value)
+double String::Convert(const std::string &value) noexcept(false)
 {
     std::size_t index = 0;
     double result = std::stod(value, &index);
@@ -466,7 +473,7 @@ double String::Convert(const std::string &value)
 
 //==============================================================================
 template <>
-long double String::Convert(const std::string &value)
+long double String::Convert(const std::string &value) noexcept(false)
 {
     std::size_t index = 0;
     long double result = std::stold(value, &index);
@@ -480,7 +487,7 @@ long double String::Convert(const std::string &value)
 }
 
 //==============================================================================
-void String::format(std::ostream &stream, const char *fmt)
+void String::format(std::ostream &stream, const char *fmt) noexcept
 {
     stream << fmt;
 }

--- a/fly/types/string.h
+++ b/fly/types/string.h
@@ -5,6 +5,7 @@
 
 #include <sstream>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 namespace fly {
@@ -26,7 +27,7 @@ public:
      *
      * @return A vector containing the split strings.
      */
-    static std::vector<std::string> Split(const std::string &, char);
+    static std::vector<std::string> Split(const std::string &, char) noexcept;
 
     /**
      * Split a string into a vector of strings, up to a maximum size. If the max
@@ -39,14 +40,15 @@ public:
      *
      * @return A vector containing the split strings.
      */
-    static std::vector<std::string> Split(const std::string &, char, size_t);
+    static std::vector<std::string>
+    Split(const std::string &, char, size_t) noexcept;
 
     /**
      * Remove leading and trailing whitespace from a string.
      *
      * @param string The string to trim.
      */
-    static void Trim(std::string &);
+    static void Trim(std::string &) noexcept;
 
     /**
      * Replace all instances of a substring in a string with a character.
@@ -55,7 +57,8 @@ public:
      * @param string The string to search for and replace.
      * @param char The replacement character.
      */
-    static void ReplaceAll(std::string &, const std::string &, const char &);
+    static void
+    ReplaceAll(std::string &, const std::string &, const char &) noexcept;
 
     /**
      * Replace all instances of a substring in a string with another string.
@@ -64,8 +67,10 @@ public:
      * @param string The string to search for and replace.
      * @param string The replacement string.
      */
-    static void
-    ReplaceAll(std::string &, const std::string &, const std::string &);
+    static void ReplaceAll(
+        std::string &,
+        const std::string &,
+        const std::string &) noexcept;
 
     /**
      * Remove all instances of a substring in a string.
@@ -73,7 +78,7 @@ public:
      * @param string The string container which will be modified.
      * @param string The string to search for and remove.
      */
-    static void RemoveAll(std::string &, const std::string &);
+    static void RemoveAll(std::string &, const std::string &) noexcept;
 
     /**
      * Check if a string begins with a character.
@@ -83,7 +88,7 @@ public:
      *
      * @return True if the string begins with the search character.
      */
-    static bool StartsWith(const std::string &, const char &);
+    static bool StartsWith(const std::string &, const char &) noexcept;
 
     /**
      * Check if a string begins with another string.
@@ -93,7 +98,7 @@ public:
      *
      * @return True if the string begins with the search string.
      */
-    static bool StartsWith(const std::string &, const std::string &);
+    static bool StartsWith(const std::string &, const std::string &) noexcept;
 
     /**
      * Check if a string ends with a character.
@@ -103,7 +108,7 @@ public:
      *
      * @return True if the string ends with the search character.
      */
-    static bool EndsWith(const std::string &, const char &);
+    static bool EndsWith(const std::string &, const char &) noexcept;
 
     /**
      * Check if a string ends with another string.
@@ -113,7 +118,7 @@ public:
      *
      * @return True if the string ends with the search string.
      */
-    static bool EndsWith(const std::string &, const std::string &);
+    static bool EndsWith(const std::string &, const std::string &) noexcept;
 
     /**
      * Check if a string matches another string with wildcard expansion.
@@ -123,7 +128,8 @@ public:
      *
      * @return True if the wildcard string matches the source string.
      */
-    static bool WildcardMatch(const std::string &, const std::string &);
+    static bool
+    WildcardMatch(const std::string &, const std::string &) noexcept;
 
     /**
      * Generate a random string of the given size.
@@ -132,7 +138,7 @@ public:
      *
      * @return The generated string.
      */
-    static std::string GenerateRandomString(const size_t);
+    static std::string GenerateRandomString(const size_t) noexcept;
 
     /**
      * Format a string with variadic template arguments. This is type safe in
@@ -155,7 +161,7 @@ public:
      * @return A string that has been formatted with the given arguments.
      */
     template <typename... Args>
-    static std::string Format(const char *, const Args &...);
+    static std::string Format(const char *, const Args &...) noexcept;
 
     /**
      * Concatenate a list of objects with the given separator.
@@ -168,7 +174,7 @@ public:
      * @return The resulting join of the given arguments.
      */
     template <typename... Args>
-    static std::string Join(const char &, const Args &...);
+    static std::string Join(const char &, const Args &...) noexcept;
 
     /**
      * Convert a string to a basic type, e.g. int or bool.
@@ -183,7 +189,8 @@ public:
      * @throws std::out_of_range Converted value is out of range of result type.
      */
     template <typename T>
-    static T Convert(const std::string &);
+    static T Convert(const std::string &) noexcept(
+        std::is_same_v<std::string, std::decay_t<T>>);
 
 private:
     /**
@@ -192,43 +199,44 @@ private:
      */
     template <typename T, typename... Args>
     static void
-    format(std::ostream &, const char *, const T &, const Args &...);
+    format(std::ostream &, const char *, const T &, const Args &...) noexcept;
 
     /**
      * Terminator for the variadic template formatter. Stream the rest of the
      * string into the given ostream.
      */
-    static void format(std::ostream &, const char *);
+    static void format(std::ostream &, const char *) noexcept;
 
     /**
      * Recursively join one argument into the given ostream.
      */
     template <typename T, typename... Args>
-    static void join(std::ostream &, const char &, const T &, const Args &...);
+    static void
+    join(std::ostream &, const char &, const T &, const Args &...) noexcept;
 
     /**
      * Terminator for the variadic template joiner. Join the last argument
      * into the given ostream.
      */
     template <typename T>
-    static void join(std::ostream &, const char &, const T &);
+    static void join(std::ostream &, const char &, const T &) noexcept;
 
     /**
      * Stream the given value into the given stream.
      */
     template <typename T, if_ostream::enabled<T> = 0>
-    static void getValue(std::ostream &, const T &);
+    static void getValue(std::ostream &, const T &) noexcept;
 
     /**
      * Stream the hash of the given value into the given stream.
      */
     template <typename T, if_ostream::disabled<T> = 0>
-    static void getValue(std::ostream &, const T &);
+    static void getValue(std::ostream &, const T &) noexcept;
 };
 
 //==============================================================================
 template <typename... Args>
-std::string String::Format(const char *fmt, const Args &... args)
+std::string String::Format(const char *fmt, const Args &... args) noexcept
 {
     std::ostringstream stream;
     stream.precision(6);
@@ -247,7 +255,7 @@ void String::format(
     std::ostream &stream,
     const char *fmt,
     const T &value,
-    const Args &... args)
+    const Args &... args) noexcept
 {
     for (; *fmt != '\0'; ++fmt)
     {
@@ -299,7 +307,7 @@ void String::format(
 
 //==============================================================================
 template <typename... Args>
-std::string String::Join(const char &separator, const Args &... args)
+std::string String::Join(const char &separator, const Args &... args) noexcept
 {
     std::ostringstream stream;
     join(stream, separator, args...);
@@ -313,7 +321,7 @@ void String::join(
     std::ostream &stream,
     const char &separator,
     const T &value,
-    const Args &... args)
+    const Args &... args) noexcept
 {
     getValue(stream, value);
     stream << separator;
@@ -323,21 +331,21 @@ void String::join(
 
 //==============================================================================
 template <typename T>
-void String::join(std::ostream &stream, const char &, const T &value)
+void String::join(std::ostream &stream, const char &, const T &value) noexcept
 {
     getValue(stream, value);
 }
 
 //==============================================================================
 template <typename T, if_ostream::enabled<T>>
-void String::getValue(std::ostream &stream, const T &value)
+void String::getValue(std::ostream &stream, const T &value) noexcept
 {
     stream << std::boolalpha << value;
 }
 
 //==============================================================================
 template <typename T, if_ostream::disabled<T>>
-void String::getValue(std::ostream &stream, const T &value)
+void String::getValue(std::ostream &stream, const T &value) noexcept
 {
     static std::hash<T *> hasher;
     stream << "[0x" << std::hex << hasher(&value) << std::dec << ']';

--- a/test/config/config.cpp
+++ b/test/config/config.cpp
@@ -1,6 +1,7 @@
 #include "fly/config/config.h"
 
 #include "fly/types/json.h"
+#include "test/config/test_config.h"
 
 #include <gtest/gtest.h>
 
@@ -11,12 +12,12 @@
 class ConfigTest : public ::testing::Test
 {
 public:
-    ConfigTest() : m_spConfig(std::make_shared<fly::Config>())
+    ConfigTest() noexcept : m_spConfig(std::make_shared<TestConfig>())
     {
     }
 
 protected:
-    std::shared_ptr<fly::Config> m_spConfig;
+    std::shared_ptr<TestConfig> m_spConfig;
 };
 
 //==============================================================================

--- a/test/config/config_manager.cpp
+++ b/test/config/config_manager.cpp
@@ -91,6 +91,14 @@ protected:
 };
 
 //==============================================================================
+class BadConfig : public fly::Config
+{
+public:
+    // Badly written config class which uses the same identifier as TestConfig.
+    static constexpr const char *identifier = TestConfig::identifier;
+};
+
+//==============================================================================
 TEST_F(ConfigManagerTest, AllFileTypesTest)
 {
     {
@@ -118,6 +126,19 @@ TEST_F(ConfigManagerTest, BadFileTypeTest)
         m_file);
 
     EXPECT_FALSE(m_spConfigManager->Start());
+}
+
+//==============================================================================
+TEST_F(ConfigManagerTest, BadConfigTypeTest)
+{
+    EXPECT_EQ(m_spConfigManager->GetSize(), m_initialSize);
+
+    auto spConfig = m_spConfigManager->CreateConfig<TestConfig>();
+    EXPECT_EQ(m_spConfigManager->GetSize(), m_initialSize + 1);
+
+    auto spConfig2 = m_spConfigManager->CreateConfig<BadConfig>();
+    EXPECT_EQ(m_spConfigManager->GetSize(), m_initialSize + 1);
+    EXPECT_FALSE(spConfig2);
 }
 
 //==============================================================================

--- a/test/config/test_config.h
+++ b/test/config/test_config.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "fly/config/config.h"
+#include "fly/types/json.h"
+
+#include <string>
+
+/**
+ * A pseudo config class to provide public access to Config methods. Only meant
+ * to be used by unit tests.
+ */
+class TestConfig : public fly::Config
+{
+public:
+    static constexpr const char *identifier = "config";
+
+    template <typename T>
+    T GetValue(const std::string &name, T def) const noexcept
+    {
+        return fly::Config::GetValue(name, def);
+    }
+
+    void Update(const fly::Json &values) noexcept
+    {
+        fly::Config::Update(values);
+    }
+};

--- a/test/logger/logger.cpp
+++ b/test/logger/logger.cpp
@@ -25,7 +25,7 @@ namespace {
 class TestLoggerConfig : public fly::LoggerConfig
 {
 public:
-    TestLoggerConfig() : fly::LoggerConfig()
+    TestLoggerConfig() noexcept : fly::LoggerConfig()
     {
         m_defaultMaxLogFileSize = 1 << 10;
     }
@@ -37,7 +37,7 @@ public:
 class LoggerTest : public ::testing::Test
 {
 public:
-    LoggerTest() :
+    LoggerTest() noexcept :
         m_path(fly::PathUtil::GenerateTempDirectory()),
 
         m_spTaskManager(std::make_shared<fly::TaskManager>(1)),
@@ -58,7 +58,7 @@ public:
     /**
      * Create the file directory and start the task manager and logger.
      */
-    void SetUp() override
+    void SetUp() noexcept override
     {
         ASSERT_TRUE(std::filesystem::create_directories(m_path));
 
@@ -71,7 +71,7 @@ public:
     /**
      * Delete the created directory and stop the task manager.
      */
-    void TearDown() override
+    void TearDown() noexcept override
     {
         ASSERT_TRUE(m_spTaskManager->Stop());
 
@@ -89,7 +89,7 @@ protected:
      *
      * @return size_t Size of the log point.
      */
-    size_t LogSize(const std::string &message)
+    size_t LogSize(const std::string &message) noexcept
     {
         fly::Log log;
 
@@ -111,12 +111,6 @@ protected:
     std::shared_ptr<fly::LoggerConfig> m_spLoggerConfig;
     std::shared_ptr<fly::Logger> m_spLogger;
 };
-
-//==============================================================================
-TEST_F(LoggerTest, LoggerConfigTest)
-{
-    EXPECT_EQ(fly::LoggerConfig::GetName(), "logger");
-}
 
 //==============================================================================
 TEST_F(LoggerTest, FilePathTest)

--- a/test/mock/mock_system.cpp
+++ b/test/mock/mock_system.cpp
@@ -10,7 +10,7 @@ bool MockSystem::s_mockSystemEnabled = false;
 MockCalls MockSystem::s_mockedCalls;
 
 //==============================================================================
-MockSystem::MockSystem(MockCall mock) : m_mock(mock)
+MockSystem::MockSystem(MockCall mock) noexcept : m_mock(mock)
 {
     std::lock_guard<std::mutex> lock(s_mockSystemMutex);
 
@@ -18,7 +18,7 @@ MockSystem::MockSystem(MockCall mock) : m_mock(mock)
     s_mockSystemEnabled = true;
 }
 //==============================================================================
-MockSystem::MockSystem(MockCall mock, bool fail) : m_mock(mock)
+MockSystem::MockSystem(MockCall mock, bool fail) noexcept : m_mock(mock)
 {
     std::lock_guard<std::mutex> lock(s_mockSystemMutex);
 
@@ -42,14 +42,14 @@ MockSystem::~MockSystem()
 }
 
 //==============================================================================
-bool MockSystem::MockEnabled(MockCall mock)
+bool MockSystem::MockEnabled(MockCall mock) noexcept
 {
     bool fail;
     return MockEnabled(mock, fail);
 }
 
 //==============================================================================
-bool MockSystem::MockEnabled(MockCall mock, bool &fail)
+bool MockSystem::MockEnabled(MockCall mock, bool &fail) noexcept
 {
     std::lock_guard<std::mutex> lock(s_mockSystemMutex);
 

--- a/test/mock/mock_system.h
+++ b/test/mock/mock_system.h
@@ -36,7 +36,7 @@ public:
      *
      * @param MockCall Mocked system call to enable.
      */
-    MockSystem(MockCall);
+    MockSystem(MockCall) noexcept;
 
     /**
      * Enable a mocked system call, specifying whether the call should fail.
@@ -44,7 +44,7 @@ public:
      * @param MockCall Mocked system call to enable.
      * @param bool Whether the system call should fail.
      */
-    MockSystem(MockCall, bool);
+    MockSystem(MockCall, bool) noexcept;
 
     /**
      * Disable the mocked system call.
@@ -58,7 +58,7 @@ public:
      *
      * @return bool True if the mocked system call is enabled.
      */
-    static bool MockEnabled(MockCall);
+    static bool MockEnabled(MockCall) noexcept;
 
     /**
      * Check if a mocked system call is enabled.
@@ -68,7 +68,7 @@ public:
      *
      * @return bool True if the mocked system call is enabled.
      */
-    static bool MockEnabled(MockCall, bool &);
+    static bool MockEnabled(MockCall, bool &) noexcept;
 
 private:
     static std::mutex s_mockSystemMutex;

--- a/test/mock/nix/mock_calls.h
+++ b/test/mock/nix/mock_calls.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <iostream>
 #include <string>
 
@@ -8,7 +9,7 @@ namespace fly {
 /**
  * Enumerated list of mocked system calls.
  */
-enum class MockCall : unsigned int
+enum class MockCall : std::uint8_t
 {
     Accept,
     Bind,

--- a/test/parser/ini_parser.cpp
+++ b/test/parser/ini_parser.cpp
@@ -11,7 +11,7 @@
 class IniParserTest : public ::testing::Test
 {
 public:
-    IniParserTest() : m_spParser(std::make_shared<fly::IniParser>())
+    IniParserTest() noexcept : m_spParser(std::make_shared<fly::IniParser>())
     {
     }
 

--- a/test/parser/json_parser.cpp
+++ b/test/parser/json_parser.cpp
@@ -15,23 +15,24 @@
 class JsonParserTest : public ::testing::Test
 {
 public:
-    JsonParserTest() : m_spParser(std::make_shared<fly::JsonParser>())
+    JsonParserTest() noexcept : m_spParser(std::make_shared<fly::JsonParser>())
     {
     }
 
 protected:
-    void ValidateFail(const std::string &test)
+    void ValidateFail(const std::string &test) noexcept
     {
         ValidateFailRaw(fly::String::Format("{ \"a\" : %s }", test));
     }
 
-    void ValidateFailRaw(const std::string &test)
+    void ValidateFailRaw(const std::string &test) noexcept
     {
         SCOPED_TRACE(test);
         EXPECT_THROW(m_spParser->ParseString(test), fly::ParserException);
     }
 
-    void ValidatePass(const std::string &test, const fly::Json &expected)
+    void
+    ValidatePass(const std::string &test, const fly::Json &expected) noexcept
     {
         ValidatePassRaw(
             fly::String::Format("{ \"a\" : %s }", test), "a", expected);
@@ -40,7 +41,7 @@ protected:
     void ValidatePassRaw(
         const std::string &test,
         const std::string &key,
-        const fly::Json &expected)
+        const fly::Json &expected) noexcept
     {
         fly::Json actual, repeat;
 

--- a/test/parser/parser.cpp
+++ b/test/parser/parser.cpp
@@ -15,7 +15,7 @@ namespace {
 class EofParser : public fly::Parser
 {
 public:
-    void CompareParsed(std::vector<int> chars) const
+    void CompareParsed(std::vector<int> chars) const noexcept
     {
         EXPECT_EQ(m_chars, chars);
     }
@@ -56,7 +56,7 @@ private:
 class ParserTest : public ::testing::Test
 {
 public:
-    ParserTest() : m_spParser(std::make_shared<EofParser>())
+    ParserTest() noexcept : m_spParser(std::make_shared<EofParser>())
     {
     }
 

--- a/test/path/path_monitor.cpp
+++ b/test/path/path_monitor.cpp
@@ -33,7 +33,7 @@ std::chrono::seconds s_waitTime(5);
 class TestPathConfig : public fly::PathConfig
 {
 public:
-    TestPathConfig() : fly::PathConfig()
+    TestPathConfig() noexcept : fly::PathConfig()
     {
         m_defaultPollInterval = I64(10);
     }
@@ -45,7 +45,7 @@ public:
 class PathMonitorTest : public ::testing::Test
 {
 public:
-    PathMonitorTest() :
+    PathMonitorTest() noexcept :
         m_spTaskManager(std::make_shared<fly::TaskManager>(1)),
 
         m_spTaskRunner(
@@ -75,7 +75,7 @@ public:
     /**
      * Create and start the task manager and path monitor.
      */
-    void SetUp() override
+    void SetUp() noexcept override
     {
         ASSERT_TRUE(std::filesystem::create_directories(m_path0));
         ASSERT_TRUE(std::filesystem::create_directories(m_path1));
@@ -96,7 +96,7 @@ public:
     /**
      * Stop the task manager and delete the created directory.
      */
-    void TearDown() override
+    void TearDown() noexcept override
     {
         ASSERT_TRUE(m_spTaskManager->Stop());
 
@@ -116,7 +116,7 @@ protected:
      */
     void HandleEvent(
         const std::filesystem::path &path,
-        fly::PathMonitor::PathEvent event)
+        fly::PathMonitor::PathEvent event) noexcept
     {
         switch (event)
         {
@@ -137,7 +137,7 @@ protected:
                 break;
         }
 
-        m_eventQueue.Push(event);
+        m_eventQueue.Push(std::move(event));
     }
 
     std::shared_ptr<fly::TaskManager> m_spTaskManager;
@@ -162,12 +162,6 @@ protected:
     std::map<std::filesystem::path, unsigned int> m_numChangedFiles;
     std::map<std::filesystem::path, unsigned int> m_numOtherEvents;
 };
-
-//==============================================================================
-TEST_F(PathMonitorTest, PathConfigTest)
-{
-    EXPECT_EQ(fly::PathConfig::GetName(), "path");
-}
 
 //==============================================================================
 TEST_F(PathMonitorTest, PathEventStreamTest)

--- a/test/system/system_monitor.cpp
+++ b/test/system/system_monitor.cpp
@@ -27,7 +27,7 @@ namespace {
 class TestSystemConfig : public fly::SystemConfig
 {
 public:
-    TestSystemConfig() : fly::SystemConfig()
+    TestSystemConfig() noexcept : fly::SystemConfig()
     {
         m_defaultPollInterval = I64(100);
     }
@@ -39,7 +39,7 @@ public:
 class SystemMonitorTest : public ::testing::Test
 {
 public:
-    SystemMonitorTest() :
+    SystemMonitorTest() noexcept :
         m_spTaskManager(std::make_shared<fly::TaskManager>(1)),
 
         m_spTaskRunner(
@@ -57,7 +57,7 @@ public:
     /**
      * Start the task manager and system monitor.
      */
-    void SetUp() override
+    void SetUp() noexcept override
     {
         ASSERT_TRUE(m_spTaskManager->Start());
         ASSERT_TRUE(m_spMonitor->Start());
@@ -67,7 +67,7 @@ public:
     /**
      * Stop the task manager.
      */
-    void TearDown() override
+    void TearDown() noexcept override
     {
         ASSERT_TRUE(m_spTaskManager->Stop());
     }
@@ -75,7 +75,7 @@ public:
     /**
      * Thread to spin infinitely until signaled to stop.
      */
-    void SpinThread()
+    void SpinThread() noexcept
     {
         while (m_aKeepRunning.load())
         {
@@ -89,12 +89,6 @@ protected:
     std::shared_ptr<fly::SystemMonitor> m_spMonitor;
     std::atomic_bool m_aKeepRunning;
 };
-
-//==============================================================================
-TEST_F(SystemMonitorTest, SystemConfigTest)
-{
-    EXPECT_EQ(fly::SystemConfig::GetName(), "system");
-}
 
 //==============================================================================
 TEST_F(SystemMonitorTest, CpuUsageTest)

--- a/test/task/task.cpp
+++ b/test/task/task.cpp
@@ -16,17 +16,17 @@ namespace {
 class CountTask : public fly::Task
 {
 public:
-    CountTask() : m_count(0)
+    CountTask() noexcept : m_count(0)
     {
     }
 
-    int GetCount() const
+    int GetCount() const noexcept
     {
         return m_count.load();
     }
 
 protected:
-    void Run() override
+    void Run() noexcept override
     {
         ++m_count;
     }
@@ -39,16 +39,16 @@ private:
 class MarkerTask : public fly::Task
 {
 public:
-    MarkerTask(fly::ConcurrentQueue<int> *pOrdering, int marker) :
+    MarkerTask(fly::ConcurrentQueue<int> *pOrdering, int marker) noexcept :
         m_pOrdering(pOrdering),
         m_marker(marker)
     {
     }
 
 protected:
-    void Run() override
+    void Run() noexcept override
     {
-        m_pOrdering->Push(m_marker);
+        m_pOrdering->Push(std::move(m_marker));
     }
 
 private:
@@ -62,14 +62,14 @@ private:
 class TaskTest : public ::testing::Test
 {
 public:
-    TaskTest() : m_spTaskManager(std::make_shared<fly::TaskManager>(1))
+    TaskTest() noexcept : m_spTaskManager(std::make_shared<fly::TaskManager>(1))
     {
     }
 
     /**
      * Start the task manager.
      */
-    void SetUp() override
+    void SetUp() noexcept override
     {
         ASSERT_TRUE(m_spTaskManager->Start());
     }
@@ -77,7 +77,7 @@ public:
     /**
      * Stop the task manager.
      */
-    void TearDown() override
+    void TearDown() noexcept override
     {
         ASSERT_TRUE(m_spTaskManager->Stop());
     }

--- a/test/traits/traits.cpp
+++ b/test/traits/traits.cpp
@@ -16,16 +16,17 @@
 namespace {
 
 //==========================================================================
-DECLARATION_TESTS(foo, T, std::declval<const T &>().Foo());
+FLY_DECLARATION_TESTS(foo, T, std::declval<const T &>().Foo());
 
 //==========================================================================
 class FooClass
 {
 public:
-    FooClass()
+    FooClass() noexcept
     {
     }
-    bool Foo() const
+
+    bool Foo() const noexcept
     {
         return true;
     }
@@ -35,11 +36,11 @@ public:
 class BarClass
 {
 public:
-    BarClass()
+    BarClass() noexcept
     {
     }
 
-    std::string operator()() const
+    std::string operator()() const noexcept
     {
         return "BarClass";
     }
@@ -55,131 +56,131 @@ std::ostream &operator<<(std::ostream &stream, const BarClass &bar)
 
 //==========================================================================
 template <typename T, if_foo::enabled<T> = 0>
-bool callFoo(const T &arg)
+bool callFoo(const T &arg) noexcept
 {
     return arg.Foo();
 }
 
 template <typename T, if_foo::disabled<T> = 0>
-bool callFoo(const T &)
+bool callFoo(const T &) noexcept
 {
     return false;
 }
 
 //==========================================================================
 template <typename T, fly::if_string::enabled<T> = 0>
-bool isString(const T &)
+bool isString(const T &) noexcept
 {
     return true;
 }
 
 template <typename T, fly::if_string::disabled<T> = 0>
-bool isString(const T &)
+bool isString(const T &) noexcept
 {
     return false;
 }
 
 //==========================================================================
 template <typename T, fly::if_ostream::enabled<T> = 0>
-bool isStreamable(std::ostream &stream, const T &arg)
+bool isStreamable(std::ostream &stream, const T &arg) noexcept
 {
     stream << arg;
     return true;
 }
 
 template <typename T, fly::if_ostream::disabled<T> = 0>
-bool isStreamable(std::ostream &, const T &)
+bool isStreamable(std::ostream &, const T &) noexcept
 {
     return false;
 }
 
 //==========================================================================
 template <typename T, fly::if_signed_integer::enabled<T> = 0>
-bool isSignedInteger(const T &)
+bool isSignedInteger(const T &) noexcept
 {
     return true;
 }
 
 template <typename T, fly::if_signed_integer::disabled<T> = 0>
-bool isSignedInteger(const T &)
+bool isSignedInteger(const T &) noexcept
 {
     return false;
 }
 
 //==========================================================================
 template <typename T, fly::if_unsigned_integer::enabled<T> = 0>
-bool isUnsignedInteger(const T &)
+bool isUnsignedInteger(const T &) noexcept
 {
     return true;
 }
 
 template <typename T, fly::if_unsigned_integer::disabled<T> = 0>
-bool isUnsignedInteger(const T &)
+bool isUnsignedInteger(const T &) noexcept
 {
     return false;
 }
 
 //==========================================================================
 template <typename T, fly::if_floating_point::enabled<T> = 0>
-bool isFloat(const T &)
+bool isFloat(const T &) noexcept
 {
     return true;
 }
 
 template <typename T, fly::if_floating_point::disabled<T> = 0>
-bool isFloat(const T &)
+bool isFloat(const T &) noexcept
 {
     return false;
 }
 
 //==========================================================================
 template <typename T, fly::if_numeric::enabled<T> = 0>
-bool isNumeric(const T &)
+bool isNumeric(const T &) noexcept
 {
     return true;
 }
 
 template <typename T, fly::if_numeric::disabled<T> = 0>
-bool isNumeric(const T &)
+bool isNumeric(const T &) noexcept
 {
     return false;
 }
 
 //==========================================================================
 template <typename T, fly::if_boolean::enabled<T> = 0>
-bool isBool(const T &)
+bool isBool(const T &) noexcept
 {
     return true;
 }
 
 template <typename T, fly::if_boolean::disabled<T> = 0>
-bool isBool(const T &)
+bool isBool(const T &) noexcept
 {
     return false;
 }
 
 //==========================================================================
 template <typename T, fly::if_map::enabled<T> = 0>
-bool isMap(const T &)
+bool isMap(const T &) noexcept
 {
     return true;
 }
 
 template <typename T, fly::if_map::disabled<T> = 0>
-bool isMap(const T &)
+bool isMap(const T &) noexcept
 {
     return false;
 }
 
 //==========================================================================
 template <typename T, fly::if_array::enabled<T> = 0>
-bool isArray(const T &)
+bool isArray(const T &) noexcept
 {
     return true;
 }
 
 template <typename T, fly::if_array::disabled<T> = 0>
-bool isArray(const T &)
+bool isArray(const T &) noexcept
 {
     return false;
 }

--- a/test/types/concurrent_container.cpp
+++ b/test/types/concurrent_container.cpp
@@ -28,8 +28,9 @@ public:
         return numWrites;
     }
 
-    unsigned int
-    ReaderThread(ObjectQueue &objectQueue, std::atomic_bool &finishedWrites) noexcept
+    unsigned int ReaderThread(
+        ObjectQueue &objectQueue,
+        std::atomic_bool &finishedWrites) noexcept
     {
         unsigned int numReads = 0;
 
@@ -55,7 +56,9 @@ public:
     }
 
 protected:
-    void RunMultiThreadedTest(unsigned int numWriters, unsigned int numReaders) noexcept
+    void RunMultiThreadedTest(
+        unsigned int numWriters,
+        unsigned int numReaders) noexcept
     {
         ObjectQueue objectQueue;
 

--- a/test/types/concurrent_container.cpp
+++ b/test/types/concurrent_container.cpp
@@ -202,7 +202,7 @@ TEST_F(ConcurrencyTest, InfiniteWaitReaderTest)
     std::future_status status = future.wait_for(std::chrono::milliseconds(10));
     ASSERT_EQ(status, std::future_status::timeout);
 
-    objectQueue.Push(Object(obj));
+    objectQueue.Push(std::move(Object(obj)));
 
     status = future.wait_for(std::chrono::milliseconds(10));
     ASSERT_EQ(status, std::future_status::ready);

--- a/test/types/json.cpp
+++ b/test/types/json.cpp
@@ -42,7 +42,7 @@ const char *ConvertToUTF8(const wchar_t *str)
 class JsonTest : public ::testing::Test
 {
 protected:
-    void ValidateFail(const std::string &test)
+    void ValidateFail(const std::string &test) noexcept
     {
         SCOPED_TRACE(test);
 
@@ -51,12 +51,12 @@ protected:
         EXPECT_THROW({ actual = test; }, fly::JsonException);
     }
 
-    void ValidatePass(const std::string &test)
+    void ValidatePass(const std::string &test) noexcept
     {
         ValidatePass(test, test);
     }
 
-    void ValidatePass(const std::string &test, const std::string &expected)
+    void ValidatePass(const std::string &test, const std::string &expected) noexcept
     {
         SCOPED_TRACE(test);
 

--- a/test/types/json.cpp
+++ b/test/types/json.cpp
@@ -56,7 +56,8 @@ protected:
         ValidatePass(test, test);
     }
 
-    void ValidatePass(const std::string &test, const std::string &expected) noexcept
+    void
+    ValidatePass(const std::string &test, const std::string &expected) noexcept
     {
         SCOPED_TRACE(test);
 

--- a/test/types/string.cpp
+++ b/test/types/string.cpp
@@ -12,20 +12,21 @@ namespace {
 class Base
 {
 public:
-    Base(const std::string &str, int num) : m_str(str), m_num(num)
+    Base(const std::string &str, int num) noexcept : m_str(str), m_num(num)
     {
     }
 
-    std::string GetStr() const
+    std::string GetStr() const noexcept
     {
         return m_str;
     };
-    int GetNum() const
+
+    int GetNum() const noexcept
     {
         return m_num;
     };
 
-    size_t Hash() const
+    size_t Hash() const noexcept
     {
         static std::hash<std::string> strHasher;
         static std::hash<int> numHasher;
@@ -47,7 +48,7 @@ private:
 class Hashable : public Base
 {
 public:
-    Hashable(const std::string &str, int num) : Base(str, num)
+    Hashable(const std::string &str, int num) noexcept : Base(str, num)
     {
     }
 };
@@ -56,7 +57,7 @@ public:
 class Streamable : public Base
 {
 public:
-    Streamable(const std::string &str, int num) : Base(str, num)
+    Streamable(const std::string &str, int num) noexcept : Base(str, num)
     {
     }
 
@@ -72,18 +73,19 @@ std::ostream &operator<<(std::ostream &stream, const Streamable &obj)
     return stream;
 }
 
+//==========================================================================
 class HashableAndStreamable : public Base
 {
 public:
-    HashableAndStreamable(const std::string &str, int num) : Base(str, num)
+    HashableAndStreamable(const std::string &str, int num) noexcept : Base(str, num)
     {
     }
 
     friend std::ostream &
-    operator<<(std::ostream &, const HashableAndStreamable &);
+    operator<<(std::ostream &, const HashableAndStreamable &) noexcept;
 };
 
-std::ostream &operator<<(std::ostream &stream, const HashableAndStreamable &obj)
+std::ostream &operator<<(std::ostream &stream, const HashableAndStreamable &obj) noexcept
 {
     stream << '[';
     stream << obj.GetStr() << ' ' << std::hex << obj.GetNum() << std::dec;
@@ -94,7 +96,7 @@ std::ostream &operator<<(std::ostream &stream, const HashableAndStreamable &obj)
 
 //==========================================================================
 template <typename T>
-std::string min_to_string()
+std::string min_to_string() noexcept
 {
     long long min = std::numeric_limits<T>::min();
     return std::to_string(min - 1);
@@ -102,7 +104,7 @@ std::string min_to_string()
 
 //==========================================================================
 template <typename T>
-std::string max_to_string()
+std::string max_to_string() noexcept
 {
     unsigned long long max = std::numeric_limits<T>::max();
     return std::to_string(max + 1);
@@ -116,7 +118,7 @@ namespace std {
 template <>
 struct hash<Hashable *>
 {
-    size_t operator()(const Hashable *value) const
+    size_t operator()(const Hashable *value) const noexcept
     {
         return value->Hash();
     }
@@ -125,7 +127,7 @@ struct hash<Hashable *>
 template <>
 struct hash<HashableAndStreamable *>
 {
-    size_t operator()(const HashableAndStreamable *value) const
+    size_t operator()(const HashableAndStreamable *value) const noexcept
     {
         return value->Hash();
     }

--- a/test/types/string.cpp
+++ b/test/types/string.cpp
@@ -77,7 +77,8 @@ std::ostream &operator<<(std::ostream &stream, const Streamable &obj)
 class HashableAndStreamable : public Base
 {
 public:
-    HashableAndStreamable(const std::string &str, int num) noexcept : Base(str, num)
+    HashableAndStreamable(const std::string &str, int num) noexcept :
+        Base(str, num)
     {
     }
 
@@ -85,7 +86,8 @@ public:
     operator<<(std::ostream &, const HashableAndStreamable &) noexcept;
 };
 
-std::ostream &operator<<(std::ostream &stream, const HashableAndStreamable &obj) noexcept
+std::ostream &
+operator<<(std::ostream &stream, const HashableAndStreamable &obj) noexcept
 {
     stream << '[';
     stream << obj.GetStr() << ' ' << std::hex << obj.GetNum() << std::dec;

--- a/test/util/capture_stream.cpp
+++ b/test/util/capture_stream.cpp
@@ -21,7 +21,7 @@
 namespace fly {
 
 //==============================================================================
-CaptureStream::CaptureStream(Stream stream) :
+CaptureStream::CaptureStream(Stream stream) noexcept :
     m_path(fly::PathUtil::GenerateTempDirectory()),
     m_stdio(-1),
     m_original(-1)
@@ -63,13 +63,13 @@ CaptureStream::~CaptureStream()
 }
 
 //==============================================================================
-std::string CaptureStream::operator()()
+std::string CaptureStream::operator()() noexcept
 {
     return restore(true);
 }
 
 //==============================================================================
-std::string CaptureStream::restore(bool read)
+std::string CaptureStream::restore(bool read) noexcept
 {
     std::string contents;
 

--- a/test/util/capture_stream.h
+++ b/test/util/capture_stream.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <filesystem>
 #include <string>
 
@@ -16,7 +17,7 @@ namespace fly {
 class CaptureStream
 {
 public:
-    enum class Stream
+    enum class Stream : std::uint8_t
     {
         Stdout,
         Stderr
@@ -27,7 +28,7 @@ public:
      *
      * @param Stream The standard stream to redirect.
      */
-    CaptureStream(Stream);
+    CaptureStream(Stream) noexcept;
 
     /**
      * Destructor. Restore the redirected stream and delete the redirect file.
@@ -40,7 +41,7 @@ public:
      *
      * @return string The contents of the redirected stream.
      */
-    std::string operator()();
+    std::string operator()() noexcept;
 
 private:
     /**
@@ -51,7 +52,7 @@ private:
      *
      * @return string The contents of the redirected stream.
      */
-    std::string restore(bool);
+    std::string restore(bool) noexcept;
 
     std::filesystem::path m_path;
 

--- a/test/util/path_util.cpp
+++ b/test/util/path_util.cpp
@@ -10,7 +10,7 @@
 namespace fly {
 
 //==============================================================================
-std::filesystem::path PathUtil::GenerateTempDirectory()
+std::filesystem::path PathUtil::GenerateTempDirectory() noexcept
 {
     return std::filesystem::temp_directory_path() /
         fly::String::GenerateRandomString(10);
@@ -19,7 +19,7 @@ std::filesystem::path PathUtil::GenerateTempDirectory()
 //==============================================================================
 bool PathUtil::WriteFile(
     const std::filesystem::path &path,
-    const std::string &contents)
+    const std::string &contents) noexcept
 {
     std::ofstream stream(path, std::ios::out);
 
@@ -32,7 +32,7 @@ bool PathUtil::WriteFile(
 }
 
 //==============================================================================
-std::string PathUtil::ReadFile(const std::filesystem::path &path)
+std::string PathUtil::ReadFile(const std::filesystem::path &path) noexcept
 {
     std::ifstream stream(path, std::ios::in);
     std::stringstream sstream;

--- a/test/util/path_util.h
+++ b/test/util/path_util.h
@@ -31,7 +31,8 @@ public:
      *
      * @return bool True if the file was correctly created.
      */
-    static bool WriteFile(const std::filesystem::path &, const std::string &) noexcept;
+    static bool
+    WriteFile(const std::filesystem::path &, const std::string &) noexcept;
 
     /**
      * Read the contents of a file.

--- a/test/util/path_util.h
+++ b/test/util/path_util.h
@@ -20,7 +20,7 @@ public:
      *
      * @param The random directory path.
      */
-    static std::filesystem::path GenerateTempDirectory();
+    static std::filesystem::path GenerateTempDirectory() noexcept;
 
     /**
      * Create a file with the given contents, verifying the file was correctly
@@ -31,7 +31,7 @@ public:
      *
      * @return bool True if the file was correctly created.
      */
-    static bool WriteFile(const std::filesystem::path &, const std::string &);
+    static bool WriteFile(const std::filesystem::path &, const std::string &) noexcept;
 
     /**
      * Read the contents of a file.
@@ -40,7 +40,7 @@ public:
      *
      * @return string Contents of the file.
      */
-    static std::string ReadFile(const std::filesystem::path &);
+    static std::string ReadFile(const std::filesystem::path &) noexcept;
 };
 
 } // namespace fly

--- a/test/util/waitable_task_runner.cpp
+++ b/test/util/waitable_task_runner.cpp
@@ -6,7 +6,8 @@
 namespace fly {
 
 //==============================================================================
-void WaitableTaskRunner::TaskComplete(const std::shared_ptr<Task> &spTask)
+void WaitableTaskRunner::TaskComplete(
+    const std::shared_ptr<Task> &spTask) noexcept
 {
     if (spTask)
     {
@@ -17,14 +18,14 @@ void WaitableTaskRunner::TaskComplete(const std::shared_ptr<Task> &spTask)
 
 //==============================================================================
 WaitableParallelTaskRunner::WaitableParallelTaskRunner(
-    const std::weak_ptr<TaskManager> &wpTaskManager) :
+    std::weak_ptr<TaskManager> wpTaskManager) noexcept :
     ParallelTaskRunner(wpTaskManager)
 {
 }
 
 //==============================================================================
 void WaitableParallelTaskRunner::TaskComplete(
-    const std::shared_ptr<Task> &spTask)
+    const std::shared_ptr<Task> &spTask) noexcept
 {
     ParallelTaskRunner::TaskComplete(spTask);
     WaitableTaskRunner::TaskComplete(spTask);
@@ -32,14 +33,14 @@ void WaitableParallelTaskRunner::TaskComplete(
 
 //==============================================================================
 WaitableSequencedTaskRunner::WaitableSequencedTaskRunner(
-    const std::weak_ptr<TaskManager> &wpTaskManager) :
+    std::weak_ptr<TaskManager> wpTaskManager) noexcept :
     SequencedTaskRunner(wpTaskManager)
 {
 }
 
 //==============================================================================
 void WaitableSequencedTaskRunner::TaskComplete(
-    const std::shared_ptr<Task> &spTask)
+    const std::shared_ptr<Task> &spTask) noexcept
 {
     SequencedTaskRunner::TaskComplete(spTask);
     WaitableTaskRunner::TaskComplete(spTask);

--- a/test/util/waitable_task_runner.h
+++ b/test/util/waitable_task_runner.h
@@ -35,7 +35,7 @@ public:
      * @tparam TaskType The task subclass to wait on.
      */
     template <typename TaskType>
-    void WaitForTaskTypeToComplete();
+    void WaitForTaskTypeToComplete() noexcept;
 
     /**
      * Wait for a specific task type to complete execution.
@@ -47,7 +47,7 @@ public:
      * @return bool True if a completed task was found in the given duration.
      */
     template <typename TaskType, typename R, typename P>
-    bool WaitForTaskTypeToComplete(std::chrono::duration<R, P>);
+    bool WaitForTaskTypeToComplete(std::chrono::duration<R, P>) noexcept;
 
 protected:
     /**
@@ -55,7 +55,7 @@ protected:
      *
      * @param Task The (possibly NULL) task that was executed or skipped.
      */
-    virtual void TaskComplete(const std::shared_ptr<Task> &) = 0;
+    virtual void TaskComplete(const std::shared_ptr<Task> &) noexcept = 0;
 
 private:
     ConcurrentQueue<size_t> m_completedTasks;
@@ -76,7 +76,7 @@ class WaitableParallelTaskRunner :
     friend class TaskManager;
 
 protected:
-    WaitableParallelTaskRunner(const std::weak_ptr<TaskManager> &);
+    WaitableParallelTaskRunner(std::weak_ptr<TaskManager>) noexcept;
 
     /**
      * When a task is complete, perform the same operations as this runner's
@@ -84,7 +84,7 @@ protected:
      *
      * @param Task The (possibly NULL) task that was executed or skipped.
      */
-    void TaskComplete(const std::shared_ptr<Task> &) override;
+    void TaskComplete(const std::shared_ptr<Task> &) noexcept override;
 };
 
 /**
@@ -102,7 +102,7 @@ class WaitableSequencedTaskRunner :
     friend class TaskManager;
 
 protected:
-    WaitableSequencedTaskRunner(const std::weak_ptr<TaskManager> &);
+    WaitableSequencedTaskRunner(std::weak_ptr<TaskManager>) noexcept;
 
     /**
      * When a task is complete, perform the same operations as this runner's
@@ -110,12 +110,12 @@ protected:
      *
      * @param Task The (possibly NULL) task that was executed or skipped.
      */
-    void TaskComplete(const std::shared_ptr<Task> &) override;
+    void TaskComplete(const std::shared_ptr<Task> &) noexcept override;
 };
 
 //==============================================================================
 template <typename TaskType>
-void WaitableTaskRunner::WaitForTaskTypeToComplete()
+void WaitableTaskRunner::WaitForTaskTypeToComplete() noexcept
 {
     static_assert(
         std::is_base_of<Task, TaskType>::value, "Given type is not a task");
@@ -132,7 +132,7 @@ void WaitableTaskRunner::WaitForTaskTypeToComplete()
 //==============================================================================
 template <typename TaskType, typename R, typename P>
 bool WaitableTaskRunner::WaitForTaskTypeToComplete(
-    std::chrono::duration<R, P> duration)
+    std::chrono::duration<R, P> duration) noexcept
 {
     static_assert(
         std::is_base_of<Task, TaskType>::value, "Given type is not a task");


### PR DESCRIPTION
fly::ConcurrentContainer now only supports moving items onto the container,
rather than copying. Further, when making asynchronous socket sends, the message
is moved and not copied.

Also some minor refactoring to fly::Config - use a constexpr string for an
identifier, and make constructor/GetValue/Update methods protected.

Make sure all enum classes use minimum storage type.

Cleanup traits to use new std::*_v value helpers.