### PR TITLE
Replace FLY_DECLARATION_TESTS with DeclarationTraits

### DIFF
--- a/fly/traits/traits.h
+++ b/fly/traits/traits.h
@@ -2,12 +2,6 @@
 
 #include <type_traits>
 
-/**
- * Wrappers around std::enable_if for testing variadic sequences of traits.
- *
- * @author Timothy Flynn (trflynn89@gmail.com)
- * @version July 28, 2017
- */
 namespace fly {
 
 /**
@@ -69,7 +63,7 @@ using enable_if_not_all =
  *     template <typename T>
  *     using FooDeclaration = decltype(std::declval<T>().Foo());
  *
- * Then use that alias to create a fly::Declaration alias:
+ * Then use that alias to create a fly::DeclarationTraits alias:
  *
  *     using FooTraits = fly::DeclarationTraits<FooDeclaration>;
  *
@@ -93,6 +87,17 @@ using enable_if_not_all =
  *         typename T,
  *         fly::enable_if_not_all<FooTraits::is_declared<T>> = 0>
  *     void foo_wrapper(const T &) { }
+ *
+ * Or in a constexpr-if expression:
+ *
+ *     template <typename T>
+ *     void foo_wrapper(const T &)
+ *     {
+ *         if constexpr (FooTraits::is_declared_v<T>)
+ *         {
+ *             arg.Foo();
+ *         }
+ *      }
  *
  * @tparam Declaration The decltype alias to test.
  * @tparam T The type to be tested.

--- a/fly/traits/traits.h
+++ b/fly/traits/traits.h
@@ -3,60 +3,6 @@
 #include <type_traits>
 
 /**
- * Define SFINAE tests for whether a function is declared for a type.
- *
- * For example, to test if a class of type T declares a function called Foo:
- *
- *     FLY_DECLARATION_TESTS(Foo, T, std::declval<const T &>().Foo());
- *
- * The macro invocation will define the following std::bool_constant<> (and
- * convenience constexpr bool):
- *
- *     template <typename T>
- *     struct FooTraits::is_declared<T>;
- *
- *     template <typename T>
- *     inline constexpr bool FooTraits::is_declared_v = is_declared<T>::value;
- *
- * And may be used as SFINAE tests to, e.g., define a function depending on
- * whether or not Foo() was declared:
- *
- *     template <
- *         typename T,
- *         fly::enable_if_all<FooTraits::is_declared<T>> = 0>
- *     void foo_wrapper(const T &arg) { arg.Foo(); }
- *
- *     template <
- *         typename T,
- *         fly::enable_if_not_all<FooTraits::is_declared<T>> = 0>
- *     void foo_wrapper(const T &) { }
- *
- * @param Label The name to give the test.
- * @param Type The type to be tested.
- * @param functor The function to test for.
- */
-#define FLY_DECLARATION_TESTS(Label, Type, functor)                            \
-    struct Label##Traits                                                       \
-    {                                                                          \
-        struct __##Label##__                                                   \
-        {                                                                      \
-            template <typename Type>                                           \
-            static constexpr auto test_##Label(Type *) -> decltype(functor);   \
-                                                                               \
-            template <typename Type>                                           \
-            static constexpr auto test_##Label(...) -> std::false_type;        \
-        };                                                                     \
-                                                                               \
-        template <typename Type>                                               \
-        using is_declared = std::negation<std::is_same<                        \
-            decltype(__##Label##__::test_##Label<Type>(0)),                    \
-            std::false_type>>;                                                 \
-                                                                               \
-        template <typename Type>                                               \
-        inline static constexpr bool is_declared_v = is_declared<Type>::value; \
-    };
-
-/**
  * Wrappers around std::enable_if for testing variadic sequences of traits.
  *
  * @author Timothy Flynn (trflynn89@gmail.com)
@@ -113,5 +59,64 @@ using enable_if_none =
 template <typename... Conditions>
 using enable_if_not_all =
     std::enable_if_t<std::negation_v<std::conjunction<Conditions...>>, bool>;
+
+/**
+ * Define SFINAE tests for whether a function is declared for a type.
+ *
+ * For example, to test if a class of type T declares a method called Foo, first
+ * define a templated decltype alias for the method:
+ *
+ *     template <typename T>
+ *     using FooDeclaration = decltype(std::declval<T>().Foo());
+ *
+ * Then use that alias to create a fly::Declaration alias:
+ *
+ *     using FooTraits = fly::DeclarationTraits<FooDeclaration>;
+ *
+ * This provides the following std::bool_constant<> (and constexpr bool):
+ *
+ *     template <typename T>
+ *     struct FooTraits::is_declared<T>;
+ *
+ *     template <typename T>
+ *     inline constexpr bool FooTraits::is_declared_v = is_declared<T>::value;
+ *
+ * Which may be used as SFINAE tests to, e.g., define a function depending on
+ * whether or not Foo() is declared for a type:
+ *
+ *     template <
+ *         typename T,
+ *         fly::enable_if_all<FooTraits::is_declared<T>> = 0>
+ *     void foo_wrapper(const T &arg) { arg.Foo(); }
+ *
+ *     template <
+ *         typename T,
+ *         fly::enable_if_not_all<FooTraits::is_declared<T>> = 0>
+ *     void foo_wrapper(const T &) { }
+ *
+ * @tparam Declaration The decltype alias to test.
+ * @tparam T The type to be tested.
+ */
+template <template <typename> class Declaration>
+struct DeclarationTraits
+{
+private:
+    struct __test__
+    {
+        template <typename T>
+        static constexpr auto test(T *) -> Declaration<T>;
+
+        template <typename T>
+        static constexpr auto test(...) -> std::false_type;
+    };
+
+public:
+    template <typename T>
+    using is_declared = std::negation<
+        std::is_same<decltype(__test__::template test<T>(0)), std::false_type>>;
+
+    template <typename T>
+    inline static constexpr bool is_declared_v = is_declared<T>::value;
+};
 
 } // namespace fly

--- a/fly/types/string.h
+++ b/fly/types/string.h
@@ -697,9 +697,13 @@ void BasicString<StringType>::stream(
     {
         BasicStringStreamer<StringType>::Stream(ostream, value);
     }
-    else
+    else if constexpr (traits::OstreamTraits::template is_declared_v<T>)
     {
         ostream << std::boolalpha << value;
+    }
+    else
+    {
+        ostream << '[' << std::hex << &value << std::dec << ']';
     }
 }
 

--- a/fly/types/string_traits.h
+++ b/fly/types/string_traits.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "fly/traits/traits.h"
 #include "fly/types/string_streamer.h"
 
 #include <string>
@@ -69,6 +70,16 @@ struct BasicStringTraits
         std::is_same_v<base_string_type, std::wstring>>;
 
     inline static constexpr bool has_stoi_family_v = has_stoi_family::value;
+
+    /**
+     * Define a trait for whether operator<< is defined for a type on the stream
+     * type used for StringType.
+     */
+    template <typename T>
+    using OstreamDeclaration =
+        decltype(std::declval<ostream_type &>() << std::declval<T>());
+
+    using OstreamTraits = DeclarationTraits<OstreamDeclaration>;
 };
 
 } // namespace fly

--- a/test/traits/traits.cpp
+++ b/test/traits/traits.cpp
@@ -7,13 +7,17 @@
 namespace {
 
 //==========================================================================
-FLY_DECLARATION_TESTS(Foo, T, std::declval<const T &>().Foo());
+template <typename T>
+using OstreamDeclaration =
+    decltype(std::declval<std::ostream &>() << std::declval<T>());
+
+using OstreamTraits = fly::DeclarationTraits<OstreamDeclaration>;
 
 //==========================================================================
-FLY_DECLARATION_TESTS(
-    Ostream,
-    T,
-    std::declval<std::ostream &>() << std::declval<const T &>());
+template <typename T>
+using FooDeclaration = decltype(std::declval<T>().Foo());
+
+using FooTraits = fly::DeclarationTraits<FooDeclaration>;
 
 //==========================================================================
 class FooClass

--- a/test/types/string.cpp
+++ b/test/types/string.cpp
@@ -13,8 +13,8 @@ template <typename StringType>
 class Streamable
 {
 public:
-    using char_type = typename StringType::value_type;
-    using ostream_type = std::basic_ostream<char_type>;
+    using ostream_type = typename fly::BasicStringTraits<
+        StringType>::streamer_type::ostream_type;
 
     Streamable(const StringType &str, int num) noexcept : m_str(str), m_num(num)
     {
@@ -42,6 +42,11 @@ public:
 private:
     StringType m_str;
     int m_num;
+};
+
+//==============================================================================
+class NotStreamable
+{
 };
 
 //==============================================================================
@@ -95,7 +100,8 @@ TYPED_TEST(BasicStringTest, SplitTest)
 {
     using string_type = typename TestFixture::string_type;
     using StringClass = fly::BasicString<string_type>;
-    using char_type = typename fly::BasicStringTraits<string_type>::char_type;
+    using traits = typename fly::BasicStringTraits<string_type>;
+    using char_type = typename traits::char_type;
 
     static constexpr std::uint32_t numSectors = 10;
     std::vector<string_type> inputSplit(numSectors);
@@ -125,7 +131,8 @@ TYPED_TEST(BasicStringTest, MaxSplitTest)
 {
     using string_type = typename TestFixture::string_type;
     using StringClass = fly::BasicString<string_type>;
-    using char_type = typename fly::BasicStringTraits<string_type>::char_type;
+    using traits = typename fly::BasicStringTraits<string_type>;
+    using char_type = typename traits::char_type;
 
     static constexpr std::uint32_t numSectors = 10;
     static constexpr std::uint32_t maxSectors = 6;
@@ -164,7 +171,8 @@ TYPED_TEST(BasicStringTest, TrimTest)
 {
     using string_type = typename TestFixture::string_type;
     using StringClass = fly::BasicString<string_type>;
-    using char_type = typename fly::BasicStringTraits<string_type>::char_type;
+    using traits = typename fly::BasicStringTraits<string_type>;
+    using char_type = typename traits::char_type;
 
     string_type test1;
     string_type test2 = FLY_STR(char_type, "   abc");
@@ -201,7 +209,8 @@ TYPED_TEST(BasicStringTest, ReplaceAllTest)
 {
     using string_type = typename TestFixture::string_type;
     using StringClass = fly::BasicString<string_type>;
-    using char_type = typename fly::BasicStringTraits<string_type>::char_type;
+    using traits = typename fly::BasicStringTraits<string_type>;
+    using char_type = typename traits::char_type;
 
     string_type source = FLY_STR(char_type, "To Be Replaced! To Be Replaced!");
     const string_type search = FLY_STR(char_type, "Be Replaced");
@@ -216,7 +225,8 @@ TYPED_TEST(BasicStringTest, ReplaceAllWithCharTest)
 {
     using string_type = typename TestFixture::string_type;
     using StringClass = fly::BasicString<string_type>;
-    using char_type = typename fly::BasicStringTraits<string_type>::char_type;
+    using traits = typename fly::BasicStringTraits<string_type>;
+    using char_type = typename traits::char_type;
 
     string_type source = FLY_STR(char_type, "To Be Replaced! To Be Replaced!");
     const string_type search = FLY_STR(char_type, "Be Replaced");
@@ -231,7 +241,8 @@ TYPED_TEST(BasicStringTest, ReplaceAllWithEmptyTest)
 {
     using string_type = typename TestFixture::string_type;
     using StringClass = fly::BasicString<string_type>;
-    using char_type = typename fly::BasicStringTraits<string_type>::char_type;
+    using traits = typename fly::BasicStringTraits<string_type>;
+    using char_type = typename traits::char_type;
 
     string_type source = FLY_STR(char_type, "To Be Replaced! To Be Replaced!");
     const string_type replace = FLY_STR(char_type, "new value");
@@ -245,7 +256,8 @@ TYPED_TEST(BasicStringTest, RemoveAllTest)
 {
     using string_type = typename TestFixture::string_type;
     using StringClass = fly::BasicString<string_type>;
-    using char_type = typename fly::BasicStringTraits<string_type>::char_type;
+    using traits = typename fly::BasicStringTraits<string_type>;
+    using char_type = typename traits::char_type;
 
     string_type source = FLY_STR(char_type, "To Be Replaced! To Be Replaced!");
     const string_type search = FLY_STR(char_type, "Be Rep");
@@ -259,7 +271,8 @@ TYPED_TEST(BasicStringTest, RemoveAllWithEmptyTest)
 {
     using string_type = typename TestFixture::string_type;
     using StringClass = fly::BasicString<string_type>;
-    using char_type = typename fly::BasicStringTraits<string_type>::char_type;
+    using traits = typename fly::BasicStringTraits<string_type>;
+    using char_type = typename traits::char_type;
 
     string_type source = FLY_STR(char_type, "To Be Replaced! To Be Replaced!");
 
@@ -272,7 +285,8 @@ TYPED_TEST(BasicStringTest, StartsWithTest)
 {
     using string_type = typename TestFixture::string_type;
     using StringClass = fly::BasicString<string_type>;
-    using char_type = typename fly::BasicStringTraits<string_type>::char_type;
+    using traits = typename fly::BasicStringTraits<string_type>;
+    using char_type = typename traits::char_type;
 
     string_type test1, test2;
 
@@ -327,7 +341,8 @@ TYPED_TEST(BasicStringTest, EndsWithTest)
 {
     using string_type = typename TestFixture::string_type;
     using StringClass = fly::BasicString<string_type>;
-    using char_type = typename fly::BasicStringTraits<string_type>::char_type;
+    using traits = typename fly::BasicStringTraits<string_type>;
+    using char_type = typename traits::char_type;
 
     string_type test1, test2;
 
@@ -379,7 +394,8 @@ TYPED_TEST(BasicStringTest, WildcardTest)
 {
     using string_type = typename TestFixture::string_type;
     using StringClass = fly::BasicString<string_type>;
-    using char_type = typename fly::BasicStringTraits<string_type>::char_type;
+    using traits = typename fly::BasicStringTraits<string_type>;
+    using char_type = typename traits::char_type;
 
     string_type test1, test2;
 
@@ -482,12 +498,11 @@ TYPED_TEST(BasicStringTest, FormatTest)
 {
     using string_type = typename TestFixture::string_type;
     using StringClass = fly::BasicString<string_type>;
-    using char_type = typename fly::BasicStringTraits<string_type>::char_type;
+    using traits = typename fly::BasicStringTraits<string_type>;
+    using char_type = typename traits::char_type;
 
-    using streamed_type =
-        typename fly::BasicStringStreamer<string_type>::streamed_type;
-    using streamed_char =
-        typename fly::BasicStringTraits<streamed_type>::char_type;
+    using streamed_type = typename traits::streamer_type::streamed_type;
+    using streamed_char = typename streamed_type::value_type;
 
     streamed_type expected;
     const char_type *format;
@@ -534,20 +549,19 @@ TYPED_TEST(BasicStringTest, JoinTest)
 {
     using string_type = typename TestFixture::string_type;
     using StringClass = fly::BasicString<string_type>;
-    using char_type = typename fly::BasicStringTraits<string_type>::char_type;
+    using traits = typename fly::BasicStringTraits<string_type>;
+    using char_type = typename traits::char_type;
 
-    using streamed_type =
-        typename fly::BasicStringStreamer<string_type>::streamed_type;
-    using streamed_char =
-        typename fly::BasicStringTraits<streamed_type>::char_type;
+    using streamed_type = typename traits::streamer_type::streamed_type;
+    using streamed_char = typename streamed_type::value_type;
 
     string_type str = FLY_STR(char_type, "a");
     const char_type *ctr = FLY_STR(char_type, "b");
     const char_type arr[] = {'c', '\0'};
     const char_type chr = 'd';
 
-    const Streamable<streamed_type> obj1(
-        FLY_STR(streamed_char, "goodbye"), 0xbeef);
+    const Streamable<streamed_type> obj1(FLY_STR(streamed_char, "hi"), 0xbeef);
+    const NotStreamable obj2;
 
     EXPECT_EQ(FLY_STR(streamed_char, "a"), StringClass::Join('.', str));
     EXPECT_EQ(FLY_STR(streamed_char, "b"), StringClass::Join('.', ctr));
@@ -570,12 +584,16 @@ TYPED_TEST(BasicStringTest, JoinTest)
     EXPECT_EQ(FLY_STR(streamed_char, "d,c"), StringClass::Join(',', chr, arr));
     EXPECT_EQ(FLY_STR(streamed_char, "d,d"), StringClass::Join(',', chr, chr));
     EXPECT_EQ(
-        FLY_STR(streamed_char, "[goodbye beef]"), StringClass::Join('.', obj1));
+        FLY_STR(streamed_char, "[hi beef]"), StringClass::Join('.', obj1));
     EXPECT_EQ(
-        FLY_STR(streamed_char, "a:[goodbye beef]:c:d"),
+        FLY_STR(streamed_char, "a:[hi beef]:c:d"),
         StringClass::Join(':', str, obj1, arr, chr));
     EXPECT_EQ(
         FLY_STR(streamed_char, "a:c:d"), StringClass::Join(':', str, arr, chr));
+
+    std::basic_regex<streamed_char> test(
+        FLY_STR(streamed_char, "\\[0x[0-9a-fA-F]+\\]:2:\\[hi beef\\]"));
+    EXPECT_TRUE(std::regex_match(StringClass::Join(':', obj2, 2, obj1), test));
 }
 
 //==============================================================================
@@ -583,7 +601,8 @@ TYPED_TEST(BasicStringTest, ConvertStringTest)
 {
     using string_type = typename TestFixture::string_type;
     using StringClass = fly::BasicString<string_type>;
-    using char_type = typename fly::BasicStringTraits<string_type>::char_type;
+    using traits = typename fly::BasicStringTraits<string_type>;
+    using char_type = typename traits::char_type;
 
     string_type s = FLY_STR(char_type, "abc");
     EXPECT_EQ(StringClass::template Convert<string_type>(s), s);
@@ -600,7 +619,8 @@ TYPED_TEST(BasicStringTest, ConvertBoolTest)
 {
     using string_type = typename TestFixture::string_type;
     using StringClass = fly::BasicString<string_type>;
-    using char_type = typename fly::BasicStringTraits<string_type>::char_type;
+    using traits = typename fly::BasicStringTraits<string_type>;
+    using char_type = typename traits::char_type;
 
     string_type s;
 
@@ -628,12 +648,11 @@ TYPED_TEST(BasicStringTest, ConvertCharTest)
 {
     using string_type = typename TestFixture::string_type;
     using StringClass = fly::BasicString<string_type>;
-    using char_type = typename fly::BasicStringTraits<string_type>::char_type;
+    using traits = typename fly::BasicStringTraits<string_type>;
+    using char_type = typename traits::char_type;
 
-    using streamed_type =
-        typename fly::BasicStringStreamer<string_type>::streamed_type;
-    using streamed_char =
-        typename fly::BasicStringTraits<streamed_type>::char_type;
+    using streamed_type = typename traits::streamer_type::streamed_type;
+    using streamed_char = typename streamed_type::value_type;
     using ustreamed_char = std::make_unsigned_t<streamed_char>;
 
     string_type s;
@@ -688,7 +707,8 @@ TYPED_TEST(BasicStringTest, ConvertInt8Test)
 {
     using string_type = typename TestFixture::string_type;
     using StringClass = fly::BasicString<string_type>;
-    using char_type = typename fly::BasicStringTraits<string_type>::char_type;
+    using traits = typename fly::BasicStringTraits<string_type>;
+    using char_type = typename traits::char_type;
 
     string_type s;
 
@@ -745,7 +765,8 @@ TYPED_TEST(BasicStringTest, ConvertInt16Test)
 {
     using string_type = typename TestFixture::string_type;
     using StringClass = fly::BasicString<string_type>;
-    using char_type = typename fly::BasicStringTraits<string_type>::char_type;
+    using traits = typename fly::BasicStringTraits<string_type>;
+    using char_type = typename traits::char_type;
 
     string_type s;
 
@@ -805,7 +826,8 @@ TYPED_TEST(BasicStringTest, ConvertInt32Test)
 {
     using string_type = typename TestFixture::string_type;
     using StringClass = fly::BasicString<string_type>;
-    using char_type = typename fly::BasicStringTraits<string_type>::char_type;
+    using traits = typename fly::BasicStringTraits<string_type>;
+    using char_type = typename traits::char_type;
 
     string_type s;
 
@@ -865,7 +887,8 @@ TYPED_TEST(BasicStringTest, ConvertInt64Test)
 {
     using string_type = typename TestFixture::string_type;
     using StringClass = fly::BasicString<string_type>;
-    using char_type = typename fly::BasicStringTraits<string_type>::char_type;
+    using traits = typename fly::BasicStringTraits<string_type>;
+    using char_type = typename traits::char_type;
 
     string_type s;
 
@@ -902,7 +925,8 @@ TYPED_TEST(BasicStringTest, ConvertDecimalTest)
 {
     using string_type = typename TestFixture::string_type;
     using StringClass = fly::BasicString<string_type>;
-    using char_type = typename fly::BasicStringTraits<string_type>::char_type;
+    using traits = typename fly::BasicStringTraits<string_type>;
+    using char_type = typename traits::char_type;
 
     string_type s;
 
@@ -937,7 +961,8 @@ TYPED_TEST(BasicStringTest, ConvertDecimalTest)
 TYPED_TEST(BasicStringTest, BasicStringStreamerTest)
 {
     using string_type = typename TestFixture::string_type;
-    using char_type = typename fly::BasicStringTraits<string_type>::char_type;
+    using traits = typename fly::BasicStringTraits<string_type>;
+    using char_type = typename traits::char_type;
 
     // Extra test to make sure the hexadecimal conversion for std::u16string and
     // std::u32string in BasicStringStreamer is exercised correctly.

--- a/test/types/string.cpp
+++ b/test/types/string.cpp
@@ -592,7 +592,7 @@ TYPED_TEST(BasicStringTest, JoinTest)
         FLY_STR(streamed_char, "a:c:d"), StringClass::Join(':', str, arr, chr));
 
     std::basic_regex<streamed_char> test(
-        FLY_STR(streamed_char, "\\[0x[0-9a-fA-F]+\\]:2:\\[hi beef\\]"));
+        FLY_STR(streamed_char, "\\[(0x)?[0-9a-fA-F]+\\]:2:\\[hi beef\\]"));
     EXPECT_TRUE(std::regex_match(StringClass::Join(':', obj2, 2, obj1), test));
 }
 

--- a/test/types/string_traits.cpp
+++ b/test/types/string_traits.cpp
@@ -10,6 +10,24 @@
 namespace {
 
 //==============================================================================
+template <typename StringType>
+class Streamable
+{
+public:
+    using ostream_type = typename fly::BasicStringTraits<
+        StringType>::streamer_type::ostream_type;
+
+    friend ostream_type &operator<<(ostream_type &, const Streamable &)
+    {
+    }
+};
+
+//==============================================================================
+class NotStreamable
+{
+};
+
+//==============================================================================
 template <
     typename T,
     fly::enable_if_any<
@@ -241,4 +259,21 @@ TYPED_TEST(BasicStringTraitsTest, StringLikeSFINAETest)
 
     EXPECT_FALSE(isStringLike(int()));
     EXPECT_FALSE(isStringLike(char_type()));
+}
+
+//==============================================================================
+TYPED_TEST(BasicStringTraitsTest, OstreamTraitsTest)
+{
+    using string_type = typename TestFixture::string_type;
+    using traits = typename fly::BasicStringTraits<string_type>;
+    using streamed_type = typename traits::streamer_type::streamed_type;
+
+    const Streamable<streamed_type> obj1;
+    const NotStreamable obj2;
+
+    EXPECT_TRUE(traits::OstreamTraits::template is_declared_v<int>);
+    EXPECT_TRUE(traits::OstreamTraits::template is_declared_v<bool>);
+    EXPECT_TRUE(traits::OstreamTraits::template is_declared_v<streamed_type>);
+    EXPECT_TRUE(traits::OstreamTraits::template is_declared_v<decltype(obj1)>);
+    EXPECT_FALSE(traits::OstreamTraits::template is_declared_v<decltype(obj2)>);
 }


### PR DESCRIPTION
Having this feature exist as a macro was a bit unnerving. Replace it with an
extensible templated struct. Extend this struct in BasicStringTraits<> to
define a trait for whether operator<< is declared for a type. Use that trait
in BasicString<>::stream() - if the type is not streamable, stream its address
instead.