### PR TITLE
Only run tests on Windows release builds

### DIFF
--- a/.azure.yml
+++ b/.azure.yml
@@ -32,20 +32,8 @@ jobs:
   #### Windows ####
   - template: build/ci/windows.yml
     parameters:
-      configuration: 'Debug'
       arch: 'x86'
 
   - template: build/ci/windows.yml
     parameters:
-      configuration: 'Debug'
-      arch: 'x64'
-
-  - template: build/ci/windows.yml
-    parameters:
-      configuration: 'Release'
-      arch: 'x86'
-
-  - template: build/ci/windows.yml
-    parameters:
-      configuration: 'Release'
       arch: 'x64'

--- a/build/ci/windows.yml
+++ b/build/ci/windows.yml
@@ -20,7 +20,7 @@ jobs:
     - task: PowerShell@2
       inputs:
         filePath: build\win\test.ps1
-        arguments: -arch ${{ parameters.arch }}
+        arguments: -configuration Release -arch ${{ parameters.arch }}
         failOnStderr: false
       displayName: 'Test'
 

--- a/build/ci/windows.yml
+++ b/build/ci/windows.yml
@@ -1,47 +1,35 @@
 parameters:
-  configuration: 'Debug'
   arch: 'x64'
 
 jobs:
-  - job: 'Windows_${{ parameters.configuration }}_${{ parameters.arch }}'
+  - job: 'Windows_${{ parameters.arch }}'
     pool:
       vmImage: 'windows-2019'
 
     steps:
     - template: setup.yml
 
-    - ${{ if eq(parameters.configuration, 'Debug') }}:
-      - task: VSBuild@1
-        inputs:
-          solution: 'build\win\libfly.sln'
-          configuration: ${{ parameters.configuration }}
-          platform: ${{ parameters.arch }}
-          maximumCpuCount: true
-        displayName: 'Build'
+    - task: VSBuild@1
+      inputs:
+        solution: 'build\win\libfly.sln'
+        configuration: 'Release'
+        platform: ${{ parameters.arch }}
+        maximumCpuCount: true
+      displayName: 'Build'
 
-      - task: PowerShell@2
-        inputs:
-          filePath: build\win\test.ps1
-          arguments: -arch ${{ parameters.arch }}
-          failOnStderr: false
-        displayName: 'Test'
+    - task: PowerShell@2
+      inputs:
+        filePath: build\win\test.ps1
+        arguments: -arch ${{ parameters.arch }}
+        failOnStderr: false
+      displayName: 'Test'
 
-    - ${{ if eq(parameters.configuration, 'Release') }}:
-      - task: VSBuild@1
-        inputs:
-          solution: 'build\win\libfly.sln'
-          msbuildArgs: '/t:libfly'
-          configuration: ${{ parameters.configuration }}
-          platform: ${{ parameters.arch }}
-          maximumCpuCount: true
-        displayName: 'Build'
+    - task: PowerShell@2
+      inputs:
+        filePath: build\win\release.ps1
+        arguments: -arch ${{ parameters.arch }}
+      displayName: 'Package'
 
-      - task: PowerShell@2
-        inputs:
-          filePath: build\win\release.ps1
-          arguments: -arch ${{ parameters.arch }}
-        displayName: 'Package'
-
-      - template: package.yml
-        parameters:
-          contents: 'build\win\libfly-*.zip'
+    - template: package.yml
+      parameters:
+        contents: 'build\win\libfly-*.zip'

--- a/build/win/test.ps1
+++ b/build/win/test.ps1
@@ -1,4 +1,5 @@
 param (
+    [Parameter(Mandatory=$true)][string]$configuration
     [Parameter(Mandatory=$true)][string]$arch
 )
 
@@ -7,7 +8,7 @@ function Run-Libfly-Test($arch)
 {
     Write-Output "Running $arch tests"
 
-    $full_path = $PSScriptRoot + "\Release-" + $arch
+    $full_path = $PSScriptRoot + "\" + $configuration + "-" + $arch
     $tests_passed = 0
     $tests_failed = 0
 
@@ -32,4 +33,4 @@ function Run-Libfly-Test($arch)
 }
 
 # Run the tests
-Run-Libfly-Test $arch
+Run-Libfly-Test $configuration $arch

--- a/build/win/test.ps1
+++ b/build/win/test.ps1
@@ -7,7 +7,7 @@ function Run-Libfly-Test($arch)
 {
     Write-Output "Running $arch tests"
 
-    $full_path = $PSScriptRoot + "\Debug-" + $arch
+    $full_path = $PSScriptRoot + "\Release-" + $arch
     $tests_passed = 0
     $tests_failed = 0
 

--- a/build/win/test.ps1
+++ b/build/win/test.ps1
@@ -4,7 +4,7 @@ param (
 )
 
 # Run all unit tests for an architecture.
-function Run-Libfly-Test($arch)
+function Run-Libfly-Test($configuration, $arch)
 {
     Write-Output "Running $arch tests"
 

--- a/build/win/test.ps1
+++ b/build/win/test.ps1
@@ -1,5 +1,5 @@
 param (
-    [Parameter(Mandatory=$true)][string]$configuration
+    [Parameter(Mandatory=$true)][string]$configuration,
     [Parameter(Mandatory=$true)][string]$arch
 )
 


### PR DESCRIPTION
Some of the tests are really slow on Windows debug builds (chiefly the JSON
parser tests reading large files). Just run tests on release builds for now.

Debug builds are still important on Linux for code coverage and sanitizers. If I
ever get around to getting code coverage from Windows, this may need to be
reverted.