### PR TITLE
Iteratively unwind JSON objects and arrays

### DIFF
--- a/build/win/libfly_unit_tests/libfly_unit_tests.vcxproj
+++ b/build/win/libfly_unit_tests/libfly_unit_tests.vcxproj
@@ -124,7 +124,6 @@
       </AdditionalLibraryDirectories>
       <AdditionalDependencies>pdh.lib;ws2_32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
-      <StackReserveSize>4194304</StackReserveSize>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -144,7 +143,6 @@
       </AdditionalLibraryDirectories>
       <AdditionalDependencies>pdh.lib;ws2_32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
-      <StackReserveSize>4194304</StackReserveSize>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -168,7 +166,6 @@
       </AdditionalLibraryDirectories>
       <AdditionalDependencies>pdh.lib;ws2_32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
-      <StackReserveSize>4194304</StackReserveSize>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -192,7 +189,6 @@
       </AdditionalLibraryDirectories>
       <AdditionalDependencies>pdh.lib;ws2_32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
-      <StackReserveSize>4194304</StackReserveSize>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/fly/types/json/json.cpp
+++ b/fly/types/json/json.cpp
@@ -63,17 +63,15 @@ Json::~Json()
 
     if (IsObject())
     {
-        for (auto &&child : std::get<JsonTraits::object_type>(m_value))
+        for (auto &&json : std::get<JsonTraits::object_type>(m_value))
         {
-            stack.push_back(std::move(child.second));
+            stack.push_back(std::move(json.second));
         }
     }
     else if (IsArray())
     {
-        std::move(
-            std::get<JsonTraits::array_type>(m_value).begin(),
-            std::get<JsonTraits::array_type>(m_value).end(),
-            std::back_inserter(stack));
+        auto &&json = std::get<JsonTraits::array_type>(m_value);
+        std::move(json.begin(), json.end(), std::back_inserter(stack));
     }
 
     while (!stack.empty())
@@ -85,19 +83,16 @@ Json::~Json()
 
         if (json.IsObject())
         {
-            for (auto &&child : std::get<JsonTraits::object_type>(m_value))
+            for (auto &&child : std::get<JsonTraits::object_type>(json.m_value))
             {
                 stack.push_back(std::move(child.second));
             }
         }
         else if (json.IsArray())
         {
-            std::move(
-                std::get<JsonTraits::array_type>(json.m_value).begin(),
-                std::get<JsonTraits::array_type>(json.m_value).end(),
-                std::back_inserter(stack));
-
-            std::get<JsonTraits::array_type>(json.m_value).clear();
+            auto &&child = std::get<JsonTraits::array_type>(json.m_value);
+            std::move(child.begin(), child.end(), std::back_inserter(stack));
+            child.clear();
         }
     }
 }

--- a/fly/types/json/json.h
+++ b/fly/types/json/json.h
@@ -205,7 +205,7 @@ public:
 
     /**
      * Destructor. Iteratively destroy nested Json instances to alleviate stack
-     * stack overflow on destruction of deeply-nested Json objects and arrays.
+     * overflow on destruction of deeply-nested Json objects and arrays.
      */
     ~Json();
 

--- a/fly/types/json/json.h
+++ b/fly/types/json/json.h
@@ -59,7 +59,7 @@ class Json
 {
 public:
     /**
-     * Alias for the std::variant holding the above JSON types.
+     * Alias for the std::variant holding the JSON types.
      */
     using json_type = std::variant<
         JsonTraits::null_type,
@@ -202,6 +202,12 @@ public:
      * @param std::initializer_list The initializer list.
      */
     Json(const std::initializer_list<Json> &) noexcept;
+
+    /**
+     * Destructor. Iteratively destroy nested Json instances to alleviate stack
+     * stack overflow on destruction of deeply-nested Json objects and arrays.
+     */
+    ~Json();
 
     /**
      * Copy assignment operator. Intializes the Json instance with the type and


### PR DESCRIPTION
Long-standing issue where deeply nested JSON instances cause a stack
overflow in the fly::Json destructor. Destroy objects and arrays
iteratively rather than recursively.