### PR TITLE
Empty release package target when not defined

### DIFF
--- a/build/nix/compile.mk
+++ b/build/nix/compile.mk
@@ -96,8 +96,12 @@ $(3): REL_LIB_DIR := $$(REL_LIB_DIR_$$(t))
 $(3): REL_INC_DIR := $$(REL_INC_DIR_$$(t))
 $(3): REL_SRC_DIR := $$(REL_SRC_DIR_$$(t))
 
+ifeq ($$(REL_CMDS_$$(t)), )
+$(3):
+else
 $(3): $(2) $$(MAKEFILES_$(d))
 	$(Q)$$(BUILD_REL)
+endif
 
 endef
 


### PR DESCRIPTION
For example, libfly_unit_tests does not have a release package. But it
would still be compiled as a dependency of 'make install', which isn't
necessary.