### PR TITLE
Use clang toolchain by default

### DIFF
--- a/.azure.yml
+++ b/.azure.yml
@@ -12,21 +12,37 @@ jobs:
   - template: build/ci/linux.yml
     parameters:
       configuration: 'Debug'
+      toolchain: 'clang'
       arch: 'x86'
 
   - template: build/ci/linux.yml
     parameters:
       configuration: 'Debug'
+      toolchain: 'clang'
+      arch: 'x64'
+
+  - template: build/ci/linux.yml
+    parameters:
+      configuration: 'Debug'
+      toolchain: 'gcc'
+      arch: 'x86'
+
+  - template: build/ci/linux.yml
+    parameters:
+      configuration: 'Debug'
+      toolchain: 'gcc'
       arch: 'x64'
 
   - template: build/ci/linux.yml
     parameters:
       configuration: 'Release'
+      toolchain: 'clang'
       arch: 'x86'
 
   - template: build/ci/linux.yml
     parameters:
       configuration: 'Release'
+      toolchain: 'clang'
       arch: 'x64'
 
   #### Windows ####

--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,16 @@
 # TODO: Create a "performance test" for enwik8
 enwik8
 
+#### Build
+
+release/
+debug/
+
 #### General
 
 *.db
 *.psd
 *.log
-release-*
-debug-*
-libfly-*x86.zip
-libfly-*x64.zip
 
 #### C++
 

--- a/build/ci/Dockerfile
+++ b/build/ci/Dockerfile
@@ -35,6 +35,7 @@ RUN apt-get update && \
         \
         # Install Qt dependencies
         libdbus-1-dev \
+        libgl1 \
         libglib2.0-0 \
         libx11-xcb1 \
         mesa-common-dev \

--- a/build/ci/Dockerfile
+++ b/build/ci/Dockerfile
@@ -1,29 +1,32 @@
-# docker image rm "trflynn89/libfly:ubuntu1910_gcc9_qt5140"
-# docker build --tag "trflynn89/libfly:ubuntu1910_gcc9_qt5140" .
-# docker push "trflynn89/libfly:ubuntu1910_gcc9_qt5140"
+# docker image rm "trflynn89/libfly:ubuntu1910_clang9_gcc9_qt5140"
+# docker build --tag "trflynn89/libfly:ubuntu1910_clang9_gcc9_qt5140" .
+# docker push "trflynn89/libfly:ubuntu1910_clang9_gcc9_qt5140"
 #
-# docker run --cap-add SYS_PTRACE --name libfly -it trflynn89/libfly:ubuntu1910_gcc9_qt5140
+# docker run --cap-add SYS_PTRACE --name libfly -it trflynn89/libfly:ubuntu1910_clang9_gcc9_qt5140
 # docker rm libfly
 FROM ubuntu:19.10
 
 MAINTAINER Timothy Flynn <trflynn89@pm.me>
 
-ENV CC gcc-9
-ENV CXX g++-9
-ENV GCOV gcov-9
+ARG CLANG_VERSION=9
+ARG GCC_VERSION=9
 
-ARG QT_INSTALLER=qt-unified-linux-x64-online.run
 ARG QT_URL=http://qt.mirror.constant.com/official_releases/online_installers
+ARG QT_INSTALLER=qt-unified-linux-x64-online.run
 
 COPY qt.js /tmp/qt.js
 
 RUN apt-get update && \
     apt-get install -y \
         # Install build dependencies
-        $CC \
-        $CC-multilib \
-        $CXX \
-        $CXX-multilib \
+        clang-$CLANG_VERSION \
+        llvm-$CLANG_VERSION \
+        \
+        gcc-$GCC_VERSION \
+        gcc-$GCC_VERSION-multilib \
+        g++-$GCC_VERSION \
+        g++-$GCC_VERSION-multilib \
+        \
         curl \
         lcov \
         make \
@@ -37,9 +40,18 @@ RUN apt-get update && \
         mesa-common-dev \
         \
         && \
-    update-alternatives --install /usr/bin/gcc gcc /usr/bin/$CC 1 && \
-    update-alternatives --install /usr/bin/g++ g++ /usr/bin/$CXX 1 && \
-    update-alternatives --install /usr/bin/gcov gcov /usr/bin/$GCOV 1 && \
+    update-alternatives --install /usr/bin/clang clang /usr/bin/clang-$CLANG_VERSION 1 && \
+    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-$CLANG_VERSION 1 && \
+    update-alternatives --install /usr/bin/llvm-cov llvm-cov /usr/bin/llvm-cov-$CLANG_VERSION 1 && \
+    \
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-$GCC_VERSION 1 && \
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-$GCC_VERSION 1 && \
+    update-alternatives --install /usr/bin/gcc-gcov gcov /usr/bin/gcov-$GCC_VERSION 1 && \
+    \
+    # Create lcov wrapper script for clang
+    echo '#!/usr/bin/env sh' > /usr/bin/clang-gcov && \
+    echo 'exec llvm-cov gcov "$@"' >> /usr/bin/clang-gcov && \
+    chmod +x /usr/bin/clang-gcov && \
     \
     # Install and compress Qt
     (cd /tmp && curl -O $QT_URL/$QT_INSTALLER) && \

--- a/build/ci/Dockerfile
+++ b/build/ci/Dockerfile
@@ -45,22 +45,18 @@ RUN apt-get update && \
     update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-$CLANG_VERSION 1 && \
     update-alternatives --install /usr/bin/llvm-ar llvm-ar /usr/bin/llvm-ar-$CLANG_VERSION 1 && \
     update-alternatives --install /usr/bin/llvm-cov llvm-cov /usr/bin/llvm-cov-$CLANG_VERSION 1 && \
+    update-alternatives --install /usr/bin/llvm-profdata llvm-profdata /usr/bin/llvm-profdata-$CLANG_VERSION 1 && \
     update-alternatives --install /usr/bin/llvm-strip llvm-strip /usr/bin/llvm-strip-$CLANG_VERSION 1 && \
     \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-$GCC_VERSION 1 && \
     update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-$GCC_VERSION 1 && \
-    update-alternatives --install /usr/bin/gcc-gcov gcov /usr/bin/gcov-$GCC_VERSION 1 && \
-    \
-    # Create lcov wrapper script for clang
-    echo '#!/usr/bin/env sh' > /usr/bin/clang-gcov && \
-    echo 'exec llvm-cov gcov "$@"' >> /usr/bin/clang-gcov && \
-    chmod +x /usr/bin/clang-gcov && \
+    update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-$GCC_VERSION 1 && \
     \
     # Install and compress Qt
     (cd /tmp && curl -O $QT_URL/$QT_INSTALLER) && \
     chmod +x /tmp/$QT_INSTALLER && \
     /tmp/$QT_INSTALLER --platform minimal --script /tmp/qt.js && \
-    rm -rf /opt/Qt/Docs /opt/Qt/Examples /opt/Qt/Licenses /opt/Qt/Tools && \
+    rm -rf /opt/Qt/Docs /opt/Qt/Examples /opt/Qt/Tools && \
     (cd /opt && tar -czf Qt.tar.gz Qt) && \
     \
     # Cleanup

--- a/build/ci/Dockerfile
+++ b/build/ci/Dockerfile
@@ -42,7 +42,9 @@ RUN apt-get update && \
         && \
     update-alternatives --install /usr/bin/clang clang /usr/bin/clang-$CLANG_VERSION 1 && \
     update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-$CLANG_VERSION 1 && \
+    update-alternatives --install /usr/bin/llvm-ar llvm-ar /usr/bin/llvm-ar-$CLANG_VERSION 1 && \
     update-alternatives --install /usr/bin/llvm-cov llvm-cov /usr/bin/llvm-cov-$CLANG_VERSION 1 && \
+    update-alternatives --install /usr/bin/llvm-strip llvm-strip /usr/bin/llvm-strip-$CLANG_VERSION 1 && \
     \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-$GCC_VERSION 1 && \
     update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-$GCC_VERSION 1 && \

--- a/build/ci/linux.yml
+++ b/build/ci/linux.yml
@@ -25,13 +25,22 @@ jobs:
           make -j -C build/nix $(config) tests
         displayName: 'Test'
 
-      - script: |
-          lcov --capture --directory build/nix --output-file coverage --gcov-tool ${{ parameters.toolchain }}-gcov
-          lcov --remove coverage '/usr/*' '*/test/*' --output-file coverage
-          lcov --list coverage
+      # For now, only emit LCOV reports for gcc. With clang, llvm-cov reports
+      # lines containing only a closing curly brace as uncovered. See:
+      #     https://libcellml.readthedocs.io/en/latest/coverage_statistics.html
+      #
+      # Alternatively, should be able to upload clang coverage reports that are
+      # non-GCOV-formatted. Something like:
+      #     llvm-profdata merge -sparse default.profraw -o default.prodata
+      #     llvm-cov show libfly_unit_tests -instr-profile=default.prodata --ignore-filename-regex="test/.*" > /tmp/coverage
+      - ${{ if eq(parameters.toolchain, 'gcc') }}:
+        - script: |
+            lcov --capture --directory build/nix --output-file coverage
+            lcov --remove coverage '/usr/*' '*/test/*' --output-file coverage
+            lcov --list coverage
 
-          bash <(curl -s https://codecov.io/bash) -f coverage
-        displayName: 'Coverage'
+            bash <(curl -s https://codecov.io/bash) -f coverage
+          displayName: 'Coverage'
 
     - ${{ if eq(parameters.configuration, 'Release') }}:
       - script: |

--- a/build/ci/linux.yml
+++ b/build/ci/linux.yml
@@ -1,15 +1,16 @@
 parameters:
   configuration: 'Debug'
+  toolchain: 'clang'
   arch: 'x64'
 
 jobs:
-  - job: 'Linux_${{ parameters.configuration }}_${{ parameters.arch }}'
+  - job: 'Linux_${{ parameters.configuration }}_${{ parameters.toolchain }}_${{ parameters.arch }}'
 
     pool:
       vmImage: ubuntu-latest
 
     container:
-      image: trflynn89/libfly:ubuntu1910_gcc9_qt5140
+      image: trflynn89/libfly:ubuntu1910_clang9_gcc9_qt5140
       options: --cap-add SYS_PTRACE
 
     steps:
@@ -17,12 +18,15 @@ jobs:
 
     - ${{ if eq(parameters.configuration, 'Debug') }}:
       - script: |
-          echo "##vso[task.setvariable variable=release]0"
-          make -j -C build/nix release=0 arch=${{ parameters.arch }} tests
+          echo "##vso[task.setvariable variable=config]release=0 toolchain=${{ parameters.toolchain }} arch=${{ parameters.arch }}"
+        displayName: 'Configure'
+
+      - script: |
+          make -j -C build/nix $(config) tests
         displayName: 'Test'
 
       - script: |
-          lcov --capture --directory build/nix --output-file coverage
+          lcov --capture --directory build/nix --output-file coverage --gcov-tool ${{ parameters.toolchain }}-gcov
           lcov --remove coverage '/usr/*' '*/test/*' --output-file coverage
           lcov --list coverage
 
@@ -31,30 +35,33 @@ jobs:
 
     - ${{ if eq(parameters.configuration, 'Release') }}:
       - script: |
-          echo "##vso[task.setvariable variable=release]1"
-          make -j -C build/nix release=1 arch=${{ parameters.arch }} libfly
+          echo "##vso[task.setvariable variable=config]release=1 toolchain=${{ parameters.toolchain }} arch=${{ parameters.arch }}"
+        displayName: 'Configure'
+
+      - script: |
+          make -j -C build/nix $(config) libfly
         displayName: 'Build'
 
       - template: package.yml
         parameters:
-          contents: 'build/nix/release-*/etc/libfly-*.tar.bz2'
+          contents: 'build/nix/release/${{ parameters.toolchain }}/${{ parameters.arch }}/etc/libfly-*.tar.bz2'
 
     - script: |
-        make -j -C build/nix release=$(release) arch=${{ parameters.arch }} install
+        make -j -C build/nix $(config) install
       displayName: 'Install'
       failOnStderr: true
 
     - ${{ if eq(parameters.arch, 'x64') }}:
       - script: |
           (cd /opt && sudo tar -xzf Qt.tar.gz)
-          make -j -C examples/qt release=$(release) arch=${{ parameters.arch }}
-          make -j -C examples/build release=$(release) arch=${{ parameters.arch }}
+          make -j -C examples/qt $(config)
+          make -j -C examples/build $(config)
         displayName: 'Examples'
         failOnStderr: true
 
     - ${{ if eq(parameters.arch, 'x86') }}:
       - script: |
-          make -j -C examples/build release=$(release) arch=${{ parameters.arch }}
+          make -j -C examples/build $(config)
         displayName: 'Examples'
         failOnStderr: true
 

--- a/build/ci/windows.yml
+++ b/build/ci/windows.yml
@@ -32,4 +32,4 @@ jobs:
 
     - template: package.yml
       parameters:
-        contents: 'build\win\libfly-*.zip'
+        contents: 'build\win\Release\msvc\libfly-*.zip'

--- a/build/nix/build.mk
+++ b/build/nix/build.mk
@@ -53,7 +53,12 @@ clean:
 tests: $(TEST_BINARIES)
 	$(Q)failed=0; \
 	for tgt in $(TEST_BINARIES) ; do \
+		if [[ $(toolchain) == "clang" ]] ; then \
+			export LLVM_PROFILE_FILE="$$tgt.profraw"; \
+		fi; \
+		\
 		$$tgt; \
+		\
 		if [[ $$? -ne 0 ]] ; then \
 			failed=$$((failed+1)); \
 		fi; \

--- a/build/nix/compile.mk
+++ b/build/nix/compile.mk
@@ -65,7 +65,6 @@ MAKEFILES_$(d) := $(BUILD_ROOT)/flags.mk $(wildcard $(d)/*.mk)
 	@mkdir -p $$(@D)
 	@echo "[Shared $$(subst $(CURDIR)/,,$$@)]"
 	$(SHARED_CXX)
-	$(STRIP)
 
 endef
 

--- a/build/nix/compile.mk
+++ b/build/nix/compile.mk
@@ -34,7 +34,7 @@ $(2): CXXFLAGS := $(CXXFLAGS_$(d)) $(CXXFLAGS)
 $(2): LDFLAGS := $(LDFLAGS_$(d)) $(LDFLAGS)
 $(2): LDLIBS := $(LDLIBS_$(d)) $(LDLIBS)
 
-$(2): $$(OBJ_$$(t)) $$(MAKEFILES_$(d))
+$(2): $$(GEN_$$(t)) $$(OBJ_$$(t)) $$(MAKEFILES_$(d))
 	@mkdir -p $$(@D)
 
 	@echo "[Link $$(subst $(CURDIR)/,,$$@)]"
@@ -56,12 +56,12 @@ MAKEFILES_$(d) := $(BUILD_ROOT)/flags.mk $(wildcard $(d)/*.mk)
 %.a %.so.$(VERSION): CXXFLAGS := $(CXXFLAGS_$(d)) $(CXXFLAGS)
 %.a %.so.$(VERSION): LDFLAGS := $(LDFLAGS_$(d)) $(LDFLAGS)
 
-%.a: $$(OBJ_$$(t)) $$(MAKEFILES_$(d))
+%.a: $$(GEN_$$(t)) $$(OBJ_$$(t)) $$(MAKEFILES_$(d))
 	@mkdir -p $$(@D)
 	@echo "[Static $$(subst $(CURDIR)/,,$$@)]"
 	$(STATIC)
 
-%.so.$(VERSION): $$(OBJ_$$(t)) $$(MAKEFILES_$(d))
+%.so.$(VERSION): $$(GEN_$$(t)) $$(OBJ_$$(t)) $$(MAKEFILES_$(d))
 	@mkdir -p $$(@D)
 	@echo "[Shared $$(subst $(CURDIR)/,,$$@)]"
 	$(SHARED_CXX)

--- a/build/nix/config.mk
+++ b/build/nix/config.mk
@@ -1,6 +1,9 @@
 # Define the default make configuration. Not all defaults are defined here, but
 # all command line options are listed here for convenience.
 
+# Toolchain to compile with
+toolchain := clang
+
 # Define debug vs. release
 release := 0
 
@@ -10,11 +13,26 @@ arch := $(arch)
 # Enable verbose builds
 verbose := 0
 
+# Define the toolchain binaries
+ifeq ($(toolchain), clang)
+    CC := clang
+    CXX := clang++
+    AR := llvm-ar
+    STRIP := llvm-strip
+else ifeq ($(toolchain), gcc)
+    CC := gcc
+    CXX := g++
+    AR := ar
+    STRIP := strip
+else
+    $(error Unrecognized toolchain $(toolchain), check config.mk)
+endif
+
 # Define the output directories
 ifeq ($(release), 1)
-    OUT_DIR := $(CURDIR)/release-$(arch)
+    OUT_DIR := $(CURDIR)/release/$(toolchain)/$(arch)
 else
-    OUT_DIR := $(CURDIR)/debug-$(arch)
+    OUT_DIR := $(CURDIR)/debug/$(toolchain)/$(arch)
 endif
 
 BIN_DIR := $(OUT_DIR)/bin

--- a/build/nix/files.mk
+++ b/build/nix/files.mk
@@ -33,16 +33,28 @@ OBJ_DIR_$(d) := $(OBJ_DIR)/$$(subst $(SOURCE_ROOT)/,,$(d))
 GEN_DIR_$(d) := $(GEN_DIR)/$$(subst $(SOURCE_ROOT)/,,$(d))
 
 ifneq ($(5),)
-    u_$(d) := $$(addsuffix .uic.h, $$(subst $(d),,$$(basename $(2))))
-    u_$(d) := $$(addprefix $$(GEN_DIR_$(d)), $$(u_$(d)))
+    # Generated UI header files
+    gu_$(d) := $$(addsuffix .uic.h, $$(subst $(d),,$$(basename $(2))))
+    gu_$(d) := $$(addprefix $$(GEN_DIR_$(d)), $$(gu_$(d)))
 
-    m_$(d) := $$(addsuffix .moc.o, $$(subst $(d),,$$(basename $(3))))
-    m_$(d) := $$(addprefix $$(OBJ_DIR_$(d)), $$(m_$(d)))
+    # Generated MOC source files
+    gm_$(d) := $$(addsuffix .moc.cpp, $$(subst $(d),,$$(basename $(3))))
+    gm_$(d) := $$(addprefix $$(GEN_DIR_$(d)), $$(gm_$(d)))
 
-    q_$(d) := $$(addsuffix .rcc.o, $$(subst $(d),,$$(basename $(4))))
-    q_$(d) := $$(addprefix $$(OBJ_DIR_$(d)), $$(q_$(d)))
+    # Compiled MOC object files
+    om_$(d) := $$(addsuffix .moc.o, $$(subst $(d),,$$(basename $(3))))
+    om_$(d) := $$(addprefix $$(OBJ_DIR_$(d)), $$(om_$(d)))
 
-    OBJ_$$(strip $(1)) += $$(u_$(d)) $$(m_$(d)) $$(q_$(d))
+    # Generated QRC source files
+    gq_$(d) := $$(addsuffix .rcc.cpp, $$(subst $(d),,$$(basename $(4))))
+    gq_$(d) := $$(addprefix $$(GEN_DIR_$(d)), $$(gq_$(d)))
+
+    # Generated QRC object files
+    oq_$(d) := $$(addsuffix .rcc.o, $$(subst $(d),,$$(basename $(4))))
+    oq_$(d) := $$(addprefix $$(OBJ_DIR_$(d)), $$(oq_$(d)))
+
+    GEN_$$(strip $(1)) += $$(gu_$(d)) $$(gm_$(d)) $$(gq_$(d))
+    OBJ_$$(strip $(1)) += $$(om_$(d)) $$(oq_$(d))
 
     CFLAGS_$$(d) += $(QT_CFLAGS)
     CXXFLAGS_$$(d) += $(QT_CFLAGS)

--- a/build/nix/flags.mk
+++ b/build/nix/flags.mk
@@ -32,7 +32,13 @@ ifeq ($(release), 1)
     CF_ALL += -O2
     LDFLAGS += -fuse-ld=gold
 else
-    CF_ALL += -O0 -g --coverage -fsanitize=address -fno-omit-frame-pointer
+    CF_ALL += -O0 -g -fsanitize=address -fno-omit-frame-pointer
+
+    ifeq ($(toolchain), clang)
+        CF_ALL += -fprofile-instr-generate -fcoverage-mapping
+    else ifeq ($(toolchain), gcc)
+        CF_ALL += --coverage
+    endif
 
     # When using address sanitizer, use gold linker with non-clang compilers.
     # With clang and address sanitizer, gold produces the following warning:

--- a/build/nix/flags.mk
+++ b/build/nix/flags.mk
@@ -8,7 +8,7 @@ MAKEFLAGS += --no-builtin-rules --no-print-directory
 SHELL := /bin/bash
 
 # Linker flags
-LDFLAGS := -L$(LIB_DIR) -fuse-ld=gold
+LDFLAGS := -L$(LIB_DIR)
 LDLIBS :=
 
 # Compiler flags for both C and C++ files
@@ -30,8 +30,16 @@ CF_ALL += -I$(SOURCE_ROOT)/test/googletest/googletest
 # debug builds
 ifeq ($(release), 1)
     CF_ALL += -O2
+    LDFLAGS += -fuse-ld=gold
 else
     CF_ALL += -O0 -g --coverage -fsanitize=address -fno-omit-frame-pointer
+
+    # When using address sanitizer, use gold linker with non-clang compilers.
+    # With clang and address sanitizer, gold produces the following warning:
+    # Cannot export local symbol '__asan_extra_spill_area'
+    ifneq ($(toolchain), clang)
+        LDFLAGS += -fuse-ld=gold
+    endif
 endif
 
 # C and C++ specific flags

--- a/build/nix/release.mk
+++ b/build/nix/release.mk
@@ -85,7 +85,7 @@ t := $(strip $(1))
 
 $(eval $(call SET_REL_VAR, $(1)))
 $(eval $(call ADD_REL_CMD, $(1), cp -f $(BIN_DIR)/$(t) $(REL_BIN_DIR_$(t))))
-$(eval $(call ADD_REL_CMD, $(1), strip -s $(REL_BIN_DIR_$(t))/$(t)))
+$(eval $(call ADD_REL_CMD, $(1), $(STRIP) -s $(REL_BIN_DIR_$(t))/$(t)))
 $(eval $(call ADD_REL_CMD, $(1), chmod 755 $(REL_BIN_DIR_$(t))/$(t)))
 
 REL_UNINSTALL_$(t) += $(REL_BIN_DIR_$(t))/$(t)
@@ -102,7 +102,7 @@ t := $(strip $(1))
 
 $(eval $(call SET_REL_VAR, $(1)))
 $(eval $(call ADD_REL_CMD, $(1), cp -f $(LIB_DIR)/$(t).* $(REL_LIB_DIR_$(t))))
-$(eval $(call ADD_REL_CMD, $(1), strip -s $(REL_LIB_DIR_$(t))/$(t).*))
+$(eval $(call ADD_REL_CMD, $(1), $(STRIP) -s $(REL_LIB_DIR_$(t))/$(t).*))
 
 REL_UNINSTALL_$(t) += $(REL_LIB_DIR_$(t))/$(t)*
 

--- a/build/nix/system.mk
+++ b/build/nix/system.mk
@@ -8,7 +8,7 @@ SUPPORTED_ARCH := x64 x86
 
 ifneq ($(findstring x86_64, $(SYSTEM)),)
     arch := x64
-else ifeq ($(arch),x64)
+else ifeq ($(arch), x64)
     $(error Cannot build 64-bit architecture on 32-bit machine)
 else
     arch := x86

--- a/build/win/libfly/libfly.vcxproj
+++ b/build/win/libfly/libfly.vcxproj
@@ -69,26 +69,26 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>$(SolutionDir)$(Configuration)-$(PlatformTarget)\$(ProjectName)\</OutDir>
-    <IntDir>$(SolutionDir)$(Configuration)-$(PlatformTarget)\$(ProjectName)\</IntDir>
+    <OutDir>$(SolutionDir)$(Configuration)\msvc\$(PlatformTarget)\$(ProjectName)\</OutDir>
+    <IntDir>$(SolutionDir)$(Configuration)\msvc\$(PlatformTarget)\$(ProjectName)\</IntDir>
     <IncludePath>$(SolutionDir)..\..;$(VC_IncludePath);$(WindowsSDK_IncludePath)</IncludePath>
     <TargetName>$(ProjectName).$(PlatformTarget)</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OutDir>$(SolutionDir)$(Configuration)-$(PlatformTarget)\$(ProjectName)\</OutDir>
-    <IntDir>$(SolutionDir)$(Configuration)-$(PlatformTarget)\$(ProjectName)\</IntDir>
+    <OutDir>$(SolutionDir)$(Configuration)\msvc\$(PlatformTarget)\$(ProjectName)\</OutDir>
+    <IntDir>$(SolutionDir)$(Configuration)\msvc\$(PlatformTarget)\$(ProjectName)\</IntDir>
     <IncludePath>$(SolutionDir)..\..;$(VC_IncludePath);$(WindowsSDK_IncludePath)</IncludePath>
     <TargetName>$(ProjectName)d.$(PlatformTarget)</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OutDir>$(SolutionDir)$(Configuration)-$(PlatformTarget)\$(ProjectName)\</OutDir>
-    <IntDir>$(SolutionDir)$(Configuration)-$(PlatformTarget)\$(ProjectName)\</IntDir>
+    <OutDir>$(SolutionDir)$(Configuration)\msvc\$(PlatformTarget)\$(ProjectName)\</OutDir>
+    <IntDir>$(SolutionDir)$(Configuration)\msvc\$(PlatformTarget)\$(ProjectName)\</IntDir>
     <IncludePath>$(SolutionDir)..\..;$(VC_IncludePath);$(WindowsSDK_IncludePath)</IncludePath>
     <TargetName>$(ProjectName).$(PlatformTarget)</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>$(SolutionDir)$(Configuration)-$(PlatformTarget)\$(ProjectName)\</OutDir>
-    <IntDir>$(SolutionDir)$(Configuration)-$(PlatformTarget)\$(ProjectName)\</IntDir>
+    <OutDir>$(SolutionDir)$(Configuration)\msvc\$(PlatformTarget)\$(ProjectName)\</OutDir>
+    <IntDir>$(SolutionDir)$(Configuration)\msvc\$(PlatformTarget)\$(ProjectName)\</IntDir>
     <IncludePath>$(SolutionDir)..\..;$(VC_IncludePath);$(WindowsSDK_IncludePath)</IncludePath>
     <TargetName>$(ProjectName)d.$(PlatformTarget)</TargetName>
   </PropertyGroup>

--- a/build/win/libfly_unit_tests/libfly_unit_tests.vcxproj
+++ b/build/win/libfly_unit_tests/libfly_unit_tests.vcxproj
@@ -77,32 +77,32 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
-    <OutDir>$(SolutionDir)$(Configuration)-$(PlatformTarget)\$(ProjectName)\</OutDir>
-    <IntDir>$(SolutionDir)$(Configuration)-$(PlatformTarget)\$(ProjectName)\</IntDir>
+    <OutDir>$(SolutionDir)$(Configuration)\msvc\$(PlatformTarget)\$(ProjectName)\</OutDir>
+    <IntDir>$(SolutionDir)$(Configuration)\msvc\$(PlatformTarget)\$(ProjectName)\</IntDir>
     <IncludePath>$(SolutionDir)..\..\test\googletest\googletest;$(SolutionDir)..\..\test\googletest\googletest\include;$(SolutionDir)..\..;$(VC_IncludePath);$(WindowsSDK_IncludePath)</IncludePath>
     <TargetExt>.exe</TargetExt>
     <TargetName>$(ProjectName)</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
-    <OutDir>$(SolutionDir)$(Configuration)-$(PlatformTarget)\$(ProjectName)\</OutDir>
-    <IntDir>$(SolutionDir)$(Configuration)-$(PlatformTarget)\$(ProjectName)\</IntDir>
+    <OutDir>$(SolutionDir)$(Configuration)\msvc\$(PlatformTarget)\$(ProjectName)\</OutDir>
+    <IntDir>$(SolutionDir)$(Configuration)\msvc\$(PlatformTarget)\$(ProjectName)\</IntDir>
     <IncludePath>$(SolutionDir)..\..\test\googletest\googletest;$(SolutionDir)..\..\test\googletest\googletest\include;$(SolutionDir)..\..;$(VC_IncludePath);$(WindowsSDK_IncludePath)</IncludePath>
     <TargetExt>.exe</TargetExt>
     <TargetName>$(ProjectName)</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
-    <OutDir>$(SolutionDir)$(Configuration)-$(PlatformTarget)\$(ProjectName)\</OutDir>
-    <IntDir>$(SolutionDir)$(Configuration)-$(PlatformTarget)\$(ProjectName)\</IntDir>
+    <OutDir>$(SolutionDir)$(Configuration)\msvc\$(PlatformTarget)\$(ProjectName)\</OutDir>
+    <IntDir>$(SolutionDir)$(Configuration)\msvc\$(PlatformTarget)\$(ProjectName)\</IntDir>
     <IncludePath>$(SolutionDir)..\..\test\googletest\googletest;$(SolutionDir)..\..\test\googletest\googletest\include;$(SolutionDir)..\..;$(VC_IncludePath);$(WindowsSDK_IncludePath)</IncludePath>
     <TargetExt>.exe</TargetExt>
     <TargetName>$(ProjectName)</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
-    <OutDir>$(SolutionDir)$(Configuration)-$(PlatformTarget)\$(ProjectName)\</OutDir>
-    <IntDir>$(SolutionDir)$(Configuration)-$(PlatformTarget)\$(ProjectName)\</IntDir>
+    <OutDir>$(SolutionDir)$(Configuration)\msvc\$(PlatformTarget)\$(ProjectName)\</OutDir>
+    <IntDir>$(SolutionDir)$(Configuration)\msvc\$(PlatformTarget)\$(ProjectName)\</IntDir>
     <IncludePath>$(SolutionDir)..\..\test\googletest\googletest;$(SolutionDir)..\..\test\googletest\googletest\include;$(SolutionDir)..\..;$(VC_IncludePath);$(WindowsSDK_IncludePath)</IncludePath>
     <TargetExt>.exe</TargetExt>
     <TargetName>$(ProjectName)</TargetName>

--- a/build/win/release.ps1
+++ b/build/win/release.ps1
@@ -10,8 +10,8 @@ function Create-Libfly-Package($arch)
     $version = Get-Content -Path ($PSScriptRoot + "\..\..\VERSION.md")
 
     $package_src_path = $PSScriptRoot + "\..\..\fly"
-    $package_lib_path = $PSScriptRoot + "\Release-" + $arch + "\libfly"
-    $package_tmp_path = $PSScriptRoot + "\libfly-win-" + $version + "." + $arch
+    $package_lib_path = $PSScriptRoot + "\Release\msvc\" + $arch + "\libfly"
+    $package_tmp_path = $PSScriptRoot + "\Release\msvc\libfly-win-" + $version + "." + $arch
     $package_zip_path = $package_tmp_path + ".zip"
 
     Remove-Item -Path $package_tmp_path -Recurse -ErrorAction SilentlyContinue

--- a/build/win/test.ps1
+++ b/build/win/test.ps1
@@ -8,7 +8,7 @@ function Run-Libfly-Test($configuration, $arch)
 {
     Write-Output "Running $arch tests"
 
-    $full_path = $PSScriptRoot + "\" + $configuration + "-" + $arch
+    $full_path = $PSScriptRoot + "\" + $configuration + "\msvc\" + $arch
     $tests_passed = 0
     $tests_failed = 0
 

--- a/examples/build/files.mk
+++ b/examples/build/files.mk
@@ -5,6 +5,7 @@ SRC_DIRS_$(d) := \
 # Define libraries to link
 LDLIBS_$(d) := \
     -lfly \
+    -latomic \
     -lpthread
 
 # Define source files

--- a/examples/qt/qt_quick/qt_quick.vcxproj
+++ b/examples/qt/qt_quick/qt_quick.vcxproj
@@ -40,12 +40,12 @@
     <QtMsBuild>$(MSBuildProjectDirectory)\QtMsBuild</QtMsBuild>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OutDir>$(SolutionDir)$(Configuration)-$(PlatformTarget)\$(ProjectName)\</OutDir>
-    <IntDir>$(SolutionDir)$(Configuration)-$(PlatformTarget)\$(ProjectName)\</IntDir>
+    <OutDir>$(SolutionDir)$(Configuration)\msvc\$(PlatformTarget)\$(ProjectName)\</OutDir>
+    <IntDir>$(SolutionDir)$(Configuration)\msvc\$(PlatformTarget)\$(ProjectName)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OutDir>$(SolutionDir)$(Configuration)-$(PlatformTarget)\$(ProjectName)\</OutDir>
-    <IntDir>$(SolutionDir)$(Configuration)-$(PlatformTarget)\$(ProjectName)\</IntDir>
+    <OutDir>$(SolutionDir)$(Configuration)\msvc\$(PlatformTarget)\$(ProjectName)\</OutDir>
+    <IntDir>$(SolutionDir)$(Configuration)\msvc\$(PlatformTarget)\$(ProjectName)\</IntDir>
   </PropertyGroup>
   <Target Name="QtMsBuildNotFound" BeforeTargets="CustomBuild;ClCompile" Condition="!Exists('$(QtMsBuild)\qt.targets') or !Exists('$(QtMsBuild)\qt.props')">
     <Message Importance="High" Text="QtMsBuild: could not locate qt.targets, qt.props; project may not build correctly." />

--- a/examples/qt/qt_widget/qt_widget.vcxproj
+++ b/examples/qt/qt_widget/qt_widget.vcxproj
@@ -42,12 +42,12 @@
     <QtMsBuild>$(MSBuildProjectDirectory)\QtMsBuild</QtMsBuild>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OutDir>$(SolutionDir)$(Configuration)-$(PlatformTarget)\$(ProjectName)\</OutDir>
-    <IntDir>$(SolutionDir)$(Configuration)-$(PlatformTarget)\$(ProjectName)\</IntDir>
+    <OutDir>$(SolutionDir)$(Configuration)\msvc\$(PlatformTarget)\$(ProjectName)\</OutDir>
+    <IntDir>$(SolutionDir)$(Configuration)\msvc\$(PlatformTarget)\$(ProjectName)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OutDir>$(SolutionDir)$(Configuration)-$(PlatformTarget)\$(ProjectName)\</OutDir>
-    <IntDir>$(SolutionDir)$(Configuration)-$(PlatformTarget)\$(ProjectName)\</IntDir>
+    <OutDir>$(SolutionDir)$(Configuration)\msvc\$(PlatformTarget)\$(ProjectName)\</OutDir>
+    <IntDir>$(SolutionDir)$(Configuration)\msvc\$(PlatformTarget)\$(ProjectName)\</IntDir>
   </PropertyGroup>
   <Target Name="QtMsBuildNotFound" BeforeTargets="CustomBuild;ClCompile" Condition="!Exists('$(QtMsBuild)\qt.targets') or !Exists('$(QtMsBuild)\qt.props')">
     <Message Importance="High" Text="QtMsBuild: could not locate qt.targets, qt.props; project may not build correctly." />

--- a/test/types/json.cpp
+++ b/test/types/json.cpp
@@ -42,6 +42,14 @@ const char *ConvertToUTF8(const wchar_t *str)
 class JsonTest : public ::testing::Test
 {
 protected:
+    template <typename T>
+    void ValidateThrow(const fly::Json &json) noexcept(false)
+    {
+        SCOPED_TRACE(json);
+
+        EXPECT_THROW((void)(T(json)), fly::JsonException);
+    }
+
     void ValidateFail(const std::string &test) noexcept(false)
     {
         SCOPED_TRACE(test);
@@ -369,7 +377,7 @@ TEST_F(JsonTest, ObjectConversionTest)
     fly::Json json;
 
     json = "abc";
-    EXPECT_THROW((std::map<std::string, fly::Json>(json)), fly::JsonException);
+    ValidateThrow<std::map<std::string, fly::Json>>(json);
 
     std::map<std::string, int> map = {};
     std::multimap<std::string, int> multimap(map.begin(), map.end());
@@ -394,22 +402,22 @@ TEST_F(JsonTest, ObjectConversionTest)
     EXPECT_EQ(decltype(umultimap)(json), umultimap);
 
     json = {'7', 8};
-    EXPECT_THROW((std::map<std::string, fly::Json>(json)), fly::JsonException);
+    ValidateThrow<std::map<std::string, fly::Json>>(json);
 
     json = true;
-    EXPECT_THROW((std::map<std::string, fly::Json>(json)), fly::JsonException);
+    ValidateThrow<std::map<std::string, fly::Json>>(json);
 
     json = 1;
-    EXPECT_THROW((std::map<std::string, fly::Json>(json)), fly::JsonException);
+    ValidateThrow<std::map<std::string, fly::Json>>(json);
 
     json = static_cast<unsigned int>(1);
-    EXPECT_THROW((std::map<std::string, fly::Json>(json)), fly::JsonException);
+    ValidateThrow<std::map<std::string, fly::Json>>(json);
 
     json = 1.0f;
-    EXPECT_THROW((std::map<std::string, fly::Json>(json)), fly::JsonException);
+    ValidateThrow<std::map<std::string, fly::Json>>(json);
 
     json = nullptr;
-    EXPECT_THROW((std::map<std::string, fly::Json>(json)), fly::JsonException);
+    ValidateThrow<std::map<std::string, fly::Json>>(json);
 }
 
 //==============================================================================
@@ -418,12 +426,12 @@ TEST_F(JsonTest, ArrayConversionTest)
     fly::Json json;
 
     json = "abc";
-    EXPECT_THROW((std::vector<int>(json)), fly::JsonException);
-    EXPECT_THROW((std::array<int, 1>(json)), fly::JsonException);
+    ValidateThrow<std::vector<int>>(json);
+    ValidateThrow<std::array<int, 1>>(json);
 
     json = {{"a", 1}, {"b", 2}};
-    EXPECT_THROW((std::vector<int>(json)), fly::JsonException);
-    EXPECT_THROW((std::array<int, 1>(json)), fly::JsonException);
+    ValidateThrow<std::vector<int>>(json);
+    ValidateThrow<std::array<int, 1>>(json);
 
     std::vector<int> vector = {7, 8};
     std::array<int, 1> array1 = {7};
@@ -446,24 +454,24 @@ TEST_F(JsonTest, ArrayConversionTest)
     EXPECT_EQ((std::array<int, 3>(json)), empty3);
 
     json = true;
-    EXPECT_THROW((std::vector<int>(json)), fly::JsonException);
-    EXPECT_THROW((std::array<int, 1>(json)), fly::JsonException);
+    ValidateThrow<std::vector<int>>(json);
+    ValidateThrow<std::array<int, 1>>(json);
 
     json = 1;
-    EXPECT_THROW((std::vector<int>(json)), fly::JsonException);
-    EXPECT_THROW((std::array<int, 1>(json)), fly::JsonException);
+    ValidateThrow<std::vector<int>>(json);
+    ValidateThrow<std::array<int, 1>>(json);
 
     json = static_cast<unsigned int>(1);
-    EXPECT_THROW((std::vector<int>(json)), fly::JsonException);
-    EXPECT_THROW((std::array<int, 1>(json)), fly::JsonException);
+    ValidateThrow<std::vector<int>>(json);
+    ValidateThrow<std::array<int, 1>>(json);
 
     json = 1.0f;
-    EXPECT_THROW((std::vector<int>(json)), fly::JsonException);
-    EXPECT_THROW((std::array<int, 1>(json)), fly::JsonException);
+    ValidateThrow<std::vector<int>>(json);
+    ValidateThrow<std::array<int, 1>>(json);
 
     json = nullptr;
-    EXPECT_THROW((std::vector<int>(json)), fly::JsonException);
-    EXPECT_THROW((std::array<int, 1>(json)), fly::JsonException);
+    ValidateThrow<std::vector<int>>(json);
+    ValidateThrow<std::array<int, 1>>(json);
 }
 
 //==============================================================================
@@ -516,19 +524,19 @@ TEST_F(JsonTest, SignedIntegerConversionTest)
     fly::Json json;
 
     json = "abc";
-    EXPECT_THROW((int(json)), fly::JsonException);
+    ValidateThrow<int>(json);
 
     json = "123";
     EXPECT_EQ(int(json), 123);
 
     json = {{"a", 1}, {"b", 2}};
-    EXPECT_THROW((int(json)), fly::JsonException);
+    ValidateThrow<int>(json);
 
     json = {7, 8};
-    EXPECT_THROW((int(json)), fly::JsonException);
+    ValidateThrow<int>(json);
 
     json = true;
-    EXPECT_THROW((int(json)), fly::JsonException);
+    ValidateThrow<int>(json);
 
     char ch = 'a';
     json = ch;
@@ -547,7 +555,7 @@ TEST_F(JsonTest, SignedIntegerConversionTest)
     EXPECT_EQ(int(json), int(floating));
 
     json = nullptr;
-    EXPECT_THROW((int(json)), fly::JsonException);
+    ValidateThrow<int>(json);
 }
 
 //==============================================================================
@@ -556,19 +564,19 @@ TEST_F(JsonTest, UnsignedIntegerConversionTest)
     fly::Json json;
 
     json = "abc";
-    EXPECT_THROW((unsigned(json)), fly::JsonException);
+    ValidateThrow<unsigned>(json);
 
     json = "123";
     EXPECT_EQ(unsigned(json), unsigned(123));
 
     json = {{"a", 1}, {"b", 2}};
-    EXPECT_THROW((unsigned(json)), fly::JsonException);
+    ValidateThrow<unsigned>(json);
 
     json = {7, 8};
-    EXPECT_THROW((unsigned(json)), fly::JsonException);
+    ValidateThrow<unsigned>(json);
 
     json = true;
-    EXPECT_THROW((unsigned(json)), fly::JsonException);
+    ValidateThrow<unsigned>(json);
 
     char ch = 'a';
     json = ch;
@@ -587,7 +595,7 @@ TEST_F(JsonTest, UnsignedIntegerConversionTest)
     EXPECT_EQ(unsigned(json), unsigned(floating));
 
     json = nullptr;
-    EXPECT_THROW((unsigned(json)), fly::JsonException);
+    ValidateThrow<unsigned>(json);
 }
 
 //==============================================================================
@@ -596,19 +604,19 @@ TEST_F(JsonTest, FloatConversionTest)
     fly::Json json;
 
     json = "abc";
-    EXPECT_THROW((float(json)), fly::JsonException);
+    ValidateThrow<float>(json);
 
     json = "123.5";
     EXPECT_EQ(float(json), 123.5f);
 
     json = {{"a", 1}, {"b", 2}};
-    EXPECT_THROW((float(json)), fly::JsonException);
+    ValidateThrow<float>(json);
 
     json = {7, 8};
-    EXPECT_THROW((float(json)), fly::JsonException);
+    ValidateThrow<float>(json);
 
     json = true;
-    EXPECT_THROW((float(json)), fly::JsonException);
+    ValidateThrow<float>(json);
 
     char ch = 'a';
     json = ch;
@@ -627,7 +635,7 @@ TEST_F(JsonTest, FloatConversionTest)
     EXPECT_EQ(float(json), floating);
 
     json = nullptr;
-    EXPECT_THROW((float(json)), fly::JsonException);
+    ValidateThrow<float>(json);
 }
 
 //==============================================================================
@@ -636,28 +644,28 @@ TEST_F(JsonTest, NullConversionTest)
     fly::Json json;
 
     json = "abc";
-    EXPECT_THROW((std::nullptr_t(json)), fly::JsonException);
+    ValidateThrow<std::nullptr_t>(json);
 
     json = {{"a", 1}, {"b", 2}};
-    EXPECT_THROW((std::nullptr_t(json)), fly::JsonException);
+    ValidateThrow<std::nullptr_t>(json);
 
     json = {7, 8};
-    EXPECT_THROW((std::nullptr_t(json)), fly::JsonException);
+    ValidateThrow<std::nullptr_t>(json);
 
     json = true;
-    EXPECT_THROW((std::nullptr_t(json)), fly::JsonException);
+    ValidateThrow<std::nullptr_t>(json);
 
     json = 'a';
-    EXPECT_THROW((std::nullptr_t(json)), fly::JsonException);
+    ValidateThrow<std::nullptr_t>(json);
 
     json = 12;
-    EXPECT_THROW((std::nullptr_t(json)), fly::JsonException);
+    ValidateThrow<std::nullptr_t>(json);
 
     json = static_cast<unsigned int>(12);
-    EXPECT_THROW((std::nullptr_t(json)), fly::JsonException);
+    ValidateThrow<std::nullptr_t>(json);
 
     json = 3.14f;
-    EXPECT_THROW((std::nullptr_t(json)), fly::JsonException);
+    ValidateThrow<std::nullptr_t>(json);
 
     json = nullptr;
     EXPECT_EQ((std::nullptr_t(json)), nullptr);


### PR DESCRIPTION
Include both clang and gcc in CI debug builds, but only use clang for release
builds. Clang seems to provide stricter compile warnings and slightly smaller
library/binary output sizes.

Code coverage will continue to be provided by gcc only for now. There are two
options for coverage with clang: GCOV-compatible and source-based coverage.

GCOV-compatible coverage falsely reports a significant amount of lines which
contain only a closing curly brace as uncovered. So while it'd be convenient
since it works easily with LCOV, it's not really a viable option.

Source-based coverage seems straightforward enough. But it reports quite a
large amount of uncovered lines. Some seem legit, others seem false. So I'll
look at this more in another branch.