### PR TITLE
Move coverage report generation to build system

### DIFF
--- a/build/ci/linux.yml
+++ b/build/ci/linux.yml
@@ -28,7 +28,7 @@ jobs:
       # For now, only emit LCOV reports for gcc.
       - ${{ if eq(parameters.toolchain, 'gcc') }}:
         - script: |
-            make -C build/nix $(config) coverage
+            make -C build/nix $(config) coverage upload=1
           displayName: 'Coverage'
 
     - ${{ if eq(parameters.configuration, 'Release') }}:

--- a/build/ci/linux.yml
+++ b/build/ci/linux.yml
@@ -25,21 +25,10 @@ jobs:
           make -j -C build/nix $(config) tests
         displayName: 'Test'
 
-      # For now, only emit LCOV reports for gcc. With clang, llvm-cov reports
-      # lines containing only a closing curly brace as uncovered. See:
-      #     https://libcellml.readthedocs.io/en/latest/coverage_statistics.html
-      #
-      # Alternatively, should be able to upload clang coverage reports that are
-      # non-GCOV-formatted. Something like:
-      #     llvm-profdata merge -sparse default.profraw -o default.prodata
-      #     llvm-cov show libfly_unit_tests -instr-profile=default.prodata --ignore-filename-regex="test/.*" > /tmp/coverage
+      # For now, only emit LCOV reports for gcc.
       - ${{ if eq(parameters.toolchain, 'gcc') }}:
         - script: |
-            lcov --capture --directory build/nix --output-file coverage
-            lcov --remove coverage '/usr/*' '*/test/*' --output-file coverage
-            lcov --list coverage
-
-            bash <(curl -s https://codecov.io/bash) -f coverage
+            make -C build/nix $(config) coverage
           displayName: 'Coverage'
 
     - ${{ if eq(parameters.configuration, 'Release') }}:

--- a/build/nix/build.mk
+++ b/build/nix/build.mk
@@ -6,7 +6,7 @@
 .PHONY: all
 .PHONY: clean
 .PHONY: tests
-.PHONY: gcov
+.PHONY: coverage
 .PHONY: install
 .PHONY: setup
 .PHONY: qt
@@ -53,7 +53,7 @@ clean:
 tests: $(TEST_BINARIES)
 	$(Q)failed=0; \
 	for tgt in $(TEST_BINARIES) ; do \
-		if [[ $(toolchain) == "clang" ]] ; then \
+		if [[ $(toolchain) == "clang" ]] && [[ $(release) -eq 0 ]] ; then \
 			export LLVM_PROFILE_FILE="$$tgt.profraw"; \
 		fi; \
 		\
@@ -66,18 +66,32 @@ tests: $(TEST_BINARIES)
 	exit $$failed
 
 # Create coverage reports
-gcov: tests
-	$(Q)for obj in $$(find $(OBJ_DIR) -name "*.o" -print) ; do \
-		path=$$(dirname "$$obj"); \
-		file=$$(basename "$$obj"); \
-		\
-		pushd $$path > /dev/null; \
-		gcov $(GCOV_FLAGS) $$file; \
-		\
-		popd > /dev/null; \
-	done; \
-	\
-	find . -name "*\#\#*.gcov" | xargs grep -l "/usr/include" | xargs -I {} $(RM) {}
+coverage: report := $(OUT_DIR)/coverage
+coverage:
+ifeq ($(toolchain), clang)
+	$(Q)llvm-profdata merge \
+		--output $(report).prodata \
+		$(addsuffix .profraw, $(TEST_BINARIES))
+
+	$(Q)llvm-cov show \
+		--instr-profile=$(report).prodata \
+		--ignore-filename-regex="test/.*" \
+		$(TEST_BINARIES) > $(report)
+
+	$(Q)llvm-cov report \
+		--instr-profile=$(report).prodata \
+		--ignore-filename-regex="test/.*" \
+		$(TEST_BINARIES)
+
+else ifeq ($(toolchain), gcc)
+	$(Q)lcov --capture --directory $(OUT_DIR) --output-file $(report)
+	$(Q)lcov --remove $(report) '/usr/*' '*/test/*' --output-file $(report)
+	$(Q)lcov --list $(report)
+endif
+
+ifeq ($(upload), 1)
+	$(Q)bash <(curl -s https://codecov.io/bash) -f $(report)
+endif
 
 # Install the target
 install: $(TARGET_PACKAGES)
@@ -95,13 +109,13 @@ install: $(TARGET_PACKAGES)
 # Install dependencies
 setup:
 ifeq ($(HOST), DEBIAN)
-	$(Q)$(SUDO) apt-get install -y git make gcc g++ clang lld llvm clang-format
+	$(Q)$(SUDO) apt install -y git make clang clang-format lld llvm gcc g++ lcov
 ifeq ($(arch), x86)
-	$(Q)$(SUDO) apt-get install -y gcc-multilib g++-multilib
+	$(Q)$(SUDO) apt install -y gcc-multilib g++-multilib
 endif
 
 else ifeq ($(HOST), REDHAT)
-	$(Q)$(SUDO) dnf install -y git make gcc gcc-c++ clang lld llvm \
+	$(Q)$(SUDO) dnf install -y git make clang lld llvm gcc gcc-c++ lcov \
 		libstdc++-static libasan libatomic
 ifeq ($(arch), x86)
 	$(Q)$(SUDO) dnf install -y glibc-devel.i686 \
@@ -122,7 +136,7 @@ ifeq ($(arch), x86)
 endif
 
 ifeq ($(HOST), DEBIAN)
-	$(Q)$(SUDO) apt-get install -y mesa-common-dev
+	$(Q)$(SUDO) apt install -y mesa-common-dev
 endif
 	$(Q)$(QT_INSTALL)
 

--- a/build/nix/build.mk
+++ b/build/nix/build.mk
@@ -87,7 +87,6 @@ else ifeq ($(toolchain), gcc)
 	$(Q)lcov --capture --directory $(OUT_DIR) --output-file $(report)
 	$(Q)lcov --remove $(report) '/usr/*' '*/test/*' --output-file $(report)
 	$(Q)lcov --list $(report)
-endif
 
 else
 	$(Q)echo "No coverage rules for toolchain $(toolchain), check build.mk"

--- a/build/nix/build.mk
+++ b/build/nix/build.mk
@@ -89,6 +89,11 @@ else ifeq ($(toolchain), gcc)
 	$(Q)lcov --list $(report)
 endif
 
+else
+	$(Q)echo "No coverage rules for toolchain $(toolchain), check build.mk"
+	$(Q)exit 1
+endif
+
 ifeq ($(upload), 1)
 	$(Q)bash <(curl -s https://codecov.io/bash) -f $(report)
 endif
@@ -120,10 +125,10 @@ else ifeq ($(HOST), REDHAT)
 ifeq ($(arch), x86)
 	$(Q)$(SUDO) dnf install -y glibc-devel.i686 \
 		libstdc++-static.i686 libasan.i686 libatomic.i686
-endif
+endifd
 
 else
-	$(Q)echo "No setup rules defined for host $(HOST), check build.mk"
+	$(Q)echo "No setup rules for host $(HOST), check build.mk"
 	$(Q)exit 1
 endif
 

--- a/build/nix/build.mk
+++ b/build/nix/build.mk
@@ -124,7 +124,7 @@ else ifeq ($(HOST), REDHAT)
 ifeq ($(arch), x86)
 	$(Q)$(SUDO) dnf install -y glibc-devel.i686 \
 		libstdc++-static.i686 libasan.i686 libatomic.i686
-endifd
+endif
 
 else
 	$(Q)echo "No setup rules for host $(HOST), check build.mk"


### PR DESCRIPTION
Rather than being in the YAML for CI, add a 'make coverage' command to
the build system, which has better knowledge of the toolchain in use.