### PR TITLE
Add API for excluding paths from code coverage

### DIFF
--- a/build/nix/Makefile
+++ b/build/nix/Makefile
@@ -13,5 +13,12 @@ $(eval $(call ADD_TARGET, libfly, fly, LIB))
 # Test targets
 $(eval $(call ADD_TARGET, libfly_unit_tests, test, TEST))
 
+# Paths to ignore during code coverage reporting
+# 1. Ignore test files
+# 2. Ignore literal_parser.h - this file is entirely constexpr functions that
+#    cannot execute at runtime, which llvm-cov doesn't seem to recognize
+$(eval $(call IGNORE_FOR_COVERAGE, test/))
+$(eval $(call IGNORE_FOR_COVERAGE, fly/types/numeric/detail/literal_parser.h))
+
 # Import the build system
 include build.mk

--- a/build/nix/api.mk
+++ b/build/nix/api.mk
@@ -1,13 +1,29 @@
 # Set of API functions for using the build system. Applications using this build
 # system should include this file first.
 
+# Verify expected variables
+ifeq ($(SOURCE_ROOT),)
+    $(error SOURCE_ROOT must be defined)
+else ifeq ($(wildcard $(SOURCE_ROOT)/.*),)
+    $(error SOURCE_ROOT $(SOURCE_ROOT) does not exist)
+endif
+
+ifeq ($(VERSION),)
+    $(error VERSION must be defined)
+else ifneq ($(words $(subst ., ,$(VERSION))), 3)
+    $(error VERSION $(VERSION) must be of the form X.Y.Z)
+endif
+
 # List of all target names
 TARGETS :=
 
 # List of all test target names
 TEST_TARGETS :=
 
-# Function to define a target.
+# List of paths to ignore during code coverage reporting
+COVERAGE_BLACKLIST :=
+
+# Define a target.
 #
 # $(1) = The target's name.
 # $(2) = The target's source directory.
@@ -23,5 +39,18 @@ ifeq ($(strip $(3)), TEST)
 else
     TARGET_TYPE_$$(strip $(1)) := $(3)
 endif
+
+endef
+
+# Add a path the the code coverage blacklist.
+#
+# $(1) = The path to ignore.
+define IGNORE_FOR_COVERAGE
+
+ifeq ($$(wildcard $(SOURCE_ROOT)/$$(strip $(1))),)
+    $$(error Could not find path $$(strip $(1)), check your Makefile)
+endif
+
+COVERAGE_BLACKLIST += $(1)
 
 endef


### PR DESCRIPTION
Use this API rather than hard-coding paths to exclude in build.mk.
Continue always excluding /usr for gcc, though.