### PR TITLE
Add support for compiler caches like ccache

### DIFF
--- a/build/nix/compile.mk
+++ b/build/nix/compile.mk
@@ -109,8 +109,9 @@ define OBJ_RULES
 
 MAKEFILES_$(d) := $(BUILD_ROOT)/flags.mk $(wildcard $(d)/*.mk)
 
-$(1)/%.o: CFLAGS := $(CFLAGS_$(d)) $(CFLAGS)
-$(1)/%.o: CXXFLAGS := $(CXXFLAGS_$(d)) $(CXXFLAGS)
+# Use = instead of := because $$(@) would become an empty string if expanded now
+$(1)/%.o: CFLAGS = $(CFLAGS_$(d)) $(CFLAGS) -MF $$(@:%.o=%.d)
+$(1)/%.o: CXXFLAGS = $(CXXFLAGS_$(d)) $(CXXFLAGS) -MF $$(@:%.o=%.d)
 
 # C files
 $(1)/%.o: $(d)/%.c $$(MAKEFILES_$(d))

--- a/build/nix/config.mk
+++ b/build/nix/config.mk
@@ -18,17 +18,23 @@ verbose := 0
 
 # Define the toolchain binaries
 ifeq ($(toolchain), clang)
-    CC := $(cacher) clang
-    CXX := $(cacher) clang++
+    CC := clang
+    CXX := clang++
     AR := llvm-ar
     STRIP := llvm-strip
 else ifeq ($(toolchain), gcc)
-    CC := $(cacher) gcc
-    CXX := $(cacher) g++
+    CC := gcc
+    CXX := g++
     AR := ar
     STRIP := strip
 else
     $(error Unrecognized toolchain $(toolchain), check config.mk)
+endif
+
+# Use a compiler cache if requested
+ifneq ($(cacher), )
+    CC := $(cacher) $(CC)
+    CXX := $(cacher) $(CXX)
 endif
 
 # Define the output directories
@@ -54,6 +60,7 @@ else
     $(info Obj dir = $(OBJ_DIR))
     $(info Etc dir = $(ETC_DIR))
     $(info Toolchain = $(toolchain))
+    $(info Cacher = $(cacher))
     $(info Release = $(release))
     $(info Arch = $(arch))
 endif

--- a/build/nix/config.mk
+++ b/build/nix/config.mk
@@ -4,6 +4,9 @@
 # Toolchain to compile with
 toolchain := clang
 
+# Compile caching system
+cacher :=
+
 # Define debug vs. release
 release := 0
 
@@ -15,13 +18,13 @@ verbose := 0
 
 # Define the toolchain binaries
 ifeq ($(toolchain), clang)
-    CC := clang
-    CXX := clang++
+    CC := $(cacher) clang
+    CXX := $(cacher) clang++
     AR := llvm-ar
     STRIP := llvm-strip
 else ifeq ($(toolchain), gcc)
-    CC := gcc
-    CXX := g++
+    CC := $(cacher) gcc
+    CXX := $(cacher) g++
     AR := ar
     STRIP := strip
 else


### PR DESCRIPTION
One odd thing is that dependency files were placed in //build/nix rather
than next to the corresponding object files. Use -MF to specify the path
to generate dependency files.