### PR TITLE
Inherit parent directory compiler and linker flags

### DIFF
--- a/build/nix/files.mk
+++ b/build/nix/files.mk
@@ -7,16 +7,12 @@
 define OBJ_OUT_FILES
 
 OBJ_DIR_$(d) := $(OBJ_DIR)/$$(subst $(SOURCE_ROOT)/,,$(d))
-GEN_DIR_$(d) := $(GEN_DIR)/$$(subst $(SOURCE_ROOT)/,,$(d))
 
 o_$(d) := $$(addsuffix .o, $$(subst $(d),,$$(basename $(2))))
 o_$(d) := $$(addprefix $$(OBJ_DIR_$(d)), $$(o_$(d)))
 
 OBJ_$$(strip $(1)) += $$(o_$(d))
 DEP_$(d) := $$(o_$(d):%.o=%.d)
-
-CFLAGS_$$(d) += -I$$(GEN_DIR_$(d))
-CXXFLAGS_$$(d) += -I$$(GEN_DIR_$(d))
 
 endef
 
@@ -56,9 +52,9 @@ ifneq ($(5),)
     GEN_$$(strip $(1)) += $$(gu_$(d)) $$(gm_$(d)) $$(gq_$(d))
     OBJ_$$(strip $(1)) += $$(om_$(d)) $$(oq_$(d))
 
-    CFLAGS_$$(d) += $(QT_CFLAGS)
-    CXXFLAGS_$$(d) += $(QT_CFLAGS)
-    LDFLAGS_$$(d) += $(QT_LDFLAGS)
+    CFLAGS_$(d) += $(QT_CFLAGS) -I$$(GEN_DIR_$(d))
+    CXXFLAGS_$(d) += $(QT_CFLAGS) -I$$(GEN_DIR_$(d))
+    LDFLAGS_$(d) += $(QT_LDFLAGS)
     LDLIBS_$(d) += $$(addprefix -lQt$(QT_VERSION_MAJOR), $(5))
 endif
 

--- a/build/nix/flags.mk
+++ b/build/nix/flags.mk
@@ -20,12 +20,6 @@ ifeq ($(arch), x86)
     CF_ALL += -m32
 endif
 
-# Unit tests include Google test
-# TODO: should be moved to //test/files.mk, but first must implement inheriting
-# parent directory CFLAGS.
-CF_ALL += -isystem $(SOURCE_ROOT)/test/googletest/googletest/include
-CF_ALL += -I$(SOURCE_ROOT)/test/googletest/googletest
-
 # Optimize release builds, and add debug symbols / use address sanitizer for
 # debug builds
 ifeq ($(release), 1)

--- a/build/nix/stack.mk
+++ b/build/nix/stack.mk
@@ -13,7 +13,8 @@
 # we need to be able to include subdirectories without the current directory
 # forgetting the previous directory.
 
-# Push a directory to the stack.
+# Push a directory to the stack. Default compiler and linker flags to the parent
+# directory's flag values.
 #
 # $(1) = The path to the target root directory.
 define PUSH_DIR
@@ -22,6 +23,13 @@ sp := $$(sp).x
 pd_$$(sp) := $$(d)
 
 d := $(SOURCE_ROOT)/$$(strip $(1))
+
+_$$(d) := $$(strip $$(patsubst %/, %, $$(dir $$(d))))
+
+CFLAGS_$$(d) := $$(CFLAGS_$$(_$$(d)))
+CXXFLAGS_$$(d) := $$(CXXFLAGS_$$(_$$(d)))
+LDFLAGS_$$(d) := $$(LDFLAGS_$$(_$$(d)))
+LDLIBS_$$(d) := $$(LDLIBS_$$(_$$(d)))
 
 endef
 

--- a/test/files.mk
+++ b/test/files.mk
@@ -37,12 +37,16 @@ SRC_$(d) := \
 SYSTEM_CALLS_$(d) := \
     ${shell grep -ohP "(?<=__wrap_)[a-zA-Z0-9_]+" "$(d)/mock/nix/mock_calls.cpp"}
 
+# Define compiler flags
+CXXFLAGS_$(d) += -isystem $(SOURCE_ROOT)/test/googletest/googletest/include
+CXXFLAGS_$(d) += -I$(SOURCE_ROOT)/test/googletest/googletest
+
 # Define linker flags
 LDFLAGS_$(d) += \
     -static-libstdc++ \
     $(foreach mock, $(SYSTEM_CALLS_$(d)), -Wl,--wrap=$(mock))
 
 # Define libraries to link
-LDLIBS_$(d) := \
+LDLIBS_$(d) += \
     -latomic \
     -lpthread


### PR DESCRIPTION
If a directory defines compiler or linker flag specific to its files.mk
(e.g. CFLAGS_$(d)), subdirectories will now inherit those flags by
default. They may override this behavior by assigning their own flags
using the := assignment flavor in their files.mk.

The main use case is to add the -I flag for Google test only to files
under the //test directory.