### PR TITLE
Remove platform-dependent SystemImpl::GetErrorString()

### DIFF
--- a/fly/system/nix/system_impl.cpp
+++ b/fly/system/nix/system_impl.cpp
@@ -46,12 +46,6 @@ int SystemImpl::GetErrorCode() noexcept
 }
 
 //==============================================================================
-std::string SystemImpl::GetErrorString(int code) noexcept
-{
-    return "(" + std::to_string(code) + ") " + ::strerror(code);
-}
-
-//==============================================================================
 std::vector<int> SystemImpl::GetSignals() noexcept
 {
     return {SIGINT, SIGTERM, SIGSYS, SIGBUS, SIGILL, SIGFPE, SIGABRT, SIGSEGV};

--- a/fly/system/nix/system_impl.h
+++ b/fly/system/nix/system_impl.h
@@ -17,7 +17,6 @@ public:
     static void PrintBacktrace() noexcept;
     static std::string LocalTime(const std::string &) noexcept;
     static int GetErrorCode() noexcept;
-    static std::string GetErrorString(int) noexcept;
     static std::vector<int> GetSignals() noexcept;
 };
 

--- a/fly/system/system.cpp
+++ b/fly/system/system.cpp
@@ -1,8 +1,10 @@
 #include "fly/system/system.h"
 
 #include "fly/fly.h"
+#include "fly/types/string/string.h"
 
 #include <csignal>
+#include <system_error>
 #include <vector>
 
 #include FLY_OS_IMPL_PATH(system, system)
@@ -36,7 +38,10 @@ std::string System::GetErrorString() noexcept
 //==============================================================================
 std::string System::GetErrorString(int code) noexcept
 {
-    return SystemImpl::GetErrorString(code);
+    return fly::String::Format(
+        "(%d) %s",
+        code,
+        std::system_category().message(code));
 }
 
 //==============================================================================

--- a/fly/system/win/system_impl.cpp
+++ b/fly/system/win/system_impl.cpp
@@ -1,25 +1,12 @@
 #include "fly/system/win/system_impl.h"
 
-#include "fly/logger/logger.h"
-#include "fly/types/string/string.h"
-
 #include <Windows.h>
 
-#include <atomic>
 #include <chrono>
 #include <csignal>
 #include <cstdio>
 
 namespace fly {
-
-namespace {
-
-    const DWORD s_formatFlags = FORMAT_MESSAGE_FROM_SYSTEM |
-        FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_IGNORE_INSERTS;
-
-    const DWORD s_langId = MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT);
-
-} // namespace
 
 //==============================================================================
 void SystemImpl::PrintBacktrace() noexcept
@@ -58,37 +45,7 @@ std::string SystemImpl::LocalTime(const std::string &fmt) noexcept
 //==============================================================================
 int SystemImpl::GetErrorCode() noexcept
 {
-    return ::WSAGetLastError();
-}
-
-//==============================================================================
-std::string SystemImpl::GetErrorString(int code) noexcept
-{
-    LPTSTR str = nullptr;
-    std::string ret;
-
-    ::FormatMessage(
-        s_formatFlags,
-        nullptr,
-        code,
-        s_langId,
-        (LPTSTR)&str,
-        0,
-        nullptr);
-
-    if (str == nullptr)
-    {
-        ret = std::to_string(code);
-    }
-    else
-    {
-        ret = "(" + std::to_string(code) + ") " + str;
-        String::Trim(ret);
-
-        ::LocalFree(str);
-    }
-
-    return ret;
+    return ::GetLastError();
 }
 
 //==============================================================================

--- a/fly/system/win/system_impl.h
+++ b/fly/system/win/system_impl.h
@@ -17,7 +17,6 @@ public:
     static void PrintBacktrace() noexcept;
     static std::string LocalTime(const std::string &) noexcept;
     static int GetErrorCode() noexcept;
-    static std::string GetErrorString(int) noexcept;
     static std::vector<int> GetSignals() noexcept;
 };
 


### PR DESCRIPTION
C++11 apparently includes a <system_error> header with methods for this
purpose. Unfortunately, I don't see a way of removing GetErrorCode()
as well. You can construct std::error_code from platform-specific
codes (errno, ::GetLastError()), but there's not a platform-independent
accessor.