### PR TITLE
Split over-sized BitStreamReader::PeekBits operations

### DIFF
--- a/fly/coders/huffman/huffman_decoder.cpp
+++ b/fly/coders/huffman/huffman_decoder.cpp
@@ -87,6 +87,7 @@ bool HuffmanDecoder::decodeHeaderVersion1(
 {
     // Decode the chunk size.
     word_type encodedChunkSizeKB;
+
     if (!input.ReadWord(encodedChunkSizeKB))
     {
         LOGW("Could not decode chunk size");
@@ -102,6 +103,7 @@ bool HuffmanDecoder::decodeHeaderVersion1(
 
     // Decode the maximum Huffman code length.
     byte_type encodedMaxCodeLength;
+
     if (!input.ReadByte(encodedMaxCodeLength))
     {
         LOGW("Could not decode maximum code length");
@@ -133,6 +135,7 @@ bool HuffmanDecoder::decodeCodes(
 
     // Decode the number of code length counts.
     byte_type countsSize;
+
     if (!input.ReadByte(countsSize))
     {
         LOGW("Could not decode number of code length counts");

--- a/fly/coders/huffman/huffman_decoder.cpp
+++ b/fly/coders/huffman/huffman_decoder.cpp
@@ -171,6 +171,7 @@ bool HuffmanDecoder::decodeCodes(
         for (std::uint16_t i = 0; i < counts[length]; ++i)
         {
             byte_type symbol;
+
             if (!input.ReadByte(symbol))
             {
                 LOGW(
@@ -235,7 +236,7 @@ bool HuffmanDecoder::decodeSymbols(
     std::uint32_t bytes = 0;
     code_type index;
 
-    while ((bytes < chunkSize) && (input.PeekBits(maxCodeLength, index) != 0))
+    while ((bytes < chunkSize) && (input.PeekBits(index, maxCodeLength) != 0))
     {
         const HuffmanCode &code = m_prefixTable[index];
 

--- a/fly/coders/huffman/huffman_decoder.h
+++ b/fly/coders/huffman/huffman_decoder.h
@@ -71,7 +71,7 @@ private:
      * Decode version 1 of the header. Extract the maximum chunk length and the
      * global maximum Huffman code length the encoder used.
      *
-     * @param BitStreamWriter Stream to store the encoded header.
+     * @param BitStreamWriter Stream storing the encoded header.
      * @param uint32_t Location to store the maximum chunk size (in bytes).
      * @param length_type Location to store the global maximum Huffman code
      *                    length.

--- a/fly/coders/huffman/huffman_encoder.cpp
+++ b/fly/coders/huffman/huffman_encoder.cpp
@@ -59,26 +59,11 @@ bool HuffmanEncoder::EncodeInternal(
 //==============================================================================
 std::uint32_t HuffmanEncoder::readStream(std::istream &input) const noexcept
 {
-    const std::ios::pos_type start = input.tellg();
-    input.seekg(0, std::ios::end);
+    input.read(
+        reinterpret_cast<std::ios::char_type *>(m_chunkBuffer.get()),
+        static_cast<std::streamsize>(m_chunkSize));
 
-    const std::ios::pos_type length = input.tellg() - start;
-    input.seekg(start, std::ios::beg);
-
-    std::uint32_t bytesRead = 0;
-
-    if (length > 0)
-    {
-        input.read(
-            reinterpret_cast<std::ios::char_type *>(m_chunkBuffer.get()),
-            std::min(
-                static_cast<std::streamsize>(length),
-                static_cast<std::streamsize>(m_chunkSize)));
-
-        bytesRead = static_cast<std::uint32_t>(input.gcount());
-    }
-
-    return bytesRead;
+    return static_cast<std::uint32_t>(input.gcount());
 }
 
 //==============================================================================

--- a/fly/types/bit_stream/bit_stream_reader.cpp
+++ b/fly/types/bit_stream/bit_stream_reader.cpp
@@ -15,7 +15,7 @@ BitStreamReader::BitStreamReader(std::istream &stream) noexcept :
     byte_type magic = 0;
 
     // Cannot use ReadByte because the remainder bits are not known yet.
-    const byte_type bytesRead = fill(detail::s_byteTypeSize, header);
+    const byte_type bytesRead = fill(header, detail::s_byteTypeSize);
 
     if (bytesRead == 1_u8)
     {
@@ -33,13 +33,13 @@ BitStreamReader::BitStreamReader(std::istream &stream) noexcept :
 //==============================================================================
 bool BitStreamReader::ReadWord(word_type &word) noexcept
 {
-    return ReadBits(detail::s_bitsPerWord, word) == detail::s_bitsPerWord;
+    return ReadBits(word, detail::s_bitsPerWord) == detail::s_bitsPerWord;
 }
 
 //==============================================================================
 bool BitStreamReader::ReadByte(byte_type &byte) noexcept
 {
-    return ReadBits(detail::s_bitsPerByte, byte) == detail::s_bitsPerByte;
+    return ReadBits(byte, detail::s_bitsPerByte) == detail::s_bitsPerByte;
 }
 
 //==============================================================================
@@ -67,7 +67,7 @@ bool BitStreamReader::refillBuffer() noexcept
     buffer_type buffer = 0;
 
     const byte_type bytesRead =
-        fill(bitsToFill / detail::s_bitsPerByte, buffer);
+        fill(buffer, bitsToFill / detail::s_bitsPerByte);
     const byte_type bitsRead = bytesRead * detail::s_bitsPerByte;
 
     if (bitsRead == 0)

--- a/fly/types/bit_stream/bit_stream_reader.cpp
+++ b/fly/types/bit_stream/bit_stream_reader.cpp
@@ -60,7 +60,7 @@ bool BitStreamReader::FullyConsumed() const noexcept
 }
 
 //==============================================================================
-bool BitStreamReader::refillBuffer() noexcept
+void BitStreamReader::refillBuffer() noexcept
 {
     const byte_type bitsToFill =
         detail::s_mostSignificantBitPosition - m_position;
@@ -68,14 +68,10 @@ bool BitStreamReader::refillBuffer() noexcept
 
     const byte_type bytesRead =
         fill(buffer, bitsToFill / detail::s_bitsPerByte);
-    const byte_type bitsRead = bytesRead * detail::s_bitsPerByte;
 
-    if (bitsRead == 0)
+    if (bytesRead > 0)
     {
-        return m_position > 0;
-    }
-    else
-    {
+        const byte_type bitsRead = bytesRead * detail::s_bitsPerByte;
         m_position += bitsRead;
 
         // It is undefined behavior to bit-shift by the size of the value being
@@ -84,16 +80,14 @@ bool BitStreamReader::refillBuffer() noexcept
         // into two operations in order to avoid that undefined behavior.
         m_buffer = (m_buffer << 1) << (bitsRead - 1);
         m_buffer |= buffer >> (detail::s_mostSignificantBitPosition - bitsRead);
-    }
 
-    if (m_stream.peek() == EOF)
-    {
-        // At end-of-file, discard any encoded zero-filled bits.
-        m_position -= m_remainder;
-        m_buffer >>= m_remainder;
+        if (m_stream.peek() == EOF)
+        {
+            // At end-of-file, discard any encoded zero-filled bits.
+            m_position -= m_remainder;
+            m_buffer >>= m_remainder;
+        }
     }
-
-    return true;
 }
 
 } // namespace fly

--- a/fly/types/bit_stream/bit_stream_reader.cpp
+++ b/fly/types/bit_stream/bit_stream_reader.cpp
@@ -15,7 +15,7 @@ BitStreamReader::BitStreamReader(std::istream &stream) noexcept :
     byte_type magic = 0;
 
     // Cannot use ReadByte because the remainder bits are not known yet.
-    const byte_type bytesRead = fill(header, detail::s_byteTypeSize);
+    const byte_type bytesRead = fill(detail::s_byteTypeSize, header);
 
     if (bytesRead == 1_u8)
     {
@@ -67,7 +67,7 @@ bool BitStreamReader::refillBuffer() noexcept
     buffer_type buffer = 0;
 
     const byte_type bytesRead =
-        fill(buffer, bitsToFill / detail::s_bitsPerByte);
+        fill(bitsToFill / detail::s_bitsPerByte, buffer);
     const byte_type bitsRead = bytesRead * detail::s_bitsPerByte;
 
     if (bitsRead == 0)

--- a/fly/types/bit_stream/bit_stream_writer.h
+++ b/fly/types/bit_stream/bit_stream_writer.h
@@ -115,7 +115,7 @@ void BitStreamWriter::WriteBits(DataType bits, byte_type size) noexcept
 
         // Fill the remainder of the byte buffer with as many bits as are
         // available, and flush it onto the stream.
-        m_buffer |= (static_cast<buffer_type>(bits) >> diff);
+        m_buffer |= static_cast<buffer_type>(bits) >> diff;
         flushBuffer();
 
         // Then update the input bits to retain only those bits that have not

--- a/fly/types/bit_stream/bit_stream_writer.h
+++ b/fly/types/bit_stream/bit_stream_writer.h
@@ -114,23 +114,23 @@ void BitStreamWriter::WriteBits(DataType bits, byte_type size) noexcept
     // break the bits into two chunks.
     if (size > m_position)
     {
-        const byte_type diff = size - m_position;
+        const byte_type rshift = size - m_position;
 
         // Fill the remainder of the byte buffer with as many bits as are
         // available, and flush it onto the stream.
-        m_buffer |= static_cast<buffer_type>(bits) >> diff;
+        m_buffer |= static_cast<buffer_type>(bits) >> rshift;
         flushBuffer();
 
         // Then update the input bits to retain only those bits that have not
         // been written yet.
-        bits &= BitMask<DataType>(diff);
-        size = diff;
+        bits &= BitMask<DataType>(rshift);
+        size = rshift;
     }
 
-    const byte_type diff = m_position - size;
+    const byte_type lshift = m_position - size;
 
-    m_buffer |= static_cast<buffer_type>(bits) << diff;
-    m_position = diff;
+    m_buffer |= static_cast<buffer_type>(bits) << lshift;
+    m_position = lshift;
 }
 
 //==============================================================================

--- a/fly/types/bit_stream/bit_stream_writer.h
+++ b/fly/types/bit_stream/bit_stream_writer.h
@@ -120,7 +120,7 @@ void BitStreamWriter::WriteBits(DataType bits, byte_type size) noexcept
 
         // Then update the input bits to retain only those bits that have not
         // been written yet.
-        bits &= GenerateMask<DataType>(diff);
+        bits &= BitMask<DataType>(diff);
         size = diff;
     }
 

--- a/fly/types/bit_stream/bit_stream_writer.h
+++ b/fly/types/bit_stream/bit_stream_writer.h
@@ -35,16 +35,18 @@ public:
     BitStreamWriter(std::iostream &) noexcept;
 
     /**
-     * Write a multibyte word to the byte buffer. Flush the buffer to the stream
-     * if it is filled during this operation.
+     * Write a multibyte word to the byte buffer.
+     *
+     * Flush the buffer to the stream if it is filled during this operation.
      *
      * @param word_type The word to write.
      */
     void WriteWord(word_type) noexcept;
 
     /**
-     * Write a full byte to the byte buffer. Flush the buffer to the stream if
-     * it is filled during this operation.
+     * Write a full byte to the byte buffer.
+     *
+     * Flush the buffer to the stream if it is filled during this operation.
      *
      * @param byte_type The byte to write.
      */
@@ -53,8 +55,9 @@ public:
     /**
      * Write a number of bits to the byte buffer. The least-significant bits in
      * the provided data type will be written, starting from the position
-     * pointed to by the provided number of bits. Flush the buffer to the stream
-     * if it is filled during this operation.
+     * pointed to by the provided number of bits.
+     *
+     * Flush the buffer to the stream if it is filled during this operation.
      *
      * @tparam DataType The data type storing the bits to write.
      *

--- a/fly/types/bit_stream/detail/bit_stream.h
+++ b/fly/types/bit_stream/detail/bit_stream.h
@@ -56,7 +56,7 @@ protected:
      * @return DataType The created mask.
      */
     template <typename DataType>
-    constexpr inline static DataType GenerateMask(const DataType);
+    constexpr inline static DataType BitMask(const DataType);
 
     byte_type m_position;
     buffer_type m_buffer;
@@ -64,16 +64,16 @@ protected:
 
 //==============================================================================
 template <typename DataType>
-constexpr inline DataType BitStream::GenerateMask(const DataType bits)
+constexpr inline DataType BitStream::BitMask(const DataType bits)
 {
     static_assert(
         BitStreamTraits::is_unsigned_integer_v<DataType>,
         "DataType must be an unsigned integer type");
 
-    constexpr auto filledMask = std::numeric_limits<DataType>::max();
-    constexpr auto numberOfBits = std::numeric_limits<DataType>::digits;
+    constexpr auto filled = std::numeric_limits<DataType>::max();
+    constexpr auto digits = std::numeric_limits<DataType>::digits;
 
-    return filledMask >> (numberOfBits - bits);
+    return static_cast<DataType>(-(bits != 0)) & (filled >> (digits - bits));
 }
 
 } // namespace fly::detail

--- a/fly/types/bit_stream/detail/bit_stream_traits.h
+++ b/fly/types/bit_stream/detail/bit_stream_traits.h
@@ -26,6 +26,16 @@ struct BitStreamTraits
     template <typename T>
     constexpr inline static bool is_unsigned_integer_v =
         is_unsigned_integer<T>::value;
+
+    /**
+     * Define a trait for testing if type T is buffer_type.
+     */
+    template <typename T>
+    using is_buffer_type =
+        std::bool_constant<std::is_same_v<buffer_type, std::decay_t<T>>>;
+
+    template <typename T>
+    constexpr inline static bool is_buffer_type_v = is_buffer_type<T>::value;
 };
 
 } // namespace fly::detail

--- a/fly/types/bit_stream/detail/bit_stream_traits.h
+++ b/fly/types/bit_stream/detail/bit_stream_traits.h
@@ -26,16 +26,6 @@ struct BitStreamTraits
     template <typename T>
     constexpr inline static bool is_unsigned_integer_v =
         is_unsigned_integer<T>::value;
-
-    /**
-     * Define a trait for testing if type T is buffer_type.
-     */
-    template <typename T>
-    using is_buffer_type =
-        std::bool_constant<std::is_same_v<buffer_type, std::decay_t<T>>>;
-
-    template <typename T>
-    constexpr inline static bool is_buffer_type_v = is_buffer_type<T>::value;
 };
 
 } // namespace fly::detail

--- a/fly/types/numeric/endian.h
+++ b/fly/types/numeric/endian.h
@@ -45,8 +45,8 @@ enum class Endian : std::uint16_t
  * Templated wrapper around platform built-in byte swapping macros to convert a
  * value between system endianness and a desired endianness.
  *
- * @tparam T The type of the value to swap.
  * @tparam Endian The desired endianness to swap between.
+ * @tparam T The type of the value to swap.
  *
  * @param T The value to swap.
  *

--- a/test/logger/logger.cpp
+++ b/test/logger/logger.cpp
@@ -114,8 +114,7 @@ protected:
                 fly::String::Split(log, '\t');
             ASSERT_EQ(sections.size(), 7_zu);
 
-            const auto index =
-                fly::String::Convert<std::size_t>(sections[0]);
+            const auto index = fly::String::Convert<std::size_t>(sections[0]);
             const auto level = static_cast<fly::Log::Level>(
                 fly::String::Convert<std::uint8_t>(sections[1]));
             const auto time = fly::String::Convert<double>(sections[2]);

--- a/test/types/bit_stream.cpp
+++ b/test/types/bit_stream.cpp
@@ -74,7 +74,7 @@ TEST_F(BitStreamTest, EmptyStreamTest)
     EXPECT_EQ(m_inputStream.gcount(), 0);
 
     // No further reads should succeed.
-    EXPECT_EQ(stream.ReadBits(1, byte), 0_u8);
+    EXPECT_EQ(stream.ReadBits(byte, 1), 0_u8);
     EXPECT_TRUE(m_inputStream.fail());
 }
 
@@ -101,7 +101,7 @@ TEST_F(BitStreamTest, HeaderTest)
         EXPECT_EQ(m_inputStream.gcount(), 1);
 
         // No further reads should succeed.
-        EXPECT_EQ(stream.ReadBits(1, byte), 0_u8);
+        EXPECT_EQ(stream.ReadBits(byte, 1), 0_u8);
         EXPECT_TRUE(stream.FullyConsumed());
     }
 }
@@ -123,7 +123,7 @@ TEST_F(BitStreamTest, BadHeaderTest)
         EXPECT_EQ(m_inputStream.gcount(), 1);
 
         // No further reads should succeed.
-        EXPECT_EQ(stream.ReadBits(1, byte), 0_u8);
+        EXPECT_EQ(stream.ReadBits(byte, 1), 0_u8);
         EXPECT_TRUE(m_inputStream.fail());
     }
 }
@@ -152,11 +152,11 @@ TEST_F(BitStreamTest, SingleBitTest)
         EXPECT_EQ(m_inputStream.gcount(), 1);
 
         // Reading a single bit should succeed.
-        EXPECT_EQ(stream.ReadBits(1, byte), 1_u8);
+        EXPECT_EQ(stream.ReadBits(byte, 1), 1_u8);
         EXPECT_EQ(byte, 1_u8);
 
         // No further reads should succeed.
-        EXPECT_EQ(stream.ReadBits(1, byte), 0_u8);
+        EXPECT_EQ(stream.ReadBits(byte, 1), 0_u8);
         EXPECT_TRUE(stream.FullyConsumed());
     }
 }
@@ -189,7 +189,7 @@ TEST_F(BitStreamTest, SingleByteTest)
         EXPECT_EQ(byte, 0xa);
 
         // No further reads should succeed.
-        EXPECT_EQ(stream.ReadBits(1, byte), 0_u8);
+        EXPECT_EQ(stream.ReadBits(byte, 1), 0_u8);
         EXPECT_TRUE(stream.FullyConsumed());
     }
 }
@@ -222,7 +222,7 @@ TEST_F(BitStreamTest, SingleWordTest)
         EXPECT_EQ(word, 0xae);
 
         // No further reads should succeed.
-        EXPECT_EQ(stream.ReadBits(1, word), 0_u8);
+        EXPECT_EQ(stream.ReadBits(word, 1), 0_u8);
         EXPECT_TRUE(stream.FullyConsumed());
     }
 }
@@ -257,17 +257,17 @@ TEST_F(BitStreamTest, MultiBufferTest)
         EXPECT_EQ(m_inputStream.gcount(), 1);
 
         // Reading all written bits should succeed.
-        EXPECT_EQ(stream.ReadBits(64, buffer), 64_u8);
+        EXPECT_EQ(stream.ReadBits(buffer, 64), 64_u8);
         EXPECT_EQ(buffer, 0xae1ae1ae1ae1ae1a_u64);
 
-        EXPECT_EQ(stream.ReadBits(15, buffer), 15_u8);
+        EXPECT_EQ(stream.ReadBits(buffer, 15), 15_u8);
         EXPECT_EQ(buffer, 0x7ef2);
 
-        EXPECT_EQ(stream.ReadBits(54, buffer), 54_u8);
+        EXPECT_EQ(stream.ReadBits(buffer, 54), 54_u8);
         EXPECT_EQ(buffer, 0x1bc9bc9bc9bc9b_u64);
 
         // No further reads should succeed.
-        EXPECT_EQ(stream.ReadBits(1, buffer), 0_u8);
+        EXPECT_EQ(stream.ReadBits(buffer, 1), 0_u8);
         EXPECT_TRUE(stream.FullyConsumed());
     }
 }
@@ -298,13 +298,13 @@ TEST_F(BitStreamTest, PeekTest)
         // Peeking a single byte multiple times should succeed.
         for (std::uint8_t i = 0; i < 10; ++i)
         {
-            EXPECT_EQ(stream.PeekBits(8_u8, byte), 8_u8);
+            EXPECT_EQ(stream.PeekBits(byte, 8_u8), 8_u8);
             EXPECT_EQ(byte, 0xa);
         }
 
         // After discarding the peeked bits, no further reads should succeed.
         stream.DiscardBits(8_u8);
-        EXPECT_EQ(stream.ReadBits(1, byte), 0_u8);
+        EXPECT_EQ(stream.ReadBits(byte, 1), 0_u8);
         EXPECT_TRUE(stream.FullyConsumed());
     }
 }
@@ -333,12 +333,12 @@ TEST_F(BitStreamTest, OverPeekTest)
         EXPECT_EQ(m_inputStream.gcount(), 1);
 
         // Trying to peek 8 bits should result in 7 bits being peeked.
-        EXPECT_EQ(stream.PeekBits(8_u8, byte), 7_u8);
-        EXPECT_EQ(byte, 0x7f << 1);
+        EXPECT_EQ(stream.PeekBits(byte, 8_u8), 7_u8);
+        EXPECT_EQ(byte, 0x7f);
 
         // After discarding the peeked bits, no further reads should succeed.
         stream.DiscardBits(7_u8);
-        EXPECT_EQ(stream.ReadBits(1, byte), 0_u8);
+        EXPECT_EQ(stream.ReadBits(byte, 1), 0_u8);
         EXPECT_TRUE(stream.FullyConsumed());
     }
 }
@@ -397,7 +397,7 @@ TEST_F(BitStreamTest, FailedWriterStreamTest)
         EXPECT_EQ(m_inputStream.gcount(), 1);
 
         // No further reads should succeed.
-        EXPECT_EQ(stream.ReadBits(1, byte), 0_u8);
+        EXPECT_EQ(stream.ReadBits(byte, 1), 0_u8);
         EXPECT_TRUE(stream.FullyConsumed());
     }
 }
@@ -427,7 +427,7 @@ TEST_F(BitStreamTest, InvalidReaderStreamTest)
         EXPECT_EQ(m_inputStream.gcount(), 0);
 
         // No further reads should succeed.
-        EXPECT_EQ(stream.ReadBits(1, byte), 0_u8);
+        EXPECT_EQ(stream.ReadBits(byte, 1), 0_u8);
     }
 }
 


### PR DESCRIPTION
Previously, to support PeekBits operations where the requested number of
bits exceeded the number of bits available in the internal byte buffer,
BitStreamReader would basically:

1. Compare the requested number of bits to the size of the buffer.
2. Refill the buffer if not enough bytes are available.
3. Make the same comparison as (1) because there could still be too few bits
   available if the underlying stream has reached end-of-file.

Instead, PeekBits can provide however many bits are available right away,
then refill the buffer and peek any remaining bits.