### PR TITLE
Tweak Linux compilation flags

### DIFF
--- a/build/nix/flags.mk
+++ b/build/nix/flags.mk
@@ -31,7 +31,6 @@ CF_ALL += \
     -Wctor-dtor-privacy \
     -Wdisabled-optimization \
     -Wfloat-equal \
-    -Winline \
     -Winvalid-pch \
     -Wmissing-declarations \
     -Wpointer-arith \
@@ -48,6 +47,11 @@ CF_ALL += \
     \
     -pedantic
 
+ifeq ($(release), 0)
+    CF_ALL += \
+        -Winline
+endif
+
 ifeq ($(toolchain), clang)
     CF_ALL += \
         -Wnewline-eof \
@@ -56,17 +60,22 @@ else ifeq ($(toolchain), gcc)
     CF_ALL += \
         -Wlogical-op \
         -Wnoexcept \
+        -Wnull-dereference \
         -Wredundant-decls \
         -Wsign-promo \
-        -Wsuggest-final-methods \
-        -Wsuggest-final-types \
         -Wsuggest-override
+
+    ifeq ($(release), 0)
+        CF_ALL += \
+            -Wsuggest-final-methods \
+            -Wsuggest-final-types
+    endif
 endif
 
 # Optimize release builds, and add debug symbols / use address sanitizer for
 # debug builds
 ifeq ($(release), 1)
-    CF_ALL += -O2
+    CF_ALL += -O2 -D_FORTIFY_SOURCE=2
 else
     CF_ALL += -O0 -g -fsanitize=address -fno-omit-frame-pointer
 

--- a/build/nix/flags.mk
+++ b/build/nix/flags.mk
@@ -75,7 +75,7 @@ endif
 # Optimize release builds, and add debug symbols / use address sanitizer for
 # debug builds
 ifeq ($(release), 1)
-    CF_ALL += -O2 -D_FORTIFY_SOURCE=2
+    CF_ALL += -O2
 else
     CF_ALL += -O0 -g -fsanitize=address -fno-omit-frame-pointer
 


### PR DESCRIPTION
Some warnings are particularly verbose with GCC release builds, where -O
is non-zero; GCC release is the single configuration not built during CI.