### PR TITLE
Simpler JSON parser

### DIFF
--- a/fly/fly.hpp
+++ b/fly/fly.hpp
@@ -10,7 +10,7 @@
 #endif
 
 // Define macro to convert a macro parameter to a string
-#define _FLY_STRINGIZE(a) #a
+#define _FLY_STRINGIZE(s) #s
 
 // Define macros to include OS dependent implementation headers. Formatter is
 // disabled because it would put a space before and after each solidus.
@@ -26,3 +26,6 @@
 #else
 #    error Unknown implementation header.
 #endif
+
+// Mark an expression or value as unused.
+#define FLY_UNUSED(expr) (void)(expr)

--- a/fly/parser/exceptions.cpp
+++ b/fly/parser/exceptions.cpp
@@ -8,10 +8,11 @@
 namespace fly {
 
 //==============================================================================
-ParserException::ParserException(int line, const std::string &message) noexcept
-    :
+ParserException::ParserException(
+    std::uint32_t line,
+    const std::string &message) noexcept :
     m_message(String::format(
-        "ParserException: Error parsing at [line %d]: %s",
+        "ParserException: Error parsing at [line %u]: %s",
         line,
         message))
 {
@@ -20,11 +21,11 @@ ParserException::ParserException(int line, const std::string &message) noexcept
 
 //==============================================================================
 ParserException::ParserException(
-    int line,
-    int column,
+    std::uint32_t line,
+    std::uint32_t column,
     const std::string &message) noexcept :
     m_message(String::format(
-        "ParserException: Error parsing at [line %d, column %d]: %s",
+        "ParserException: Error parsing at [line %u, column %u]: %s",
         line,
         column,
         message))
@@ -40,8 +41,8 @@ const char *ParserException::what() const noexcept
 
 //==============================================================================
 UnexpectedCharacterException::UnexpectedCharacterException(
-    int line,
-    int column,
+    std::uint32_t line,
+    std::uint32_t column,
     int ch) noexcept :
     ParserException(
         line,
@@ -54,8 +55,8 @@ UnexpectedCharacterException::UnexpectedCharacterException(
 
 //==============================================================================
 BadConversionException::BadConversionException(
-    int line,
-    int column,
+    std::uint32_t line,
+    std::uint32_t column,
     const std::string &value) noexcept :
     ParserException(
         line,

--- a/fly/parser/exceptions.hpp
+++ b/fly/parser/exceptions.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <exception>
 #include <string>
 
@@ -20,7 +21,7 @@ public:
      * @param line Line number where error was encountered.
      * @param message Message indicating what error was encountered.
      */
-    ParserException(int line, const std::string &message) noexcept;
+    ParserException(std::uint32_t line, const std::string &message) noexcept;
 
     /**
      * Constructor.
@@ -29,7 +30,10 @@ public:
      * @param column Column number in line where error was encountered.
      * @param message Message indicating what error was encountered.
      */
-    ParserException(int line, int column, const std::string &message) noexcept;
+    ParserException(
+        std::uint32_t line,
+        std::uint32_t column,
+        const std::string &message) noexcept;
 
     /**
      * @return A C-string representing this exception.
@@ -56,7 +60,10 @@ public:
      * @param column Column number in line where error was encountered.
      * @param ch Unexpected character code.
      */
-    UnexpectedCharacterException(int line, int column, int ch) noexcept;
+    UnexpectedCharacterException(
+        std::uint32_t line,
+        std::uint32_t column,
+        int ch) noexcept;
 };
 
 /**
@@ -76,8 +83,8 @@ public:
      * @param value The unconvertable value.
      */
     BadConversionException(
-        int line,
-        int column,
+        std::uint32_t line,
+        std::uint32_t column,
         const std::string &value) noexcept;
 };
 

--- a/fly/parser/json_parser.cpp
+++ b/fly/parser/json_parser.cpp
@@ -2,7 +2,6 @@
 
 #include "fly/types/string/string.hpp"
 
-#include <iostream>
 #include <string_view>
 
 namespace fly {
@@ -81,7 +80,7 @@ Json JsonParser::parse_object(std::istream &stream) noexcept(false)
     Json object = JsonTraits::object_type();
     consume_token(stream, Token::StartBrace);
 
-    auto stop_parsing = [&stream, this]() {
+    auto stop_parsing = [&stream, this]() noexcept {
         consume_whitespace(stream);
         const Token token = peek(stream);
 
@@ -116,7 +115,7 @@ Json JsonParser::parse_array(std::istream &stream) noexcept(false)
     Json array = JsonTraits::array_type();
     consume_token(stream, Token::StartBracket);
 
-    auto stop_parsing = [&stream, this]() {
+    auto stop_parsing = [&stream, this]() noexcept {
         consume_whitespace(stream);
         const Token token = peek(stream);
 
@@ -179,9 +178,10 @@ Json JsonParser::parse_value(std::istream &stream) noexcept(false)
         }
         catch (...)
         {
-            throw BadConversionException(m_line, m_column, value);
         }
     }
+
+    throw BadConversionException(m_line, m_column, value);
 }
 
 //==============================================================================
@@ -191,7 +191,7 @@ JsonParser::consume_value(std::istream &stream, bool for_string) noexcept(false)
     Json::stream_type parsing;
     Token token;
 
-    auto stop_parsing = [&token, &for_string, this]() {
+    auto stop_parsing = [&token, &for_string, this]() noexcept {
         if (for_string)
         {
             return token == Token::Quote;
@@ -357,12 +357,12 @@ JsonParser::validate_number(const JsonTraits::string_type &value) const
         std::basic_string_view<JsonTraits::string_type::value_type>(value)
             .substr(is_signed ? 1 : 0);
 
-    auto is_octal = [&signless]() -> bool {
+    auto is_octal = [&signless]() noexcept -> bool {
         return (signless.size() > 1) && (signless[0] == '0') &&
             std::isdigit(static_cast<unsigned char>(signless[1]));
     };
 
-    auto is_float = [this, &value, &signless]() -> bool {
+    auto is_float = [this, &value, &signless]() noexcept(false) -> bool {
         const JsonTraits::string_type::size_type d = signless.find('.');
         const JsonTraits::string_type::size_type e1 = signless.find('e');
         const JsonTraits::string_type::size_type e2 = signless.find('E');

--- a/fly/parser/json_parser.cpp
+++ b/fly/parser/json_parser.cpp
@@ -1,10 +1,8 @@
 #include "fly/parser/json_parser.hpp"
 
-#include "fly/parser/exceptions.hpp"
 #include "fly/types/string/string.hpp"
 
-#include <cctype>
-#include <cstdio>
+#include <iostream>
 #include <string_view>
 
 namespace fly {
@@ -15,7 +13,7 @@ JsonParser::JsonParser() noexcept : Parser(), m_features(Features::Strict)
 }
 
 //==============================================================================
-JsonParser::JsonParser(Features features) noexcept :
+JsonParser::JsonParser(const Features features) noexcept :
     Parser(),
     m_features(features)
 {
@@ -24,540 +22,159 @@ JsonParser::JsonParser(Features features) noexcept :
 //==============================================================================
 Json JsonParser::parse_internal(std::istream &stream) noexcept(false)
 {
-    m_states = decltype(m_states)();
-    m_states.push(State::NoState);
-
-    Json values;
-    m_value = &values;
-
-    m_parents = decltype(m_parents)();
-    m_parents.push(m_value);
-
-    m_parsing.str(std::string());
-    m_parsing_started = false;
-    m_parsing_complete = false;
-    m_parsing_string = false;
-    m_parsed_string = false;
-    m_expecting_value = false;
+    Json json;
 
     try
     {
-        int c = 0;
-
-        while ((c = stream.get()) != EOF)
-        {
-            Token token = static_cast<Token>(c);
-            ++m_column;
-
-            switch (token)
-            {
-                case Token::Tab:
-                case Token::NewLine:
-                case Token::CarriageReturn:
-                case Token::Space:
-                    on_whitespace(token, c);
-                    break;
-
-                case Token::StartBrace:
-                case Token::StartBracket:
-                    on_start_brace_or_bracket(token, c);
-                    break;
-
-                case Token::CloseBrace:
-                case Token::CloseBracket:
-                    on_close_brace_or_bracket(token, c);
-                    break;
-
-                case Token::Quote:
-                    on_quotation(c);
-                    break;
-
-                case Token::Comma:
-                    on_comma(c);
-                    break;
-
-                case Token::Colon:
-                    on_colon(c);
-                    break;
-
-                case Token::Solidus:
-                    on_solidus(c, stream);
-                    break;
-
-                default:
-                    on_character(token, c, stream);
-                    break;
-            }
-        }
+        json = parse_json(stream);
     }
     catch (const JsonException &ex)
     {
         throw ParserException(m_line, m_column, ex.what());
     }
 
-    if (m_states.top() != State::NoState)
+    consume_whitespace(stream);
+
+    if (!stream.eof())
     {
         throw ParserException(
             m_line,
             m_column,
-            "Finished parsing with incomplete JSON object");
+            "Extraneous symbols found after JSON value");
+    }
+    else if (!json.is_object() && !json.is_array())
+    {
+        throw ParserException(
+            m_line,
+            m_column,
+            "JSON value must be an object or array");
     }
 
-    return values;
+    return json;
 }
 
 //==============================================================================
-void JsonParser::on_whitespace(Token token, int c) noexcept(false)
+Json JsonParser::parse_json(std::istream &stream) noexcept(false)
 {
-    if (m_parsing_string)
+    consume_whitespace(stream);
+
+    switch (peek(stream))
     {
-        if (token != Token::Space)
+        case Token::StartBrace:
+            return parse_object(stream);
+
+        case Token::StartBracket:
+            return parse_array(stream);
+
+        case Token::Solidus:
+            consume_comment(stream);
+            return parse_json(stream);
+
+        default:
+            return parse_value(stream);
+    }
+}
+
+//==============================================================================
+Json JsonParser::parse_object(std::istream &stream) noexcept(false)
+{
+    Json object = JsonTraits::object_type();
+    consume_token(stream, Token::StartBrace);
+
+    auto stop_parsing = [&stream, this]() {
+        consume_whitespace(stream);
+        const Token token = peek(stream);
+
+        return (token == Token::EndOfFile) || (token == Token::CloseBrace);
+    };
+
+    while (!stop_parsing())
+    {
+        if (object && consume_comma(stream, stop_parsing))
         {
-            throw UnexpectedCharacterException(m_line, m_column, c);
+            break;
         }
 
-        push_value(c);
-    }
-    else
-    {
-        if (m_parsing_started)
+        if (peek(stream) == Token::Solidus)
         {
-            m_parsing_complete = true;
+            consume_comment(stream);
         }
 
-        if (token == Token::NewLine)
-        {
-            ++m_line;
-            m_column = 0;
-        }
+        JsonTraits::string_type key = consume_value(stream, true);
+        consume_token(stream, Token::Colon);
+
+        object[std::move(key)] = parse_json(stream);
     }
+
+    consume_token(stream, Token::CloseBrace);
+    return object;
 }
 
 //==============================================================================
-void JsonParser::on_start_brace_or_bracket(Token token, int c) noexcept(false)
+Json JsonParser::parse_array(std::istream &stream) noexcept(false)
 {
-    switch (m_states.top())
+    Json array = JsonTraits::array_type();
+    consume_token(stream, Token::StartBracket);
+
+    auto stop_parsing = [&stream, this]() {
+        consume_whitespace(stream);
+        const Token token = peek(stream);
+
+        return (token == Token::EndOfFile) || (token == Token::CloseBracket);
+    };
+
+    while (!stop_parsing())
     {
-        case State::NoState:
-            if (m_value == nullptr)
-            {
-                throw UnexpectedCharacterException(m_line, m_column, c);
-            }
-
-            break;
-
-        case State::ParsingColon:
-        case State::ParsingObject:
-            throw UnexpectedCharacterException(m_line, m_column, c);
-
-        case State::ParsingArray:
-            m_states.push(State::ParsingValue);
-
-            m_value = &((*m_value)[m_value->size()]);
-            m_parents.push(m_value);
-
-            break;
-
-        case State::ParsingName:
-        case State::ParsingValue:
-            if (m_parsing_string)
-            {
-                push_value(c);
-                return;
-            }
-            else if (m_parsing_started)
-            {
-                throw UnexpectedCharacterException(m_line, m_column, c);
-            }
-
-            break;
-
-        default:
-            break;
-    }
-
-    if (token == Token::StartBrace)
-    {
-        *m_value = JsonTraits::object_type();
-        m_states.push(State::ParsingObject);
-    }
-    else
-    {
-        *m_value = JsonTraits::array_type();
-        m_states.push(State::ParsingArray);
-    }
-
-    m_expecting_value = false;
-}
-
-//==============================================================================
-void JsonParser::on_close_brace_or_bracket(Token token, int c) noexcept(false)
-{
-    switch (m_states.top())
-    {
-        case State::NoState:
-        case State::ParsingColon:
-            throw UnexpectedCharacterException(m_line, m_column, c);
-
-        case State::ParsingName:
-        case State::ParsingValue:
-            if (m_parsing_string)
-            {
-                push_value(c);
-                return;
-            }
-
-            break;
-
-        default:
-            break;
-    }
-
-    if ((!store_value() && m_expecting_value) || m_parents.empty())
-    {
-        throw UnexpectedCharacterException(m_line, m_column, c);
-    }
-
-    m_parents.pop();
-    m_value = (m_parents.empty() ? nullptr : m_parents.top());
-
-    // Formatter doesn't have options for hanging indent after ternary operator
-    // clang-format off
-    const State expected = (token == Token::CloseBrace) ?
-        State::ParsingObject : State::ParsingArray;
-    const State unexpected = (token == Token::CloseBrace) ?
-        State::ParsingArray : State::ParsingObject;
-    // clang-format on
-
-    while (m_states.top() != expected)
-    {
-        if (m_states.top() == unexpected)
+        if (array && consume_comma(stream, stop_parsing))
         {
-            throw UnexpectedCharacterException(m_line, m_column, c);
+            break;
         }
 
-        m_states.pop();
+        array[array.size()] = parse_json(stream);
     }
 
-    m_states.pop();
-
-    if (m_states.top() != State::NoState)
-    {
-        m_states.push(State::ParsingComma);
-    }
+    consume_token(stream, Token::CloseBracket);
+    return array;
 }
 
 //==============================================================================
-void JsonParser::on_quotation(int c) noexcept(false)
+Json JsonParser::parse_value(std::istream &stream) noexcept(false)
 {
-    switch (m_states.top())
+    const bool is_string = peek(stream) == Token::Quote;
+    const JsonTraits::string_type value = consume_value(stream, is_string);
+
+    if (is_string)
     {
-        case State::ParsingObject:
-            m_states.push(State::ParsingName);
-            break;
-
-        case State::ParsingArray:
-            m_states.push(State::ParsingValue);
-
-            m_value = &((*m_value)[m_value->size()]);
-            m_parents.push(m_value);
-
-            break;
-
-        case State::ParsingName:
-            m_states.pop();
-            m_states.push(State::ParsingColon);
-
-            m_value = &((*m_value)[pop_value()]);
-            m_parents.push(m_value);
-
-            m_expecting_value = false;
-
-            break;
-
-        case State::ParsingValue:
-            if (m_parsing_string)
-            {
-                m_parsing_complete = true;
-                m_parsed_string = true;
-
-                m_states.pop();
-                m_states.push(State::ParsingComma);
-            }
-            else if (m_parsing_started)
-            {
-                throw UnexpectedCharacterException(m_line, m_column, c);
-            }
-
-            break;
-
-        default:
-            throw UnexpectedCharacterException(m_line, m_column, c);
+        return value;
     }
-
-    m_parsing_string = !m_parsing_string;
-}
-
-//==============================================================================
-void JsonParser::on_colon(int c) noexcept(false)
-{
-    switch (m_states.top())
-    {
-        case State::ParsingColon:
-            m_states.pop();
-            m_states.push(State::ParsingValue);
-
-            m_expecting_value = true;
-
-            break;
-
-        case State::ParsingName:
-        case State::ParsingValue:
-            if (m_parsing_string)
-            {
-                push_value(c);
-            }
-            else
-            {
-                throw UnexpectedCharacterException(m_line, m_column, c);
-            }
-            break;
-
-        default:
-            throw UnexpectedCharacterException(m_line, m_column, c);
-    }
-}
-
-//==============================================================================
-void JsonParser::on_comma(int c) noexcept(false)
-{
-    switch (m_states.top())
-    {
-        case State::ParsingName:
-            push_value(c);
-            break;
-
-        case State::ParsingValue:
-            if (m_parsing_string)
-            {
-                push_value(c);
-            }
-            else if (store_value())
-            {
-                m_states.pop();
-            }
-            else if (m_expecting_value)
-            {
-                throw UnexpectedCharacterException(m_line, m_column, c);
-            }
-
-            break;
-
-        case State::ParsingComma:
-            store_value();
-            m_states.pop();
-
-            if (m_states.top() == State::ParsingValue)
-            {
-                m_states.pop();
-            }
-
-            break;
-
-        default:
-            throw UnexpectedCharacterException(m_line, m_column, c);
-    }
-
-    if (is_feature_allowed(Features::AllowTrailingComma))
-    {
-        m_expecting_value = false;
-    }
-    else
-    {
-        m_expecting_value = !m_parsing_string;
-    }
-}
-
-//==============================================================================
-void JsonParser::on_solidus(int c, std::istream &stream) noexcept(false)
-{
-    if (m_parsing_string)
-    {
-        push_value(c);
-    }
-    else if (is_feature_allowed(Features::AllowComments))
-    {
-        Token token = static_cast<Token>(stream.get());
-
-        switch (token)
-        {
-            case Token::Solidus:
-                do
-                {
-                    c = stream.get();
-                } while ((c != EOF) &&
-                         (static_cast<Token>(c) != Token::NewLine));
-
-                break;
-
-            case Token::Asterisk:
-            {
-                bool parsing = true;
-
-                do
-                {
-                    c = stream.get();
-
-                    if ((static_cast<Token>(c) == Token::Asterisk) &&
-                        (static_cast<Token>(stream.peek()) == Token::Solidus))
-                    {
-                        parsing = false;
-                        stream.get();
-                    }
-                } while ((c != EOF) && parsing);
-
-                if (parsing)
-                {
-                    throw UnexpectedCharacterException(m_line, m_column, c);
-                }
-
-                break;
-            }
-
-            default:
-                throw UnexpectedCharacterException(m_line, m_column, c);
-        }
-    }
-    else
-    {
-        throw UnexpectedCharacterException(m_line, m_column, c);
-    }
-}
-
-//==============================================================================
-void JsonParser::on_character(
-    Token token,
-    int c,
-    std::istream &stream) noexcept(false)
-{
-    if (std::isspace(c))
-    {
-        throw UnexpectedCharacterException(m_line, m_column, c);
-    }
-
-    switch (m_states.top())
-    {
-        case State::ParsingArray:
-            m_states.push(State::ParsingValue);
-
-            m_value = &((*m_value)[m_value->size()]);
-            m_parents.push(m_value);
-
-            push_value(c);
-            break;
-
-        case State::ParsingValue:
-        case State::ParsingName:
-            push_value(c);
-
-            // Blindly ignore the escaped character, the Json class will
-            // check whether it is valid. Just read at least one more
-            // character to prevent the parser from failing if the next
-            // character is a quote.
-            if (m_parsing_string && (token == Token::ReverseSolidus))
-            {
-                if ((c = stream.get()) == EOF)
-                {
-                    throw UnexpectedCharacterException(m_line, m_column, c);
-                }
-
-                push_value(c);
-            }
-
-            break;
-
-        default:
-            throw UnexpectedCharacterException(m_line, m_column, c);
-    }
-}
-
-//==============================================================================
-void JsonParser::push_value(int c) noexcept(false)
-{
-    if (m_parsing_complete)
-    {
-        throw UnexpectedCharacterException(m_line, m_column, c);
-    }
-
-    m_parsing << static_cast<Json::stream_type::char_type>(c);
-    m_parsing_started = true;
-}
-
-//==============================================================================
-std::string JsonParser::pop_value() noexcept
-{
-    const std::string value = m_parsing.str();
-
-    m_parsing.str(std::string());
-    m_parsing_started = false;
-    m_parsing_complete = false;
-
-    return value;
-}
-
-//==============================================================================
-bool JsonParser::store_value() noexcept(false)
-{
-    const std::string value = pop_value();
-
-    // Parsed a string value
-    if (m_parsed_string)
-    {
-        m_parsed_string = false;
-        *m_value = value;
-    }
-
-    // No parsed value
-    else if (value.empty())
-    {
-        return false;
-    }
-
-    // Parsed a boolean value
     else if (value == "true")
     {
-        *m_value = true;
+        return true;
     }
     else if (value == "false")
     {
-        *m_value = false;
+        return false;
     }
-
-    // Parsed a null value
     else if (value == "null")
     {
-        *m_value = nullptr;
+        return nullptr;
     }
-
-    // Parsed a number
     else
     {
-        bool is_float = false, is_signed = false;
-        validate_number(value, is_float, is_signed);
+        const NumericType number_type = validate_number(value);
 
         try
         {
-            if (is_float)
+            switch (number_type)
             {
-                *m_value = String::convert<JsonTraits::float_type>(value);
-            }
-            else if (is_signed)
-            {
-                *m_value = String::convert<JsonTraits::signed_type>(value);
-            }
-            else
-            {
-                *m_value = String::convert<JsonTraits::unsigned_type>(value);
+                case NumericType::SignedInteger:
+                    return String::convert<JsonTraits::signed_type>(value);
+
+                case NumericType::UnsignedInteger:
+                    return String::convert<JsonTraits::unsigned_type>(value);
+
+                case NumericType::FloatingPoint:
+                    return String::convert<JsonTraits::float_type>(value);
             }
         }
         catch (...)
@@ -565,40 +182,197 @@ bool JsonParser::store_value() noexcept(false)
             throw BadConversionException(m_line, m_column, value);
         }
     }
-
-    m_parents.pop();
-    m_value = (m_parents.empty() ? nullptr : m_parents.top());
-
-    m_expecting_value = false;
-
-    return true;
 }
 
 //==============================================================================
-void JsonParser::validate_number(
-    const std::string &value,
-    bool &is_float,
-    bool &is_signed) const noexcept(false)
+JsonTraits::string_type
+JsonParser::consume_value(std::istream &stream, bool for_string) noexcept(false)
 {
-    is_signed = (value[0] == '-');
+    Json::stream_type parsing;
+    Token token;
 
-    const auto signless = std::string_view(value).substr(is_signed ? 1 : 0);
+    auto stop_parsing = [&token, &for_string, this]() {
+        if (for_string)
+        {
+            return token == Token::Quote;
+        }
 
-    auto octal_test = [&signless]() -> bool {
+        return is_whitespace(token) || (token == Token::Comma) ||
+            (token == Token::CloseBracket) || (token == Token::CloseBrace);
+    };
+
+    if (for_string)
+    {
+        consume_token(stream, Token::Quote);
+    }
+
+    while (((token = peek(stream)) != Token::EndOfFile) && !stop_parsing())
+    {
+        parsing << static_cast<Json::stream_type::char_type>(token);
+        discard(stream);
+
+        // Blindly ignore escaped symbols, the Json class will check whether
+        // they are valid. Just read at least one more symbol to prevent
+        // breaking out of the loop too early if the next symbol is a quote.
+        if (for_string && (token == Token::ReverseSolidus))
+        {
+            if ((token = consume(stream)) == Token::EndOfFile)
+            {
+                throw UnexpectedTokenException(m_line, m_column, token);
+            }
+
+            parsing << static_cast<Json::stream_type::char_type>(token);
+        }
+    }
+
+    if (for_string)
+    {
+        consume_token(stream, Token::Quote);
+    }
+
+    return parsing.str();
+}
+
+//==============================================================================
+void JsonParser::consume_token(
+    std::istream &stream,
+    const Token &token) noexcept(false)
+{
+    consume_whitespace(stream);
+
+    const Token parsed = consume(stream);
+
+    if (parsed != token)
+    {
+        throw UnexpectedTokenException(m_line, m_column, parsed);
+    }
+}
+
+//==============================================================================
+void JsonParser::consume_whitespace(std::istream &stream) noexcept
+{
+    Token token;
+
+    while (((token = peek(stream)) != Token::EndOfFile) && is_whitespace(token))
+    {
+        discard(stream);
+
+        if (token == Token::NewLine)
+        {
+            m_column = 0;
+            ++m_line;
+        }
+    }
+}
+
+//==============================================================================
+bool JsonParser::consume_comma(
+    std::istream &stream,
+    const std::function<bool()> &stop_parsing) noexcept(false)
+{
+    consume_token(stream, Token::Comma);
+
+    if (stop_parsing())
+    {
+        if (is_feature_allowed(Features::AllowTrailingComma))
+        {
+            return true;
+        }
+
+        throw UnexpectedTokenException(m_line, m_column, Token::Comma);
+    }
+
+    return false;
+}
+
+//==============================================================================
+void JsonParser::consume_comment(std::istream &stream) noexcept(false)
+{
+    if (!is_feature_allowed(Features::AllowComments))
+    {
+        throw UnexpectedTokenException(m_line, m_column, Token::Solidus);
+    }
+
+    consume_token(stream, Token::Solidus);
+    Token token;
+
+    switch (consume(stream))
+    {
+        case Token::Solidus:
+            do
+            {
+                token = consume(stream);
+            } while ((token != Token::EndOfFile) && (token != Token::NewLine));
+
+            break;
+
+        case Token::Asterisk:
+            do
+            {
+                token = consume(stream);
+
+                if ((token == Token::Asterisk) &&
+                    (peek(stream) == Token::Solidus))
+                {
+                    consume_token(stream, Token::Solidus);
+                    break;
+                }
+            } while (token != Token::EndOfFile);
+
+            break;
+
+        default:
+            throw UnexpectedTokenException(m_line, m_column, Token::Solidus);
+    }
+}
+
+//==============================================================================
+JsonParser::Token JsonParser::peek(std::istream &stream) noexcept
+{
+    return static_cast<Token>(stream.peek());
+}
+
+//==============================================================================
+JsonParser::Token JsonParser::consume(std::istream &stream) noexcept
+{
+    ++m_column;
+    return static_cast<Token>(stream.get());
+}
+
+//==============================================================================
+void JsonParser::discard(std::istream &stream) noexcept
+{
+    ++m_column;
+    (void)stream.get();
+}
+
+//==============================================================================
+JsonParser::NumericType
+JsonParser::validate_number(const JsonTraits::string_type &value) const
+    noexcept(false)
+{
+    const bool is_signed = value[0] == '-';
+
+    const auto signless =
+        std::basic_string_view<JsonTraits::string_type::value_type>(value)
+            .substr(is_signed ? 1 : 0);
+
+    auto is_octal = [&signless]() -> bool {
         return (signless.size() > 1) && (signless[0] == '0') &&
             std::isdigit(static_cast<unsigned char>(signless[1]));
     };
 
-    auto float_test = [this, &value, &signless]() -> bool {
-        const std::string::size_type d = signless.find('.');
-        const std::string::size_type e1 = signless.find('e');
-        const std::string::size_type e2 = signless.find('E');
+    auto is_float = [this, &value, &signless]() -> bool {
+        const JsonTraits::string_type::size_type d = signless.find('.');
+        const JsonTraits::string_type::size_type e1 = signless.find('e');
+        const JsonTraits::string_type::size_type e2 = signless.find('E');
 
-        if (d != std::string::npos)
+        if (d != JsonTraits::string_type::npos)
         {
-            std::string::size_type end = signless.size();
+            JsonTraits::string_type::size_type end = signless.size();
 
-            if ((e1 != std::string::npos) || (e2 != std::string::npos))
+            if ((e1 != JsonTraits::string_type::npos) ||
+                (e2 != JsonTraits::string_type::npos))
             {
                 end = std::min(e1, e2);
             }
@@ -611,23 +385,51 @@ void JsonParser::validate_number(
             return true;
         }
 
-        return (e1 != std::string::npos) || (e2 != std::string::npos);
+        return (e1 != JsonTraits::string_type::npos) ||
+            (e2 != JsonTraits::string_type::npos);
     };
 
     if (!std::isdigit(static_cast<unsigned char>(signless[0])))
     {
         throw BadConversionException(m_line, m_column, value);
     }
-    else if (octal_test())
+    else if (is_octal())
     {
         throw BadConversionException(m_line, m_column, value);
     }
-
-    is_float = float_test();
+    else if (is_float())
+    {
+        return NumericType::FloatingPoint;
+    }
+    else if (is_signed)
+    {
+        return NumericType::SignedInteger;
+    }
+    else
+    {
+        return NumericType::UnsignedInteger;
+    }
 }
 
 //==============================================================================
-bool JsonParser::is_feature_allowed(Features feature) const noexcept(false)
+bool JsonParser::is_whitespace(const Token &token) const noexcept
+{
+    switch (token)
+    {
+        case Token::Tab:
+        case Token::NewLine:
+        case Token::VerticalTab:
+        case Token::CarriageReturn:
+        case Token::Space:
+            return true;
+
+        default:
+            return false;
+    }
+}
+
+//==============================================================================
+bool JsonParser::is_feature_allowed(Features feature) const noexcept
 {
     return (m_features & feature) != Features::Strict;
 }
@@ -648,6 +450,15 @@ operator|(JsonParser::Features a, JsonParser::Features b) noexcept
     return static_cast<JsonParser::Features>(
         static_cast<std::underlying_type_t<JsonParser::Features>>(a) |
         static_cast<std::underlying_type_t<JsonParser::Features>>(b));
+}
+
+//==============================================================================
+JsonParser::UnexpectedTokenException::UnexpectedTokenException(
+    std::uint32_t line,
+    std::uint32_t column,
+    JsonParser::Token token) :
+    UnexpectedCharacterException(line, column, static_cast<int>(token))
+{
 }
 
 } // namespace fly

--- a/fly/parser/json_parser.hpp
+++ b/fly/parser/json_parser.hpp
@@ -104,7 +104,7 @@ private:
      */
     enum class JsonType : std::uint8_t
     {
-        String,
+        JsonString,
         Other,
     };
 

--- a/fly/parser/json_parser.hpp
+++ b/fly/parser/json_parser.hpp
@@ -1,14 +1,15 @@
 #pragma once
 
+#include "fly/parser/exceptions.hpp"
 #include "fly/parser/parser.hpp"
 #include "fly/types/json/json.hpp"
+#include "fly/types/json/json_traits.hpp"
 
 #include <cstdint>
+#include <functional>
 #include <istream>
 #include <limits>
-#include <stack>
 #include <string>
-#include <type_traits>
 
 namespace fly {
 
@@ -16,43 +17,10 @@ namespace fly {
  * Implementation of the Parser interface for the .json format.
  *
  * @author Timothy Flynn (trflynn89@pm.me)
- * @version July 19, 2017
+ * @version May 13, 2020
  */
 class JsonParser : public Parser
 {
-    enum class Token : std::uint8_t
-    {
-        Tab = 0x09, // \t
-        NewLine = 0x0a, // \n
-        CarriageReturn = 0x0d, // \r
-        Space = 0x20, // <space>
-
-        Asterisk = 0x2a, // *
-        Quote = 0x22, // "
-        Comma = 0x2c, // ,
-        Solidus = 0x2f, // /
-        Colon = 0x3a, // :
-
-        StartBracket = 0x5b, // [
-        CloseBracket = 0x5d, // ]
-
-        StartBrace = 0x7b, // {
-        CloseBrace = 0x7d, // }
-
-        ReverseSolidus = 0x5c, /* \ */
-    };
-
-    enum class State : std::uint8_t
-    {
-        NoState,
-        ParsingObject,
-        ParsingArray,
-        ParsingName,
-        ParsingValue,
-        ParsingColon,
-        ParsingComma,
-    };
-
 public:
     /**
      * Optional parsing features. May be combined with bitwise and/or operators.
@@ -74,153 +42,247 @@ public:
     };
 
     /**
-     * Constructor. Create a parser with strict https://www.json.org compliance.
+     * Constructor. Create a parser with strict compliance.
      */
     JsonParser() noexcept;
 
     /**
-     * Constructor. Create a parser with the specific features.
+     * Constructor. Create a parser with the specified features.
      *
      * @param features The extra features to allow.
      */
-    explicit JsonParser(Features features) noexcept;
+    explicit JsonParser(const Features features) noexcept;
 
 protected:
     /**
-     * Parse a stream and retrieve the parsed values.
+     * Parse a single complete JSON value from a stream.
      *
      * @param stream Stream holding the contents to parse.
      *
-     * @return The parsed values.
+     * @return The parsed JSON value.
      *
-     * @throws ParserException If an error occurs parsing the stream.
-     * @throws UnexpectedCharacterException A parsed character was unexpected.
-     * @throws BadConversionException A parsed object was invalid.
+     * @throws ParserException The parsed JSON value is invalid, or the stream
+     *         contains more than a JSON value.
+     * @throws UnexpectedCharacterException A parsed symbol was unexpected.
+     * @throws BadConversionException A parsed value could not be converted to
+     *         a JSON type.
      */
     Json parse_internal(std::istream &stream) noexcept(false) override;
 
 private:
     /**
-     * Handle a whitespace character.
-     *
-     * @param token The current parsed token.
-     * @param c The current parsed character.
-     *
-     * @throws UnexpectedCharacterException A parsed character was unexpected.
+     * ASCII codes for special JSON tokens.
      */
-    void on_whitespace(Token token, int c) noexcept(false);
+    enum class Token : std::int16_t
+    {
+        EndOfFile =
+            std::char_traits<JsonTraits::string_type::value_type>::eof(),
+
+        Tab = 0x09, // \t
+        NewLine = 0x0a, // \n
+        VerticalTab = 0x0b, // \v
+        CarriageReturn = 0x0d, // \r
+        Space = 0x20, // <space>
+
+        Quote = 0x22, // "
+        Asterisk = 0x2a, // *
+        Comma = 0x2c, // ,
+        Hyphen = 0x2d, // -
+        Solidus = 0x2f, // /
+        Colon = 0x3a, // :
+        ReverseSolidus = 0x5c, /* \ */
+
+        StartBracket = 0x5b, // [
+        CloseBracket = 0x5d, // ]
+
+        StartBrace = 0x7b, // {
+        CloseBrace = 0x7d, // }
+    };
 
     /**
-     * Handle the start of an object or array.
-     *
-     * @param token The current parsed token.
-     * @param c The current parsed character ({ or [).
-     *
-     * @throws UnexpectedCharacterException A parsed character was unexpected.
+     * Helper enumeration to indicate the numeric type of a JSON number.
      */
-    void on_start_brace_or_bracket(Token token, int c) noexcept(false);
+    enum class NumericType : std::uint8_t
+    {
+        SignedInteger,
+        UnsignedInteger,
+        FloatingPoint,
+    };
 
     /**
-     * Handle the end of an object or array.
-     *
-     * @param token The current parsed token.
-     * @param c The current parsed character (} or ]).
-     *
-     * @throws UnexpectedCharacterException A parsed character was unexpected.
-     * @throws BadConversionException A parsed object was invalid.
+     * Helper class to convert an unexpected Token to the value type needed by
+     * UnexpectedCharacterException.
      */
-    void on_close_brace_or_bracket(Token token, int c) noexcept(false);
+    class UnexpectedTokenException : public UnexpectedCharacterException
+    {
+    public:
+        UnexpectedTokenException(
+            std::uint32_t line,
+            std::uint32_t column,
+            JsonParser::Token token);
+    };
 
     /**
-     * Handle the start or end of a string, for either a name or value.
+     * Parse a complete JSON value from a stream. May be called recursively for
+     * nested values.
      *
-     * @param c The current parsed character (").
-     *
-     * @throws UnexpectedCharacterException A parsed character was unexpected.
-     */
-    void on_quotation(int c) noexcept(false);
-
-    /**
-     * Handle a colon between name-value pairs.
-     *
-     * @param c The current parsed character (:).
-     *
-     * @throws UnexpectedCharacterException A parsed character was unexpected.
-     */
-    void on_colon(int c) noexcept(false);
-
-    /**
-     * Handle a comma, either in an array or after an object.
-     *
-     * @param c The current parsed character (,).
-     *
-     * @throws UnexpectedCharacterException A parsed character was unexpected.
-     * @throws BadConversionException A parsed object was invalid.
-     */
-    void on_comma(int c) noexcept(false);
-
-    /**
-     * Handle the start of a comment, if comments are allowed. Consumes the
-     * stream until the end of the comment.
-     *
-     * @param c The current parsed character.
      * @param stream Stream holding the contents to parse.
      *
-     * @throws UnexpectedCharacterException A parsed character was unexpected.
+     * @return The parsed JSON value.
+     *
+     * @throws UnexpectedCharacterException A parsed symbol was unexpected.
+     * @throws BadConversionException A parsed value could not be converted to
+     *         a JSON type.
      */
-    void on_solidus(int c, std::istream &stream) noexcept(false);
+    Json parse_json(std::istream &stream) noexcept(false);
 
     /**
-     * Handle any other character. If the character is a reverse solidus, accept
-     * the next character as well.
+     * Parse a JSON object from a stream.
      *
-     * @param token The current parsed token.
-     * @param c The current parsed character.
      * @param stream Stream holding the contents to parse.
      *
-     * @throws UnexpectedCharacterException A parsed character was unexpected.
+     * @return The parsed JSON object.
+     *
+     * @throws UnexpectedCharacterException A parsed symbol was unexpected.
+     * @throws BadConversionException A parsed value could not be converted to
+     *         a JSON type.
      */
-    void on_character(Token token, int c, std::istream &stream) noexcept(false);
+    Json parse_object(std::istream &stream) noexcept(false);
 
     /**
-     * Push a parsed character onto the parsing stream.
+     * Parse a JSON array from a stream.
      *
-     * @param c The current parsed character.
+     * @param stream Stream holding the contents to parse.
      *
-     * @throws UnexpectedCharacterException Any character was unexpected.
+     * @return The parsed JSON array.
+     *
+     * @throws UnexpectedCharacterException A parsed symbol was unexpected.
+     * @throws BadConversionException A parsed value could not be converted to
+     *         a JSON type.
      */
-    void push_value(int c) noexcept(false);
+    Json parse_array(std::istream &stream) noexcept(false);
 
     /**
-     * Retrieve and clear the current value of the parsing stream.
+     * Parse a JSON string, number, boolean, or null value from a stream.
      *
-     * @return The current value of the parsing stream.
+     * @param stream Stream holding the contents to parse.
+     *
+     * @return The parsed JSON number, boolean, or null value.
+     *
+     * @throws UnexpectedCharacterException A parsed symbol was unexpected.
+     * @throws BadConversionException A parsed value could not be converted to
+     *         a JSON type.
      */
-    std::string pop_value() noexcept;
+    Json parse_value(std::istream &stream) noexcept(false);
 
     /**
-     * Store the current value of the parsing stream as a JSON object. Ensures
-     * that the syntax of the value is compliant with https://www.json.org.
+     * Extract a string, number, boolean, or null value from a stream. If
+     * parsing a string, escaped symbols are preserved in that string, and the
+     * returned value does not contain its surrounding quotes.
      *
-     * @return True if a value was stored.
+     * @param stream Stream holding the contents to parse.
      *
-     * @throws BadConversionException A parsed object was invalid.
+     * @return The parsed value as a string.
+     *
+     * @throws UnexpectedCharacterException A parsed symbol was unexpected.
      */
-    bool store_value() noexcept(false);
+    JsonTraits::string_type
+    consume_value(std::istream &stream, bool for_string) noexcept(false);
 
     /**
-     * Validate that a parsed number is compliant with https://www.json.org.
+     * Extract a single symbol from a stream. Ensure that symbol is equal to an
+     * expected token.
+     *
+     * @param stream Stream holding the contents to parse.
+     *
+     * @throws UnexpectedCharacterException A parsed symbol was unexpected.
+     */
+    void
+    consume_token(std::istream &stream, const Token &token) noexcept(false);
+
+    /**
+     * Extract all consecutive whitespace symbols from a stream until a non-
+     * whitespace symbol is encountered. The non-whitespace symbol is left on
+     * the stream.
+     *
+     * @param stream Stream holding the contents to parse.
+     */
+    void consume_whitespace(std::istream &stream) noexcept;
+
+    /**
+     * Extract a comma from a stream. Handles any trailing commas, allowing a
+     * single trailing comma if enabled in the feature set.
+     *
+     * @param stream Stream holding the contents to parse.
+     * @param stop_parsing Callback to indicate whether the calling parser
+     *        should stop parsing.
+     *
+     * @return True if the callback indicated parsing is complete.
+     *
+     * @throws UnexpectedCharacterException A trailing comma was found, but the
+     *         feature is not enabled.
+     */
+    bool consume_comma(
+        std::istream &stream,
+        const std::function<bool()> &stop_parsing) noexcept(false);
+
+    /**
+     * Extract a single- or multi-line comment from a stream, if enabled in the
+     * feature set.
+     *
+     * @param stream Stream holding the contents to parse.
+     *
+     * @throws UnexpectedCharacterException A parsed symbol was unexpected, or
+     *         the comment feature is not enabled,
+     */
+    void consume_comment(std::istream &stream) noexcept(false);
+
+    /**
+     * Read the next symbol in a stream without extracting it.
+     *
+     * @param stream Stream holding the contents to parse.
+     *
+     * @return The peeked symbol.
+     */
+    Token peek(std::istream &stream) noexcept;
+
+    /**
+     * Extract the next symbol in a stream.
+     *
+     * @param stream Stream holding the contents to parse.
+     *
+     * @return The extracted symbol.
+     */
+    Token consume(std::istream &stream) noexcept;
+
+    /**
+     * Extract the next symbol in a stream and discard it.
+     *
+     * @param stream Stream holding the contents to parse.
+     */
+    void discard(std::istream &stream) noexcept;
+
+    /**
+     * Validate that a parsed number is valid and interpret its numeric JSON
+     * type.
      *
      * @param value The parsed number to validate.
-     * @param is_float Set to true if the parsed number is a floating point.
-     * @param is_signed Set to true if the parsed number is signed.
      *
-     * @throws BadConversionException A parsed number was invalid.
+     * @return The interpreted numeric type.
+     *
+     * @throws BadConversionException The parsed number is not valid.
      */
-    void validate_number(
-        const std::string &value,
-        bool &is_float,
-        bool &is_signed) const noexcept(false);
+    NumericType validate_number(const JsonTraits::string_type &value) const
+        noexcept(false);
+
+    /**
+     * Check if a symbol is a whitespace symbol.
+     *
+     * @param token The token to inspect.
+     *
+     * @return True if the symbol is whitespace.
+     */
+    bool is_whitespace(const Token &token) const noexcept;
 
     /**
      * Check if a feature has been allowed.
@@ -229,22 +291,9 @@ private:
      *
      * @return True if the feature is allowed.
      */
-    bool is_feature_allowed(Features feature) const noexcept(false);
+    bool is_feature_allowed(Features feature) const noexcept;
 
-    Features m_features;
-
-    std::stack<State> m_states;
-
-    Json *m_value;
-    std::stack<Json *> m_parents;
-
-    Json::stream_type m_parsing;
-
-    bool m_parsing_started;
-    bool m_parsing_complete;
-    bool m_parsing_string;
-    bool m_parsed_string;
-    bool m_expecting_value;
+    const Features m_features;
 };
 
 /**

--- a/fly/parser/json_parser.hpp
+++ b/fly/parser/json_parser.hpp
@@ -100,6 +100,15 @@ private:
     };
 
     /**
+     * Helper enumeration to indicate the type of a JSON value.
+     */
+    enum class JsonType : std::uint8_t
+    {
+        String,
+        Other,
+    };
+
+    /**
      * Helper enumeration to indicate the numeric type of a JSON number.
      */
     enum class NumericType : std::uint8_t
@@ -176,20 +185,6 @@ private:
     Json parse_value(std::istream &stream) noexcept(false);
 
     /**
-     * Extract a string, number, boolean, or null value from a stream. If
-     * parsing a string, escaped symbols are preserved in that string, and the
-     * returned value does not contain its surrounding quotes.
-     *
-     * @param stream Stream holding the contents to parse.
-     *
-     * @return The parsed value as a string.
-     *
-     * @throws UnexpectedCharacterException A parsed symbol was unexpected.
-     */
-    JsonTraits::string_type
-    consume_value(std::istream &stream, bool for_string) noexcept(false);
-
-    /**
      * Extract a single symbol from a stream. Ensure that symbol is equal to an
      * expected token.
      *
@@ -199,15 +194,6 @@ private:
      */
     void
     consume_token(std::istream &stream, const Token &token) noexcept(false);
-
-    /**
-     * Extract all consecutive whitespace symbols from a stream until a non-
-     * whitespace symbol is encountered. The non-whitespace symbol is left on
-     * the stream.
-     *
-     * @param stream Stream holding the contents to parse.
-     */
-    void consume_whitespace(std::istream &stream) noexcept;
 
     /**
      * Extract a comma from a stream. Handles any trailing commas, allowing a
@@ -227,13 +213,48 @@ private:
         const std::function<bool()> &stop_parsing) noexcept(false);
 
     /**
+     * Extract a string, number, boolean, or null value from a stream. If
+     * parsing a string, escaped symbols are preserved in that string, and the
+     * returned value does not contain its surrounding quotes.
+     *
+     * @param stream Stream holding the contents to parse.
+     * @param type The JSON value type to consume.
+     *
+     * @return The parsed value as a string.
+     *
+     * @throws UnexpectedCharacterException A parsed symbol was unexpected.
+     */
+    JsonTraits::string_type
+    consume_value(std::istream &stream, JsonType type) noexcept(false);
+
+    /**
+     * Extract all consecutive whitespace symbols and comments (if enabled in
+     * the feature set) from a stream. The first non-whitespace, non-comment
+     * symbol is left on the stream.
+     *
+     * @param stream Stream holding the contents to parse.
+     *
+     * @throws UnexpectedCharacterException A parsed symbol was unexpected.
+     */
+    void consume_whitespace_and_comments(std::istream &stream) noexcept(false);
+
+    /**
+     * Extract all consecutive whitespace symbols from a stream until a non-
+     * whitespace symbol is encountered. The non-whitespace symbol is left on
+     * the stream.
+     *
+     * @param stream Stream holding the contents to parse.
+     */
+    void consume_whitespace(std::istream &stream) noexcept;
+
+    /**
      * Extract a single- or multi-line comment from a stream, if enabled in the
      * feature set.
      *
      * @param stream Stream holding the contents to parse.
      *
      * @throws UnexpectedCharacterException A parsed symbol was unexpected, or
-     *         the comment feature is not enabled,
+     *         the comment feature is not enabled.
      */
     void consume_comment(std::istream &stream) noexcept(false);
 

--- a/fly/parser/parser.hpp
+++ b/fly/parser/parser.hpp
@@ -2,6 +2,7 @@
 
 #include "fly/types/json/json.hpp"
 
+#include <cstdint>
 #include <filesystem>
 #include <istream>
 #include <string>
@@ -57,8 +58,8 @@ protected:
      */
     virtual Json parse_internal(std::istream &stream) noexcept(false) = 0;
 
-    int m_line;
-    int m_column;
+    std::uint32_t m_line;
+    std::uint32_t m_column;
 
 private:
     /**

--- a/test/parser/exceptions.cpp
+++ b/test/parser/exceptions.cpp
@@ -7,8 +7,8 @@
 //==============================================================================
 TEST(ParserExceptionTest, ParserException)
 {
-    int line = 123;
-    int column = 456;
+    std::uint32_t line = 123;
+    std::uint32_t column = 456;
     std::string message("Bad file!");
 
     try
@@ -43,8 +43,8 @@ TEST(ParserExceptionTest, ParserException)
 //==============================================================================
 TEST(ParserExceptionTest, UnexpectedCharacterException)
 {
-    int line = 123;
-    int column = 456;
+    std::uint32_t line = 123;
+    std::uint32_t column = 456;
     int c1 = '\0';
     int c2 = 'A';
 
@@ -88,8 +88,8 @@ TEST(ParserExceptionTest, UnexpectedCharacterException)
 //==============================================================================
 TEST(ParserExceptionTest, BadConversionException)
 {
-    int line = 123;
-    int column = 456;
+    std::uint32_t line = 123;
+    std::uint32_t column = 456;
     std::string value("789");
 
     try

--- a/test/parser/json_parser.cpp
+++ b/test/parser/json_parser.cpp
@@ -202,33 +202,23 @@ TEST_F(JsonParserTest, AllUnicode)
 //==============================================================================
 TEST_F(JsonParserTest, NonExistingPath)
 {
-    fly::Json values;
-
-    ASSERT_NO_THROW(
-        values =
-            m_parser.parse_file(std::filesystem::path("foo_abc") / "a.json"));
-    EXPECT_TRUE(values.is_null());
+    EXPECT_THROW(
+        m_parser.parse_file(std::filesystem::path("foo_abc") / "a.json"),
+        fly::ParserException);
 }
 
 //==============================================================================
 TEST_F(JsonParserTest, NonExistingFile)
 {
-    fly::Json values;
-
-    ASSERT_NO_THROW(
-        values = m_parser.parse_file(
-            std::filesystem::temp_directory_path() / "a.json"));
-    EXPECT_TRUE(values.is_null());
+    EXPECT_THROW(
+        m_parser.parse_file(std::filesystem::temp_directory_path() / "a.json"),
+        fly::ParserException);
 }
 
 //==============================================================================
 TEST_F(JsonParserTest, EmptyFile)
 {
-    const std::string contents;
-    fly::Json values;
-
-    ASSERT_NO_THROW(values = m_parser.parse_string(contents));
-    EXPECT_TRUE(values.is_null());
+    validate_fail_raw("");
 }
 
 //==============================================================================
@@ -446,7 +436,9 @@ TEST_F(JsonParserTest, NumericConversion)
     validate_fail("1.2e2e2");
     validate_fail("1.2E2e2");
     validate_fail("1.2E2E2");
-    validate_fail("01.1");
+    validate_fail("0b1");
+    validate_fail("01");
+    validate_fail("0x1");
     validate_fail(".1");
     validate_fail("e5");
     validate_fail("E5");

--- a/test/parser/json_parser.cpp
+++ b/test/parser/json_parser.cpp
@@ -449,6 +449,53 @@ TEST_F(JsonParserTest, SingleLineComment)
 {
     fly::JsonParser parser(fly::JsonParser::Features::AllowComments);
     {
+        std::string str = R"(
+        // here is a comment1
+        // here is a comment2
+        {
+            "a" : 12,
+            "b" : 13
+        })";
+
+        fly::Json json;
+
+        EXPECT_THROW(m_parser.parse_string(str), fly::ParserException);
+        EXPECT_NO_THROW(json = parser.parse_string(str));
+        EXPECT_EQ(json.size(), 2);
+        EXPECT_EQ(json["a"], 12);
+        EXPECT_EQ(json["b"], 13);
+    }
+    {
+        std::string str = R"(
+        {
+            "a" : 12,
+            "b" : 13
+        }
+        // here is a comment1
+        // here is a comment2
+        )";
+
+        fly::Json json;
+
+        EXPECT_THROW(m_parser.parse_string(str), fly::ParserException);
+        EXPECT_NO_THROW(json = parser.parse_string(str));
+        EXPECT_EQ(json.size(), 2);
+        EXPECT_EQ(json["a"], 12);
+        EXPECT_EQ(json["b"], 13);
+    }
+    {
+        std::string str = R"({
+            "a" : 12 // here is a comment
+        })";
+
+        fly::Json json;
+
+        EXPECT_THROW(m_parser.parse_string(str), fly::ParserException);
+        EXPECT_NO_THROW(json = parser.parse_string(str));
+        EXPECT_EQ(json.size(), 1);
+        EXPECT_EQ(json["a"], 12);
+    }
+    {
         std::string str = R"({
             "a" : 12, // here is a comment
             "b" : 13
@@ -492,20 +539,6 @@ TEST_F(JsonParserTest, SingleLineComment)
         EXPECT_EQ(json["a"], "abdc // here is a comment efgh");
         EXPECT_EQ(json["b"], 13);
     }
-    {
-        std::string str = R"({
-            "a" : 12 / here is a bad comment
-        })";
-
-        EXPECT_THROW(m_parser.parse_string(str), fly::ParserException);
-        EXPECT_THROW(parser.parse_string(str), fly::ParserException);
-    }
-    {
-        std::string str = R"({"a" : 12 /)";
-
-        EXPECT_THROW(m_parser.parse_string(str), fly::ParserException);
-        EXPECT_THROW(parser.parse_string(str), fly::ParserException);
-    }
 }
 
 //==============================================================================
@@ -513,8 +546,57 @@ TEST_F(JsonParserTest, MultiLineComment)
 {
     fly::JsonParser parser(fly::JsonParser::Features::AllowComments);
     {
+        std::string str = R"(
+        /* here is a comment1 */
+        /* here is a comment2 */
+        {
+            "a" : 12,
+            "b" : 13
+        })";
+
+        fly::Json json;
+
+        EXPECT_THROW(m_parser.parse_string(str), fly::ParserException);
+        EXPECT_NO_THROW(json = parser.parse_string(str));
+        EXPECT_EQ(json.size(), 2);
+        EXPECT_EQ(json["a"], 12);
+        EXPECT_EQ(json["b"], 13);
+    }
+    {
+        std::string str = R"(
+        {
+            "a" : 12,
+            "b" : 13
+        }
+        /* here is a comment1 */
+        /* here is a comment2 */
+        )";
+
+        fly::Json json;
+
+        EXPECT_THROW(m_parser.parse_string(str), fly::ParserException);
+        EXPECT_NO_THROW(json = parser.parse_string(str));
+        EXPECT_EQ(json.size(), 2);
+        EXPECT_EQ(json["a"], 12);
+        EXPECT_EQ(json["b"], 13);
+    }
+    {
         std::string str = R"({
             "a" : 12, /* here is a comment */
+            "b" : 13
+        })";
+
+        fly::Json json;
+
+        EXPECT_THROW(m_parser.parse_string(str), fly::ParserException);
+        EXPECT_NO_THROW(json = parser.parse_string(str));
+        EXPECT_EQ(json.size(), 2);
+        EXPECT_EQ(json["a"], 12);
+        EXPECT_EQ(json["b"], 13);
+    }
+    {
+        std::string str = R"({
+            "a" : 12/* here is a comment */,
             "b" : 13
         })";
 
@@ -577,6 +659,26 @@ TEST_F(JsonParserTest, MultiLineComment)
         EXPECT_EQ(json.size(), 2);
         EXPECT_EQ(json["a"], "abdc /* here is a comment */ efgh");
         EXPECT_EQ(json["b"], 13);
+    }
+}
+
+//==============================================================================
+TEST_F(JsonParserTest, InvalidComment)
+{
+    fly::JsonParser parser(fly::JsonParser::Features::AllowComments);
+    {
+        std::string str = R"({
+            "a" : 12 / here is a bad comment
+        })";
+
+        EXPECT_THROW(m_parser.parse_string(str), fly::ParserException);
+        EXPECT_THROW(parser.parse_string(str), fly::ParserException);
+    }
+    {
+        std::string str = R"({"a" : 12 /)";
+
+        EXPECT_THROW(m_parser.parse_string(str), fly::ParserException);
+        EXPECT_THROW(parser.parse_string(str), fly::ParserException);
     }
     {
         std::string str = R"({


### PR DESCRIPTION
The existing JSON parser was just a mess. It maintained a state machine and
several other boolean states in an attempt to iteratively parse JSON files.
It was pretty fragile though and hard to read & follow.

This new parser is recursive, which isn't ideal, but it at least doesn't
blow out the stack in any of the existing test cases. The main improvement
is that it doesn't suck to look at.