### PR TITLE
Canonical STL container definitions for Json class

### DIFF
--- a/fly/types/json/json.hpp
+++ b/fly/types/json/json.hpp
@@ -72,6 +72,19 @@ public:
         JsonTraits::float_type>;
 
     /**
+     * Aliases for canonical STL container member types.
+     */
+    using value_type = Json;
+    using size_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
+    using allocator_type = std::allocator<value_type>;
+    using reference = value_type &;
+    using const_reference = const value_type &;
+    using pointer = typename std::allocator_traits<allocator_type>::pointer;
+    using const_pointer =
+        typename std::allocator_traits<allocator_type>::const_pointer;
+
+    /**
      * Alias for a basic_stringstream with the JSON string type.
      */
     using stream_type =
@@ -182,7 +195,7 @@ public:
      *
      * @param json The Json instance to copy.
      */
-    Json(const Json &json) noexcept;
+    Json(const_reference json) noexcept;
 
     /**
      * Move constructor. Intializes the Json instance with the type and value
@@ -217,7 +230,7 @@ public:
      *
      * @return A reference to this Json instance.
      */
-    Json &operator=(Json json) noexcept;
+    reference operator=(Json json) noexcept;
 
     /**
      * @return True if the Json instance is null.
@@ -386,7 +399,7 @@ public:
      * @throws JsonException If the Json instance is neither an object nor null,
      *         or the key value is invalid.
      */
-    Json &operator[](
+    reference operator[](
         const typename JsonTraits::object_type::key_type &key) noexcept(false);
 
     /**
@@ -402,7 +415,7 @@ public:
      * @throws JsonException If the Json instance is not an object, or the key
      *         value does not exist, or the key value is invalid.
      */
-    const Json &
+    const_reference
     operator[](const typename JsonTraits::object_type::key_type &key) const
         noexcept(false);
 
@@ -421,8 +434,7 @@ public:
      *
      * @throws JsonException If the Json instance is neither an array nor null.
      */
-    Json &operator[](typename JsonTraits::array_type::size_type index) noexcept(
-        false);
+    reference operator[](size_type index) noexcept(false);
 
     /**
      * Array read-only access operator.
@@ -437,12 +449,87 @@ public:
      * @throws JsonException If the Json instance is not an array or the index
      *         does not exist.
      */
-    const Json &
-    operator[](typename JsonTraits::array_type::size_type index) const
+    const_reference operator[](size_type index) const noexcept(false);
+
+    /**
+     * Object read-only accessor.
+     *
+     * If the Json instance is an object, perform a lookup on the object with a
+     * key value.
+     *
+     * @param key The key value to lookup.
+     *
+     * @return A reference to the Json instance at the key value.
+     *
+     * @throws JsonException If the Json instance is not an object, or the key
+     *         value does not exist, or the key value is invalid.
+     */
+    reference
+    at(const typename JsonTraits::object_type::key_type &key) noexcept(false);
+
+    /**
+     * Object read-only accessor.
+     *
+     * If the Json instance is an object, perform a lookup on the object with a
+     * key value.
+     *
+     * @param key The key value to lookup.
+     *
+     * @return A reference to the Json instance at the key value.
+     *
+     * @throws JsonException If the Json instance is not an object, or the key
+     *         value does not exist, or the key value is invalid.
+     */
+    const_reference
+    at(const typename JsonTraits::object_type::key_type &key) const
         noexcept(false);
 
     /**
-     * Get the size of the Json instance.
+     * Array read-only accessor.
+     *
+     * If the Json instance is an array, perform a lookup on the array with an
+     * index.
+     *
+     * @param index The index to lookup.
+     *
+     * @return A reference to the Json instance at the index.
+     *
+     * @throws JsonException If the Json instance is not an array or the index
+     *         does not exist.
+     */
+    reference at(size_type index) noexcept(false);
+
+    /**
+     * Array read-only accessor.
+     *
+     * If the Json instance is an array, perform a lookup on the array with an
+     * index.
+     *
+     * @param index The index to lookup.
+     *
+     * @return A reference to the Json instance at the index.
+     *
+     * @throws JsonException If the Json instance is not an array or the index
+     *         does not exist.
+     */
+    const_reference at(size_type index) const noexcept(false);
+
+    /**
+     * Check if the Json instance contains zero elements.
+     *
+     * If the Json instance is an object, array, or string, return whether the
+     * stored container is empty.
+     *
+     * If the Json instance is null, return true.
+     *
+     * If the Json instance is a boolean or numeric, return false.
+     *
+     * @return True if the instance is empty.
+     */
+    bool empty() const noexcept;
+
+    /**
+     * Get the number of elements in the Json instance.
      *
      * If the Json instance is an object or array, return the number of elements
      * stored in the object or array.
@@ -455,7 +542,56 @@ public:
      *
      * @return The size of the Json instance.
      */
-    std::size_t size() const noexcept;
+    size_type size() const noexcept;
+
+    /**
+     * Clear the contents of the Json instance.
+     *
+     * If the Json instance is an object, array, or string, clears the stored
+     * container.
+     *
+     * If the Json instance is a boolean, sets to false.
+     *
+     * If the Json instance is numeric, sets to zero.
+     */
+    void clear() noexcept;
+
+    /**
+     * Exchange the contents of the Json instance with another instance.
+     *
+     * @param json The Json instance to swap with.
+     */
+    void swap(reference json) noexcept;
+
+    /**
+     * Exchange the contents of the Json instance with another string. Only
+     * valid if the Json instance is a string.
+     *
+     * @param json The string to swap with.
+     *
+     * @throws JsonException If the Json instance is not a string.
+     */
+    void swap(JsonTraits::string_type &other) noexcept(false);
+
+    /**
+     * Exchange the contents of the Json instance with another object. Only
+     * valid if the Json instance is an object.
+     *
+     * @param json The object to swap with.
+     *
+     * @throws JsonException If the Json instance is not an object.
+     */
+    void swap(JsonTraits::object_type &other) noexcept(false);
+
+    /**
+     * Exchange the contents of the Json instance with another array. Only
+     * valid if the Json instance is an array.
+     *
+     * @param json The array to swap with.
+     *
+     * @throws JsonException If the Json instance is not an array.
+     */
+    void swap(JsonTraits::array_type &other) noexcept(false);
 
     /**
      * Equality operator. Compares two Json instances for equality. They are
@@ -473,7 +609,8 @@ public:
      *
      * @return True if the two Json instances are equal.
      */
-    friend bool operator==(const Json &json1, const Json &json2) noexcept;
+    friend bool
+    operator==(const_reference json1, const_reference json2) noexcept;
 
     /**
      * Unequality operator. Compares two Json instances for unequality. They are
@@ -481,7 +618,8 @@ public:
      *
      * @return True if the two Json instances are unequal.
      */
-    friend bool operator!=(const Json &json1, const Json &json2) noexcept;
+    friend bool
+    operator!=(const_reference json1, const_reference json2) noexcept;
 
     /**
      * Stream operator. Stream the Json instance into an output stream.
@@ -492,7 +630,7 @@ public:
      * @return A reference to the output stream.
      */
     friend std::ostream &
-    operator<<(std::ostream &stream, const Json &json) noexcept;
+    operator<<(std::ostream &stream, const_reference json) noexcept;
 
 private:
     /**
@@ -526,9 +664,16 @@ private:
         JsonTraits::string_type::const_iterator &it,
         const JsonTraits::string_type::const_iterator &end) noexcept(false);
 
+    /**
+     * Write a character to a stream, handling any value that should be escaped.
+     * For those characters, an extra reverse solidus is inserted.
+     *
+     * @param stream Stream to pipe the escaped character into.
+     * @param ch Character to escape.
+     */
     static void write_escaped_charater(
         std::ostream &stream,
-        JsonTraits::string_type::value_type ch) noexcept(false);
+        JsonTraits::string_type::value_type ch) noexcept;
 
     /**
      * After determining the escaped character is a unicode encoding, read the
@@ -603,7 +748,9 @@ public:
      * @param json The Json instance for which the error was encountered.
      * @param message Message indicating what error was encountered.
      */
-    JsonException(const Json &json, const std::string &message) noexcept;
+    JsonException(
+        Json::const_reference json,
+        const std::string &message) noexcept;
 
     /**
      * @return C-string representing this exception.

--- a/test/types/json.cpp
+++ b/test/types/json.cpp
@@ -734,6 +734,62 @@ TEST_F(JsonTest, ObjectAccess)
 }
 
 //==============================================================================
+TEST_F(JsonTest, ObjectAt)
+{
+    fly::Json string1 = "abc";
+    EXPECT_THROW(string1.at("a"), fly::JsonException);
+
+    const fly::Json string2 = "abc";
+    EXPECT_THROW(string2.at("a"), fly::JsonException);
+
+    fly::Json object1 = {{"a", 1}, {"b", 2}};
+    EXPECT_EQ(object1.at("a"), 1);
+    EXPECT_EQ(object1.at("b"), 2);
+    EXPECT_THROW(object1.at("c"), fly::JsonException);
+
+    const fly::Json object2 = {{"a", 1}, {"b", 2}};
+    EXPECT_EQ(object2.at("a"), 1);
+    EXPECT_EQ(object2.at("b"), 2);
+    EXPECT_THROW(object2.at("c"), fly::JsonException);
+
+    fly::Json array1 = {'7', 8};
+    EXPECT_THROW(array1.at("a"), fly::JsonException);
+
+    const fly::Json array2 = {'7', 8};
+    EXPECT_THROW(array2.at("a"), fly::JsonException);
+
+    fly::Json bool1 = true;
+    EXPECT_THROW(bool1.at("a"), fly::JsonException);
+
+    const fly::Json bool2 = true;
+    EXPECT_THROW(bool2.at("a"), fly::JsonException);
+
+    fly::Json signed1 = 1;
+    EXPECT_THROW(signed1.at("a"), fly::JsonException);
+
+    const fly::Json signed2 = 1;
+    EXPECT_THROW(signed2.at("a"), fly::JsonException);
+
+    fly::Json unsigned1 = static_cast<unsigned int>(1);
+    EXPECT_THROW(unsigned1.at("a"), fly::JsonException);
+
+    const fly::Json unsigned2 = static_cast<unsigned int>(1);
+    EXPECT_THROW(unsigned2.at("a"), fly::JsonException);
+
+    fly::Json float1 = 1.0f;
+    EXPECT_THROW(float1.at("a"), fly::JsonException);
+
+    const fly::Json float2 = 1.0f;
+    EXPECT_THROW(float2.at("a"), fly::JsonException);
+
+    fly::Json null1 = nullptr;
+    EXPECT_THROW(null1.at("a"), fly::JsonException);
+
+    const fly::Json null2 = nullptr;
+    EXPECT_THROW(null2.at("a"), fly::JsonException);
+}
+
+//==============================================================================
 TEST_F(JsonTest, ArrayAccess)
 {
     fly::Json string1 = "abc";
@@ -775,7 +831,6 @@ TEST_F(JsonTest, ArrayAccess)
     EXPECT_THROW(unsigned1[0], fly::JsonException);
 
     const fly::Json unsigned2 = static_cast<unsigned int>(1);
-    ;
     EXPECT_THROW(unsigned2[0], fly::JsonException);
 
     fly::Json float1 = 1.0f;
@@ -791,6 +846,101 @@ TEST_F(JsonTest, ArrayAccess)
 
     const fly::Json null2 = nullptr;
     EXPECT_THROW(null2[0], fly::JsonException);
+}
+
+//==============================================================================
+TEST_F(JsonTest, ArrayAt)
+{
+    fly::Json string1 = "abc";
+    EXPECT_THROW(string1.at(0), fly::JsonException);
+
+    const fly::Json string2 = "abc";
+    EXPECT_THROW(string2.at(0), fly::JsonException);
+
+    fly::Json object1 = {{"a", 1}, {"b", 2}};
+    EXPECT_THROW(object1.at(0), fly::JsonException);
+
+    const fly::Json object2 = {{"a", 1}, {"b", 2}};
+    EXPECT_THROW(object2.at(0), fly::JsonException);
+
+    fly::Json array1 = {'7', 8};
+    EXPECT_EQ(array1.at(0), '7');
+    EXPECT_EQ(array1.at(1), 8);
+    EXPECT_THROW(array1.at(2), fly::JsonException);
+
+    const fly::Json array2 = {'7', 8};
+    EXPECT_EQ(array2.at(0), '7');
+    EXPECT_EQ(array2.at(1), 8);
+    EXPECT_THROW(array2.at(2), fly::JsonException);
+
+    fly::Json bool1 = true;
+    EXPECT_THROW(bool1.at(0), fly::JsonException);
+
+    const fly::Json bool2 = true;
+    EXPECT_THROW(bool2.at(0), fly::JsonException);
+
+    fly::Json signed1 = 1;
+    EXPECT_THROW(signed1.at(0), fly::JsonException);
+
+    const fly::Json signed2 = 1;
+    EXPECT_THROW(signed2.at(0), fly::JsonException);
+
+    fly::Json unsigned1 = static_cast<unsigned int>(1);
+    EXPECT_THROW(unsigned1.at(0), fly::JsonException);
+
+    const fly::Json unsigned2 = static_cast<unsigned int>(1);
+    EXPECT_THROW(unsigned2.at(0), fly::JsonException);
+
+    fly::Json float1 = 1.0f;
+    EXPECT_THROW(float1.at(0), fly::JsonException);
+
+    const fly::Json float2 = 1.0f;
+    EXPECT_THROW(float2.at(0), fly::JsonException);
+
+    fly::Json null1 = nullptr;
+    EXPECT_THROW(null1.at(0), fly::JsonException);
+
+    const fly::Json null2 = nullptr;
+    EXPECT_THROW(null2.at(0), fly::JsonException);
+}
+
+//==============================================================================
+TEST_F(JsonTest, Empty)
+{
+    fly::Json json;
+
+    json = "abcdef";
+    EXPECT_FALSE(json.empty());
+
+    json = {{"a", 1}, {"b", 2}};
+    EXPECT_FALSE(json.empty());
+
+    json = {'7', 8, 9, 10};
+    EXPECT_FALSE(json.empty());
+
+    json = true;
+    EXPECT_FALSE(json.empty());
+
+    json = 1;
+    EXPECT_FALSE(json.empty());
+
+    json = static_cast<unsigned int>(1);
+    EXPECT_FALSE(json.empty());
+
+    json = 1.0f;
+    EXPECT_FALSE(json.empty());
+
+    json = nullptr;
+    EXPECT_TRUE(json.empty());
+
+    json = "";
+    EXPECT_TRUE(json.empty());
+
+    json = fly::JsonTraits::object_type();
+    EXPECT_TRUE(json.empty());
+
+    json = fly::JsonTraits::array_type();
+    EXPECT_TRUE(json.empty());
 }
 
 //==============================================================================
@@ -821,6 +971,174 @@ TEST_F(JsonTest, Size)
 
     json = nullptr;
     EXPECT_EQ(json.size(), 0);
+}
+
+//==============================================================================
+TEST_F(JsonTest, Clear)
+{
+    fly::Json json;
+
+    json = "abcdef";
+    EXPECT_EQ(json.size(), 6);
+    json.clear();
+    EXPECT_TRUE(json.empty());
+
+    json = {{"a", 1}, {"b", 2}};
+    EXPECT_EQ(json.size(), 2);
+    json.clear();
+    EXPECT_TRUE(json.empty());
+
+    json = {'7', 8, 9, 10};
+    EXPECT_EQ(json.size(), 4);
+    json.clear();
+    EXPECT_TRUE(json.empty());
+
+    json = true;
+    EXPECT_TRUE(json);
+    json.clear();
+    EXPECT_FALSE(json);
+
+    json = 1;
+    EXPECT_EQ(json, 1);
+    json.clear();
+    EXPECT_EQ(json, 0);
+
+    json = static_cast<unsigned int>(1);
+    EXPECT_EQ(json, 1);
+    json.clear();
+    EXPECT_EQ(json, 0);
+
+    json = 1.0f;
+    EXPECT_DOUBLE_EQ(double(json), 1.0);
+    json.clear();
+    EXPECT_DOUBLE_EQ(double(json), 0.0);
+
+    json = nullptr;
+    EXPECT_EQ(json, nullptr);
+    json.clear();
+    EXPECT_EQ(json, nullptr);
+}
+
+//==============================================================================
+TEST_F(JsonTest, JsonSwap)
+{
+    fly::Json json1 = 12389;
+    fly::Json json2 = "string";
+    fly::Json json3 = {1, 2, 3, 8, 9};
+
+    json1.swap(json2);
+    EXPECT_EQ(json1, "string");
+    EXPECT_EQ(json2, 12389);
+
+    json2.swap(json3);
+    EXPECT_EQ(json2, fly::Json({1, 2, 3, 8, 9}));
+    EXPECT_EQ(json3, 12389);
+
+    json3.swap(json1);
+    EXPECT_EQ(json1, 12389);
+    EXPECT_EQ(json3, "string");
+}
+
+//==============================================================================
+TEST_F(JsonTest, StringSwap)
+{
+    fly::Json json;
+    std::string str;
+
+    json = "abcdef";
+    str = "ghijkl";
+    EXPECT_NO_THROW(json.swap(str));
+    EXPECT_EQ(json, "ghijkl");
+    EXPECT_EQ(str, "abcdef");
+
+    json = {{"a", 1}, {"b", 2}};
+    EXPECT_THROW(json.swap(str), fly::JsonException);
+
+    json = {'7', 8, 9, 10};
+    EXPECT_THROW(json.swap(str), fly::JsonException);
+
+    json = true;
+    EXPECT_THROW(json.swap(str), fly::JsonException);
+
+    json = 1;
+    EXPECT_THROW(json.swap(str), fly::JsonException);
+
+    json = static_cast<unsigned int>(1);
+    EXPECT_THROW(json.swap(str), fly::JsonException);
+
+    json = 1.0f;
+    EXPECT_THROW(json.swap(str), fly::JsonException);
+
+    json = nullptr;
+    EXPECT_THROW(json.swap(str), fly::JsonException);
+}
+
+//==============================================================================
+TEST_F(JsonTest, ObjectSwap)
+{
+    fly::Json json;
+    std::map<fly::JsonTraits::string_type, fly::Json> map;
+
+    json = "abcdef";
+    EXPECT_THROW(json.swap(map), fly::JsonException);
+
+    json = {{"a", 1}, {"b", 2}};
+    map = {{"c", 3}, {"d", 4}};
+    EXPECT_NO_THROW(json.swap(map));
+    EXPECT_EQ(json, fly::Json({{"c", 3}, {"d", 4}}));
+    EXPECT_EQ(map, fly::Json({{"a", 1}, {"b", 2}}));
+
+    json = {'7', 8, 9, 10};
+    EXPECT_THROW(json.swap(map), fly::JsonException);
+
+    json = true;
+    EXPECT_THROW(json.swap(map), fly::JsonException);
+
+    json = 1;
+    EXPECT_THROW(json.swap(map), fly::JsonException);
+
+    json = static_cast<unsigned int>(1);
+    EXPECT_THROW(json.swap(map), fly::JsonException);
+
+    json = 1.0f;
+    EXPECT_THROW(json.swap(map), fly::JsonException);
+
+    json = nullptr;
+    EXPECT_THROW(json.swap(map), fly::JsonException);
+}
+
+//==============================================================================
+TEST_F(JsonTest, ArraySwap)
+{
+    fly::Json json;
+    std::vector<fly::Json> array;
+
+    json = "abcdef";
+    EXPECT_THROW(json.swap(array), fly::JsonException);
+
+    json = {{"a", 1}, {"b", 2}};
+    EXPECT_THROW(json.swap(array), fly::JsonException);
+
+    json = {'7', 8, 9, 10};
+    array = {1, true, nullptr};
+    EXPECT_NO_THROW(json.swap(array));
+    EXPECT_EQ(json, fly::Json({1, true, nullptr}));
+    EXPECT_EQ(array, fly::Json({'7', 8, 9, 10}));
+
+    json = true;
+    EXPECT_THROW(json.swap(array), fly::JsonException);
+
+    json = 1;
+    EXPECT_THROW(json.swap(array), fly::JsonException);
+
+    json = static_cast<unsigned int>(1);
+    EXPECT_THROW(json.swap(array), fly::JsonException);
+
+    json = 1.0f;
+    EXPECT_THROW(json.swap(array), fly::JsonException);
+
+    json = nullptr;
+    EXPECT_THROW(json.swap(array), fly::JsonException);
 }
 
 //==============================================================================


### PR DESCRIPTION
Define aliases for Json member types (e.g value_type, size_type) that STL
containers define.

Define standard container methods (e.g. swap, clear) that STL containers
define.

Iterators are a big missing piece to really make the Json class STL-like.
Without them, it cannot define methods like insert, find, etc.