### PR TITLE
More generic Json swap method

### DIFF
--- a/fly/types/json/json.cpp
+++ b/fly/types/json/json.cpp
@@ -442,34 +442,6 @@ void Json::swap(JsonTraits::string_type &other) noexcept(false)
 }
 
 //==============================================================================
-void Json::swap(JsonTraits::object_type &other) noexcept(false)
-{
-    if (is_object())
-    {
-        auto &value = std::get<JsonTraits::object_type>(m_value);
-        std::swap(value, other);
-    }
-    else
-    {
-        throw JsonException(*this, "JSON type invalid for swap(object)");
-    }
-}
-
-//==============================================================================
-void Json::swap(JsonTraits::array_type &other) noexcept(false)
-{
-    if (is_array())
-    {
-        auto &value = std::get<JsonTraits::array_type>(m_value);
-        std::swap(value, other);
-    }
-    else
-    {
-        throw JsonException(*this, "JSON type invalid for swap(array)");
-    }
-}
-
-//==============================================================================
 bool operator==(
     Json::const_reference json1,
     Json::const_reference json2) noexcept

--- a/fly/types/json/json.hpp
+++ b/fly/types/json/json.hpp
@@ -585,7 +585,8 @@ public:
      *
      * @throws JsonException If the Json instance is not an object.
      */
-    void swap(JsonTraits::object_type &other) noexcept(false);
+    template <typename T, enable_if_all<JsonTraits::is_object<T>> = 0>
+    void swap(T &other) noexcept(false);
 
     /**
      * Exchange the contents of the Json instance with another array. Only
@@ -595,7 +596,8 @@ public:
      *
      * @throws JsonException If the Json instance is not an array.
      */
-    void swap(JsonTraits::array_type &other) noexcept(false);
+    template <typename T, enable_if_all<JsonTraits::is_array<T>> = 0>
+    void swap(T &other) noexcept(false);
 
     /**
      * Equality operator. Compares two Json instances for equality. They are
@@ -897,7 +899,6 @@ Json::operator T() const noexcept
             return false;
         }
     };
-
     return std::visit(visitor, m_value);
 }
 
@@ -935,6 +936,40 @@ Json::operator T() const noexcept(false)
     };
 
     return std::visit(visitor, m_value);
+}
+
+//==============================================================================
+template <typename T, enable_if_all<JsonTraits::is_object<T>>>
+void Json::swap(T &other) noexcept(false)
+{
+    if (is_object())
+    {
+        T object = static_cast<T>(*this);
+        *this = other;
+
+        std::swap(object, other);
+    }
+    else
+    {
+        throw JsonException(*this, "JSON type invalid for swap(object)");
+    }
+}
+
+//==============================================================================
+template <typename T, enable_if_all<JsonTraits::is_array<T>>>
+void Json::swap(T &other) noexcept(false)
+{
+    if (is_array())
+    {
+        T array = static_cast<T>(*this);
+        *this = other;
+
+        std::swap(array, other);
+    }
+    else
+    {
+        throw JsonException(*this, "JSON type invalid for swap(array)");
+    }
 }
 
 } // namespace fly

--- a/test/types/json.cpp
+++ b/test/types/json.cpp
@@ -385,68 +385,82 @@ TEST_F(JsonTest, ObjectConversion)
     validate_throw<std::unordered_map<std::string, fly::Json>>(json);
     validate_throw<std::unordered_multimap<std::string, fly::Json>>(json);
 
-    std::map<std::string, int> map1 = {{"1", 2}, {"3", 4}};
-    std::map<std::string, std::string> map2 = {{"1", "2"}, {"3", "4"}};
+    std::map<std::string, int> map1 = {{"a", 2}, {"b", 4}};
+    std::map<std::string, std::string> map2 = {{"a", "2"}, {"b", "4"}};
+    std::map<std::string, fly::Json> map3 = {{"a", 2}, {"b", "4"}};
     json = map1;
     EXPECT_EQ((decltype(map1)(json)), map1);
     EXPECT_EQ((decltype(map2)(json)), map2);
     json = map2;
     EXPECT_EQ((decltype(map1)(json)), map1);
     EXPECT_EQ((decltype(map2)(json)), map2);
-    json = {{"1", 2}, {"3", "4"}};
+    json = map3;
     EXPECT_EQ((decltype(map1)(json)), map1);
     EXPECT_EQ((decltype(map2)(json)), map2);
-    json = {{"1", true}};
+    EXPECT_EQ((decltype(map3)(json)), map3);
+    json = {{"a", true}};
     validate_throw<std::map<std::string, int>>(json);
-    json = {{"1", "string"}};
+    json = {{"a", "string"}};
     validate_throw<std::map<std::string, int>>(json);
 
-    std::multimap<std::string, int> multimap1 = {{"1", 2}, {"3", 4}};
-    std::multimap<std::string, std::string> multimap2 = {{"1", "2"}, {"3", "4"}};
-    json = multimap1;
-    EXPECT_EQ((decltype(multimap1)(json)), multimap1);
-    EXPECT_EQ((decltype(multimap2)(json)), multimap2);
-    json = multimap2;
-    EXPECT_EQ((decltype(multimap1)(json)), multimap1);
-    EXPECT_EQ((decltype(multimap2)(json)), multimap2);
-    json = {{"1", 2}, {"3", "4"}};
-    EXPECT_EQ((decltype(multimap1)(json)), multimap1);
-    EXPECT_EQ((decltype(multimap2)(json)), multimap2);
-    json = {{"1", true}};
+    std::multimap<std::string, int> mmap1 = {{"a", 2}, {"b", 4}};
+    std::multimap<std::string, std::string> mmap2 = {{"a", "2"}, {"b", "4"}};
+    std::multimap<std::string, fly::Json> mmap3 = {{"a", 2}, {"b", "4"}};
+    json = mmap1;
+    EXPECT_EQ((decltype(mmap1)(json)), mmap1);
+    EXPECT_EQ((decltype(mmap2)(json)), mmap2);
+    json = mmap2;
+    EXPECT_EQ((decltype(mmap1)(json)), mmap1);
+    EXPECT_EQ((decltype(mmap2)(json)), mmap2);
+    json = mmap3;
+    EXPECT_EQ((decltype(mmap1)(json)), mmap1);
+    EXPECT_EQ((decltype(mmap2)(json)), mmap2);
+    EXPECT_EQ((decltype(mmap3)(json)), mmap3);
+    json = {{"a", true}};
     validate_throw<std::multimap<std::string, int>>(json);
-    json = {{"1", "string"}};
+    json = {{"a", "string"}};
     validate_throw<std::multimap<std::string, int>>(json);
 
-    std::unordered_map<std::string, int> u_map1 = {{"1", 2}, {"3", 4}};
-    std::unordered_map<std::string, std::string> u_map2 = {{"1", "2"}, {"3", "4"}};
+    std::unordered_map<std::string, int> u_map1 = {{"a", 2}, {"b", 4}};
+    std::unordered_map<std::string, std::string> u_map2 = {
+        {"a", "2"},
+        {"b", "4"}};
+    std::unordered_map<std::string, fly::Json> u_map3 = {{"a", 2}, {"b", "4"}};
     json = u_map1;
     EXPECT_EQ((decltype(u_map1)(json)), u_map1);
     EXPECT_EQ((decltype(u_map2)(json)), u_map2);
     json = u_map2;
     EXPECT_EQ((decltype(u_map1)(json)), u_map1);
     EXPECT_EQ((decltype(u_map2)(json)), u_map2);
-    json = {{"1", 2}, {"3", "4"}};
+    json = u_map3;
     EXPECT_EQ((decltype(u_map1)(json)), u_map1);
     EXPECT_EQ((decltype(u_map2)(json)), u_map2);
-    json = {{"1", true}};
+    EXPECT_EQ((decltype(u_map3)(json)), u_map3);
+    json = {{"a", true}};
     validate_throw<std::unordered_map<std::string, int>>(json);
-    json = {{"1", "string"}};
+    json = {{"a", "string"}};
     validate_throw<std::unordered_map<std::string, int>>(json);
 
-    std::unordered_multimap<std::string, int> u_multimap1 = {{"1", 2}, {"3", 4}};
-    std::unordered_multimap<std::string, std::string> u_multimap2 = {{"1", "2"}, {"3", "4"}};
-    json = u_multimap1;
-    EXPECT_EQ((decltype(u_multimap1)(json)), u_multimap1);
-    EXPECT_EQ((decltype(u_multimap2)(json)), u_multimap2);
-    json = u_multimap2;
-    EXPECT_EQ((decltype(u_multimap1)(json)), u_multimap1);
-    EXPECT_EQ((decltype(u_multimap2)(json)), u_multimap2);
-    json = {{"1", 2}, {"3", "4"}};
-    EXPECT_EQ((decltype(u_multimap1)(json)), u_multimap1);
-    EXPECT_EQ((decltype(u_multimap2)(json)), u_multimap2);
-    json = {{"1", true}};
+    std::unordered_multimap<std::string, int> u_mmap1 = {{"a", 2}, {"b", 4}};
+    std::unordered_multimap<std::string, std::string> u_mmap2 = {
+        {"a", "2"},
+        {"b", "4"}};
+    std::unordered_multimap<std::string, fly::Json> u_mmap3 = {
+        {"a", 2},
+        {"b", "4"}};
+    json = u_mmap1;
+    EXPECT_EQ((decltype(u_mmap1)(json)), u_mmap1);
+    EXPECT_EQ((decltype(u_mmap2)(json)), u_mmap2);
+    json = u_mmap2;
+    EXPECT_EQ((decltype(u_mmap1)(json)), u_mmap1);
+    EXPECT_EQ((decltype(u_mmap2)(json)), u_mmap2);
+    json = u_mmap3;
+    EXPECT_EQ((decltype(u_mmap1)(json)), u_mmap1);
+    EXPECT_EQ((decltype(u_mmap2)(json)), u_mmap2);
+    EXPECT_EQ((decltype(u_mmap3)(json)), u_mmap3);
+    json = {{"a", true}};
     validate_throw<std::unordered_multimap<std::string, int>>(json);
-    json = {{"1", "string"}};
+    json = {{"a", "string"}};
     validate_throw<std::unordered_multimap<std::string, int>>(json);
 
     json = {'7', 8};
@@ -515,39 +529,43 @@ TEST_F(JsonTest, ArrayConversion)
 
     std::array<int, 4> array1 = {50, 60, 70, 80};
     std::array<std::string, 4> array2 = {"50", "60", "70", "80"};
+    std::array<fly::Json, 4> array3 = {50, "60", 70, "80"};
     json = array1;
     EXPECT_EQ((decltype(array1)(json)), array1);
     EXPECT_EQ((decltype(array2)(json)), array2);
     json = array2;
     EXPECT_EQ((decltype(array1)(json)), array1);
     EXPECT_EQ((decltype(array2)(json)), array2);
-    json = {50, "60", 70, "80"};
+    json = array3;
     EXPECT_EQ((decltype(array1)(json)), array1);
     EXPECT_EQ((decltype(array2)(json)), array2);
+    EXPECT_EQ((decltype(array3)(json)), array3);
     json = {true};
     validate_throw<std::array<int, 1>>(json);
     json = {"string"};
     validate_throw<std::array<int, 1>>(json);
 
-    std::array<int, 1> array3 = {7};
-    std::array<int, 2> array4 = {7, 8};
-    std::array<int, 3> array5 = {7, 8, 0};
-    json = array4;
-    EXPECT_EQ((decltype(array3)(json)), array3);
+    std::array<int, 1> array4 = {7};
+    std::array<int, 2> array5 = {7, 8};
+    std::array<int, 3> array6 = {7, 8, 0};
+    json = array5;
     EXPECT_EQ((decltype(array4)(json)), array4);
     EXPECT_EQ((decltype(array5)(json)), array5);
+    EXPECT_EQ((decltype(array6)(json)), array6);
 
     std::deque<int> deque1 = {50, 60, 70, 80};
     std::deque<std::string> deque2 = {"50", "60", "70", "80"};
+    std::deque<fly::Json> deque3 = {50, "60", 70, "80"};
     json = deque1;
     EXPECT_EQ((decltype(deque1)(json)), deque1);
     EXPECT_EQ((decltype(deque2)(json)), deque2);
     json = deque2;
     EXPECT_EQ((decltype(deque1)(json)), deque1);
     EXPECT_EQ((decltype(deque2)(json)), deque2);
-    json = {50, "60", 70, "80"};
+    json = deque3;
     EXPECT_EQ((decltype(deque1)(json)), deque1);
     EXPECT_EQ((decltype(deque2)(json)), deque2);
+    EXPECT_EQ((decltype(deque3)(json)), deque3);
     json = {true};
     validate_throw<std::deque<int>>(json);
     json = {"string"};
@@ -555,15 +573,17 @@ TEST_F(JsonTest, ArrayConversion)
 
     std::forward_list<int> forward_list1 = {50, 60, 70, 80};
     std::forward_list<std::string> forward_list2 = {"50", "60", "70", "80"};
+    std::forward_list<fly::Json> forward_list3 = {50, "60", 70, "80"};
     json = forward_list1;
     EXPECT_EQ((decltype(forward_list1)(json)), forward_list1);
     EXPECT_EQ((decltype(forward_list2)(json)), forward_list2);
     json = forward_list2;
     EXPECT_EQ((decltype(forward_list1)(json)), forward_list1);
     EXPECT_EQ((decltype(forward_list2)(json)), forward_list2);
-    json = {50, "60", 70, "80"};
+    json = forward_list3;
     EXPECT_EQ((decltype(forward_list1)(json)), forward_list1);
     EXPECT_EQ((decltype(forward_list2)(json)), forward_list2);
+    EXPECT_EQ((decltype(forward_list3)(json)), forward_list3);
     json = {true};
     validate_throw<std::forward_list<int>>(json);
     json = {"string"};
@@ -571,15 +591,17 @@ TEST_F(JsonTest, ArrayConversion)
 
     std::list<int> list1 = {50, 60, 70, 80};
     std::list<std::string> list2 = {"50", "60", "70", "80"};
+    std::list<fly::Json> list3 = {50, "60", 70, "80"};
     json = list1;
     EXPECT_EQ((decltype(list1)(json)), list1);
     EXPECT_EQ((decltype(list2)(json)), list2);
     json = list2;
     EXPECT_EQ((decltype(list1)(json)), list1);
     EXPECT_EQ((decltype(list2)(json)), list2);
-    json = {50, "60", 70, "80"};
+    json = list3;
     EXPECT_EQ((decltype(list1)(json)), list1);
     EXPECT_EQ((decltype(list2)(json)), list2);
+    EXPECT_EQ((decltype(list3)(json)), list3);
     json = {true};
     validate_throw<std::list<int>>(json);
     json = {"string"};
@@ -587,15 +609,17 @@ TEST_F(JsonTest, ArrayConversion)
 
     std::multiset<int> multiset1 = {50, 60, 70, 80};
     std::multiset<std::string> multiset2 = {"50", "60", "70", "80"};
+    // std::multiset<fly::Json> multiset3 = {50, "60", 70, "80"};
     json = multiset1;
     EXPECT_EQ((decltype(multiset1)(json)), multiset1);
     EXPECT_EQ((decltype(multiset2)(json)), multiset2);
     json = multiset2;
     EXPECT_EQ((decltype(multiset1)(json)), multiset1);
     EXPECT_EQ((decltype(multiset2)(json)), multiset2);
-    json = {50, "60", 70, "80"};
-    EXPECT_EQ((decltype(multiset1)(json)), multiset1);
-    EXPECT_EQ((decltype(multiset2)(json)), multiset2);
+    // json = multiset3;
+    // EXPECT_EQ((decltype(multiset1)(json)), multiset1);
+    // EXPECT_EQ((decltype(multiset2)(json)), multiset2);
+    // EXPECT_EQ((decltype(multiset3)(json)), multiset3);
     json = {true};
     validate_throw<std::multiset<int>>(json);
     json = {"string"};
@@ -603,15 +627,17 @@ TEST_F(JsonTest, ArrayConversion)
 
     std::set<int> set1 = {50, 60, 70, 80};
     std::set<std::string> set2 = {"50", "60", "70", "80"};
+    // std::set<fly::Json> set3 = {50, "60", 70, "80"};
     json = set1;
     EXPECT_EQ((decltype(set1)(json)), set1);
     EXPECT_EQ((decltype(set2)(json)), set2);
     json = set2;
     EXPECT_EQ((decltype(set1)(json)), set1);
     EXPECT_EQ((decltype(set2)(json)), set2);
-    json = {50, "60", 70, "80"};
-    EXPECT_EQ((decltype(set1)(json)), set1);
-    EXPECT_EQ((decltype(set2)(json)), set2);
+    // json = set3;
+    // EXPECT_EQ((decltype(set1)(json)), set1);
+    // EXPECT_EQ((decltype(set2)(json)), set2);
+    // EXPECT_EQ((decltype(set3)(json)), set3);
     json = {true};
     validate_throw<std::set<int>>(json);
     json = {"string"};
@@ -619,15 +645,17 @@ TEST_F(JsonTest, ArrayConversion)
 
     std::unordered_multiset<int> u_multiset1 = {50, 60, 70, 80};
     std::unordered_multiset<std::string> u_multiset2 = {"50", "60", "70", "80"};
+    // std::unordered_multiset<fly::Json> u_multiset3 = {50, "60", 70, "80"};
     json = u_multiset1;
     EXPECT_EQ((decltype(u_multiset1)(json)), u_multiset1);
     EXPECT_EQ((decltype(u_multiset2)(json)), u_multiset2);
     json = u_multiset2;
     EXPECT_EQ((decltype(u_multiset1)(json)), u_multiset1);
     EXPECT_EQ((decltype(u_multiset2)(json)), u_multiset2);
-    json = {50, "60", 70, "80"};
-    EXPECT_EQ((decltype(u_multiset1)(json)), u_multiset1);
-    EXPECT_EQ((decltype(u_multiset2)(json)), u_multiset2);
+    // json = u_multiset3;
+    // EXPECT_EQ((decltype(u_multiset1)(json)), u_multiset1);
+    // EXPECT_EQ((decltype(u_multiset2)(json)), u_multiset2);
+    // EXPECT_EQ((decltype(u_multiset3)(json)), u_multiset3);
     json = {true};
     validate_throw<std::unordered_multiset<int>>(json);
     json = {"string"};
@@ -635,15 +663,17 @@ TEST_F(JsonTest, ArrayConversion)
 
     std::unordered_set<int> u_set1 = {50, 60, 70, 80};
     std::unordered_set<std::string> u_set2 = {"50", "60", "70", "80"};
+    // std::unordered_set<fly::Json> u_set3 = {50, "60", 70, "80"};
     json = u_set1;
     EXPECT_EQ((decltype(u_set1)(json)), u_set1);
     EXPECT_EQ((decltype(u_set2)(json)), u_set2);
     json = u_set2;
     EXPECT_EQ((decltype(u_set1)(json)), u_set1);
     EXPECT_EQ((decltype(u_set2)(json)), u_set2);
-    json = {50, "60", 70, "80"};
-    EXPECT_EQ((decltype(u_set1)(json)), u_set1);
-    EXPECT_EQ((decltype(u_set2)(json)), u_set2);
+    // json = u_set3;
+    // EXPECT_EQ((decltype(u_set1)(json)), u_set1);
+    // EXPECT_EQ((decltype(u_set2)(json)), u_set2);
+    // EXPECT_EQ((decltype(u_set3)(json)), u_set3);
     json = {true};
     validate_throw<std::unordered_set<int>>(json);
     json = {"string"};
@@ -651,15 +681,17 @@ TEST_F(JsonTest, ArrayConversion)
 
     std::vector<int> vector1 = {50, 60, 70, 80};
     std::vector<std::string> vector2 = {"50", "60", "70", "80"};
+    std::vector<fly::Json> vector3 = {50, "60", 70, "80"};
     json = vector1;
     EXPECT_EQ((decltype(vector1)(json)), vector1);
     EXPECT_EQ((decltype(vector2)(json)), vector2);
     json = vector2;
     EXPECT_EQ((decltype(vector1)(json)), vector1);
     EXPECT_EQ((decltype(vector2)(json)), vector2);
-    json = {50, "60", 70, "80"};
+    json = vector3;
     EXPECT_EQ((decltype(vector1)(json)), vector1);
     EXPECT_EQ((decltype(vector2)(json)), vector2);
+    EXPECT_EQ((decltype(vector3)(json)), vector3);
     json = {true};
     validate_throw<std::vector<int>>(json);
     json = {"string"};
@@ -1321,68 +1353,410 @@ TEST_F(JsonTest, StringSwap)
 TEST_F(JsonTest, ObjectSwap)
 {
     fly::Json json;
-    std::map<fly::JsonTraits::string_type, fly::Json> map;
+    std::map<std::string, fly::Json> map;
+    std::multimap<std::string, fly::Json> mmap;
+    std::unordered_map<std::string, fly::Json> u_map;
+    std::unordered_multimap<std::string, fly::Json> u_mmap;
 
     json = "abcdef";
     EXPECT_THROW(json.swap(map), fly::JsonException);
+    EXPECT_THROW(json.swap(mmap), fly::JsonException);
+    EXPECT_THROW(json.swap(u_map), fly::JsonException);
+    EXPECT_THROW(json.swap(u_mmap), fly::JsonException);
 
-    json = {{"a", 1}, {"b", 2}};
-    map = {{"c", 3}, {"d", 4}};
-    EXPECT_NO_THROW(json.swap(map));
-    EXPECT_EQ(json, fly::Json({{"c", 3}, {"d", 4}}));
-    EXPECT_EQ(map, fly::Json({{"a", 1}, {"b", 2}}));
+    std::map<std::string, int> map1 = {{"a", 2}, {"b", 4}};
+    std::map<std::string, std::string> map2 = {{"a", "2"}, {"b", "4"}};
+    std::map<std::string, fly::Json> map3 = {{"a", 5}, {"b", "6"}};
+    json = {{"c", 100}, {"d", 200}};
+    EXPECT_NO_THROW(json.swap(map1));
+    EXPECT_EQ(json, (decltype(map1)({{"a", 2}, {"b", 4}})));
+    EXPECT_EQ(map1, (decltype(map1)({{"c", 100}, {"d", 200}})));
+    json = {{"c", 100}, {"d", 200}};
+    EXPECT_NO_THROW(json.swap(map2));
+    EXPECT_EQ(json, (decltype(map2)({{"a", "2"}, {"b", "4"}})));
+    EXPECT_EQ(map2, (decltype(map2)({{"c", "100"}, {"d", "200"}})));
+    json = {{"c", nullptr}, {"d", true}};
+    EXPECT_NO_THROW(json.swap(map3));
+    EXPECT_EQ(json, (decltype(map3)({{"a", 5}, {"b", "6"}})));
+    EXPECT_EQ(map3, (decltype(map3)({{"c", nullptr}, {"d", true}})));
+    json = {{"c", 100}, {"d", "200"}};
+    EXPECT_NO_THROW(json.swap(map1));
+    EXPECT_EQ(json, (decltype(map1)({{"c", 100}, {"d", 200}})));
+    EXPECT_EQ(map1, (decltype(map1)({{"c", 100}, {"d", 200}})));
+
+    std::multimap<std::string, int> mmap1 = {{"a", 2}, {"b", 4}};
+    std::multimap<std::string, std::string> mmap2 = {{"a", "2"}, {"b", "4"}};
+    std::multimap<std::string, fly::Json> mmap3 = {{"a", 5}, {"b", "6"}};
+    json = {{"c", 100}, {"d", 200}};
+    EXPECT_NO_THROW(json.swap(mmap1));
+    EXPECT_EQ(json, (decltype(mmap1)({{"a", 2}, {"b", 4}})));
+    EXPECT_EQ(mmap1, (decltype(mmap1)({{"c", 100}, {"d", 200}})));
+    json = {{"c", 100}, {"d", 200}};
+    EXPECT_NO_THROW(json.swap(mmap2));
+    EXPECT_EQ(json, (decltype(mmap2)({{"a", "2"}, {"b", "4"}})));
+    EXPECT_EQ(mmap2, (decltype(mmap2)({{"c", "100"}, {"d", "200"}})));
+    json = {{"c", nullptr}, {"d", true}};
+    EXPECT_NO_THROW(json.swap(mmap3));
+    EXPECT_EQ(json, (decltype(mmap3)({{"a", 5}, {"b", "6"}})));
+    EXPECT_EQ(mmap3, (decltype(mmap3)({{"c", nullptr}, {"d", true}})));
+    json = {{"c", 100}, {"d", "200"}};
+    EXPECT_NO_THROW(json.swap(mmap1));
+    EXPECT_EQ(json, (decltype(mmap1)({{"c", 100}, {"d", 200}})));
+    EXPECT_EQ(mmap1, (decltype(mmap1)({{"c", 100}, {"d", 200}})));
+
+    std::unordered_map<std::string, int> u_map1 = {{"a", 2}, {"b", 4}};
+    std::unordered_map<std::string, std::string> u_map2 = {
+        {"a", "2"},
+        {"b", "4"}};
+    std::unordered_map<std::string, fly::Json> u_map3 = {{"a", 5}, {"b", "6"}};
+    json = {{"c", 100}, {"d", 200}};
+    EXPECT_NO_THROW(json.swap(u_map1));
+    EXPECT_EQ(json, (decltype(u_map1)({{"a", 2}, {"b", 4}})));
+    EXPECT_EQ(u_map1, (decltype(u_map1)({{"c", 100}, {"d", 200}})));
+    json = {{"c", 100}, {"d", 200}};
+    EXPECT_NO_THROW(json.swap(u_map2));
+    EXPECT_EQ(json, (decltype(u_map2)({{"a", "2"}, {"b", "4"}})));
+    EXPECT_EQ(u_map2, (decltype(u_map2)({{"c", "100"}, {"d", "200"}})));
+    json = {{"c", nullptr}, {"d", true}};
+    EXPECT_NO_THROW(json.swap(u_map3));
+    EXPECT_EQ(json, (decltype(u_map3)({{"a", 5}, {"b", "6"}})));
+    EXPECT_EQ(u_map3, (decltype(u_map3)({{"c", nullptr}, {"d", true}})));
+    json = {{"c", 100}, {"d", "200"}};
+    EXPECT_NO_THROW(json.swap(u_map1));
+    EXPECT_EQ(json, (decltype(u_map1)({{"c", 100}, {"d", 200}})));
+    EXPECT_EQ(u_map1, (decltype(u_map1)({{"c", 100}, {"d", 200}})));
+
+    std::unordered_multimap<std::string, int> u_mmap1 = {{"a", 2}, {"b", 4}};
+    std::unordered_multimap<std::string, std::string> u_mmap2 = {
+        {"a", "2"},
+        {"b", "4"}};
+    std::unordered_multimap<std::string, fly::Json> u_mmap3 = {
+        {"a", 5},
+        {"b", "6"}};
+    json = {{"c", 100}, {"d", 200}};
+    EXPECT_NO_THROW(json.swap(u_mmap1));
+    EXPECT_EQ(json, (decltype(u_mmap1)({{"a", 2}, {"b", 4}})));
+    EXPECT_EQ(u_mmap1, (decltype(u_mmap1)({{"c", 100}, {"d", 200}})));
+    json = {{"c", 100}, {"d", 200}};
+    EXPECT_NO_THROW(json.swap(u_mmap2));
+    EXPECT_EQ(json, (decltype(u_mmap2)({{"a", "2"}, {"b", "4"}})));
+    EXPECT_EQ(u_mmap2, (decltype(u_mmap2)({{"c", "100"}, {"d", "200"}})));
+    json = {{"c", nullptr}, {"d", true}};
+    EXPECT_NO_THROW(json.swap(u_mmap3));
+    EXPECT_EQ(json, (decltype(u_mmap3)({{"a", 5}, {"b", "6"}})));
+    EXPECT_EQ(u_mmap3, (decltype(u_mmap3)({{"c", nullptr}, {"d", true}})));
+    json = {{"c", 100}, {"d", "200"}};
+    EXPECT_NO_THROW(json.swap(u_mmap1));
+    EXPECT_EQ(json, (decltype(u_mmap1)({{"c", 100}, {"d", 200}})));
+    EXPECT_EQ(u_mmap1, (decltype(u_mmap1)({{"c", 100}, {"d", 200}})));
 
     json = {'7', 8, 9, 10};
     EXPECT_THROW(json.swap(map), fly::JsonException);
+    EXPECT_THROW(json.swap(mmap), fly::JsonException);
+    EXPECT_THROW(json.swap(u_map), fly::JsonException);
+    EXPECT_THROW(json.swap(u_mmap), fly::JsonException);
 
     json = true;
     EXPECT_THROW(json.swap(map), fly::JsonException);
+    EXPECT_THROW(json.swap(mmap), fly::JsonException);
+    EXPECT_THROW(json.swap(u_map), fly::JsonException);
+    EXPECT_THROW(json.swap(u_mmap), fly::JsonException);
 
     json = 1;
     EXPECT_THROW(json.swap(map), fly::JsonException);
+    EXPECT_THROW(json.swap(mmap), fly::JsonException);
+    EXPECT_THROW(json.swap(u_map), fly::JsonException);
+    EXPECT_THROW(json.swap(u_mmap), fly::JsonException);
 
     json = static_cast<unsigned int>(1);
     EXPECT_THROW(json.swap(map), fly::JsonException);
+    EXPECT_THROW(json.swap(mmap), fly::JsonException);
+    EXPECT_THROW(json.swap(u_map), fly::JsonException);
+    EXPECT_THROW(json.swap(u_mmap), fly::JsonException);
 
     json = 1.0f;
     EXPECT_THROW(json.swap(map), fly::JsonException);
+    EXPECT_THROW(json.swap(mmap), fly::JsonException);
+    EXPECT_THROW(json.swap(u_map), fly::JsonException);
+    EXPECT_THROW(json.swap(u_mmap), fly::JsonException);
 
     json = nullptr;
     EXPECT_THROW(json.swap(map), fly::JsonException);
+    EXPECT_THROW(json.swap(mmap), fly::JsonException);
+    EXPECT_THROW(json.swap(u_map), fly::JsonException);
+    EXPECT_THROW(json.swap(u_mmap), fly::JsonException);
 }
 
 //==============================================================================
 TEST_F(JsonTest, ArraySwap)
 {
     fly::Json json;
-    std::vector<fly::Json> array;
+    std::array<int, 4> array;
+    std::deque<int> deque;
+    std::forward_list<int> forward_list;
+    std::list<int> list;
+    std::multiset<int> multiset;
+    std::set<int> set;
+    std::unordered_multiset<int> u_multiset;
+    std::unordered_set<int> u_set;
+    std::vector<int> vector;
 
     json = "abcdef";
     EXPECT_THROW(json.swap(array), fly::JsonException);
+    EXPECT_THROW(json.swap(deque), fly::JsonException);
+    EXPECT_THROW(json.swap(forward_list), fly::JsonException);
+    EXPECT_THROW(json.swap(list), fly::JsonException);
+    EXPECT_THROW(json.swap(multiset), fly::JsonException);
+    EXPECT_THROW(json.swap(set), fly::JsonException);
+    EXPECT_THROW(json.swap(u_multiset), fly::JsonException);
+    EXPECT_THROW(json.swap(u_set), fly::JsonException);
+    EXPECT_THROW(json.swap(vector), fly::JsonException);
 
     json = {{"a", 1}, {"b", 2}};
     EXPECT_THROW(json.swap(array), fly::JsonException);
+    EXPECT_THROW(json.swap(deque), fly::JsonException);
+    EXPECT_THROW(json.swap(forward_list), fly::JsonException);
+    EXPECT_THROW(json.swap(list), fly::JsonException);
+    EXPECT_THROW(json.swap(multiset), fly::JsonException);
+    EXPECT_THROW(json.swap(set), fly::JsonException);
+    EXPECT_THROW(json.swap(u_multiset), fly::JsonException);
+    EXPECT_THROW(json.swap(u_set), fly::JsonException);
+    EXPECT_THROW(json.swap(vector), fly::JsonException);
 
-    json = {'7', 8, 9, 10};
-    array = {1, true, nullptr};
-    EXPECT_NO_THROW(json.swap(array));
-    EXPECT_EQ(json, fly::Json({1, true, nullptr}));
-    EXPECT_EQ(array, fly::Json({'7', 8, 9, 10}));
+    std::array<int, 4> array1 = {50, 60, 70, 80};
+    std::array<std::string, 4> array2 = {"50", "60", "70", "80"};
+    std::array<fly::Json, 4> array3 = {"a", 90, "b", 100};
+    json = {1, 2};
+    EXPECT_NO_THROW(json.swap(array1));
+    EXPECT_EQ(json, (decltype(array1)({50, 60, 70, 80})));
+    EXPECT_EQ(array1, (decltype(array1)({1, 2, 0, 0})));
+    json = {1, 2};
+    EXPECT_NO_THROW(json.swap(array2));
+    EXPECT_EQ(json, (decltype(array2)({"50", "60", "70", "80"})));
+    EXPECT_EQ(array2, (decltype(array2)({"1", "2"})));
+    json = {nullptr, true};
+    EXPECT_NO_THROW(json.swap(array3));
+    EXPECT_EQ(json, (decltype(array3)({"a", 90, "b", 100})));
+    EXPECT_EQ(array3, (decltype(array3)({nullptr, true})));
+    json = {50, "60", 70, "80"};
+    EXPECT_NO_THROW(json.swap(array1));
+    EXPECT_EQ(json, (decltype(array1)({1, 2})));
+    EXPECT_EQ(array1, (decltype(array1)({50, 60, 70, 80})));
+
+    std::deque<int> deque1 = {50, 60, 70, 80};
+    std::deque<std::string> deque2 = {"50", "60", "70", "80"};
+    std::deque<fly::Json> deque3 = {"a", 90, "b", 100};
+    json = {1, 2};
+    EXPECT_NO_THROW(json.swap(deque1));
+    EXPECT_EQ(json, (decltype(deque1)({50, 60, 70, 80})));
+    EXPECT_EQ(deque1, (decltype(deque1)({1, 2})));
+    json = {1, 2};
+    EXPECT_NO_THROW(json.swap(deque2));
+    EXPECT_EQ(json, (decltype(deque2)({"50", "60", "70", "80"})));
+    EXPECT_EQ(deque2, (decltype(deque2)({"1", "2"})));
+    json = {nullptr, true};
+    EXPECT_NO_THROW(json.swap(deque3));
+    EXPECT_EQ(json, (decltype(deque3)({"a", 90, "b", 100})));
+    EXPECT_EQ(deque3, (decltype(deque3)({nullptr, true})));
+    json = {50, "60", 70, "80"};
+    EXPECT_NO_THROW(json.swap(deque1));
+    EXPECT_EQ(json, (decltype(deque1)({1, 2})));
+    EXPECT_EQ(deque1, (decltype(deque1)({50, 60, 70, 80})));
+
+    std::forward_list<int> forward_list1 = {50, 60, 70, 80};
+    std::forward_list<std::string> forward_list2 = {"50", "60", "70", "80"};
+    std::forward_list<fly::Json> forward_list3 = {"a", 90, "b", 100};
+    json = {1, 2};
+    EXPECT_NO_THROW(json.swap(forward_list1));
+    EXPECT_EQ(json, (decltype(forward_list1)({50, 60, 70, 80})));
+    EXPECT_EQ(forward_list1, (decltype(forward_list1)({1, 2})));
+    json = {1, 2};
+    EXPECT_NO_THROW(json.swap(forward_list2));
+    EXPECT_EQ(json, (decltype(forward_list2)({"50", "60", "70", "80"})));
+    EXPECT_EQ(forward_list2, (decltype(forward_list2)({"1", "2"})));
+    json = {nullptr, true};
+    EXPECT_NO_THROW(json.swap(forward_list3));
+    EXPECT_EQ(json, (decltype(forward_list3)({"a", 90, "b", 100})));
+    EXPECT_EQ(forward_list3, (decltype(forward_list3)({nullptr, true})));
+    json = {50, "60", 70, "80"};
+    EXPECT_NO_THROW(json.swap(forward_list1));
+    EXPECT_EQ(json, (decltype(forward_list1)({1, 2})));
+    EXPECT_EQ(forward_list1, (decltype(forward_list1)({50, 60, 70, 80})));
+
+    std::list<int> list1 = {50, 60, 70, 80};
+    std::list<std::string> list2 = {"50", "60", "70", "80"};
+    std::list<fly::Json> list3 = {"a", 90, "b", 100};
+    json = {1, 2};
+    EXPECT_NO_THROW(json.swap(list1));
+    EXPECT_EQ(json, (decltype(list1)({50, 60, 70, 80})));
+    EXPECT_EQ(list1, (decltype(list1)({1, 2})));
+    json = {1, 2};
+    EXPECT_NO_THROW(json.swap(list2));
+    EXPECT_EQ(json, (decltype(list2)({"50", "60", "70", "80"})));
+    EXPECT_EQ(list2, (decltype(list2)({"1", "2"})));
+    json = {nullptr, true};
+    EXPECT_NO_THROW(json.swap(list3));
+    EXPECT_EQ(json, (decltype(list3)({"a", 90, "b", 100})));
+    EXPECT_EQ(list3, (decltype(list3)({nullptr, true})));
+    json = {50, "60", 70, "80"};
+    EXPECT_NO_THROW(json.swap(list1));
+    EXPECT_EQ(json, (decltype(list1)({1, 2})));
+    EXPECT_EQ(list1, (decltype(list1)({50, 60, 70, 80})));
+
+    std::multiset<int> multiset1 = {50, 60, 70, 80};
+    std::multiset<std::string> multiset2 = {"50", "60", "70", "80"};
+    // std::multiset<fly::Json> multiset3 = {"a", 90, "b", 100};
+    json = {1, 2};
+    EXPECT_NO_THROW(json.swap(multiset1));
+    EXPECT_EQ(json, (decltype(multiset1)({50, 60, 70, 80})));
+    EXPECT_EQ(multiset1, (decltype(multiset1)({1, 2})));
+    json = {1, 2};
+    EXPECT_NO_THROW(json.swap(multiset2));
+    EXPECT_EQ(json, (decltype(multiset2)({"50", "60", "70", "80"})));
+    EXPECT_EQ(multiset2, (decltype(multiset2)({"1", "2"})));
+    // json = {nullptr, true};
+    // EXPECT_NO_THROW(json.swap(multiset3));
+    // EXPECT_EQ(json, (decltype(multiset3)({"a", 90, "b", 100})));
+    // EXPECT_EQ(multiset3, (decltype(multiset3)({nullptr, true})));
+    json = {50, "60", 70, "80"};
+    EXPECT_NO_THROW(json.swap(multiset1));
+    EXPECT_EQ(json, (decltype(multiset1)({1, 2})));
+    EXPECT_EQ(multiset1, (decltype(multiset1)({50, 60, 70, 80})));
+
+    std::set<int> set1 = {50, 60, 70, 80};
+    std::set<std::string> set2 = {"50", "60", "70", "80"};
+    // std::set<fly::Json> set3 = {"a", 90, "b", 100};
+    json = {1, 2};
+    EXPECT_NO_THROW(json.swap(set1));
+    EXPECT_EQ(json, (decltype(set1)({50, 60, 70, 80})));
+    EXPECT_EQ(set1, (decltype(set1)({1, 2})));
+    json = {1, 2};
+    EXPECT_NO_THROW(json.swap(set2));
+    EXPECT_EQ(json, (decltype(set2)({"50", "60", "70", "80"})));
+    EXPECT_EQ(set2, (decltype(set2)({"1", "2"})));
+    // json = {nullptr, true};
+    // EXPECT_NO_THROW(json.swap(set3));
+    // EXPECT_EQ(json, (decltype(set3)({"a", 90, "b", 100})));
+    // EXPECT_EQ(set3, (decltype(set3)({nullptr, true})));
+    json = {50, "60", 70, "80"};
+    EXPECT_NO_THROW(json.swap(set1));
+    EXPECT_EQ(json, (decltype(set1)({1, 2})));
+    EXPECT_EQ(set1, (decltype(set1)({50, 60, 70, 80})));
+
+    std::unordered_multiset<int> u_multiset1 = {50, 60, 70, 80};
+    std::unordered_multiset<std::string> u_multiset2 = {"50", "60", "70", "80"};
+    // std::unordered_multiset<fly::Json> u_multiset3 = {"a", 90, "b", 100};
+    json = {1, 2};
+    EXPECT_NO_THROW(json.swap(u_multiset1));
+    EXPECT_EQ(json, (decltype(u_multiset1)({50, 60, 70, 80})));
+    EXPECT_EQ(u_multiset1, (decltype(u_multiset1)({1, 2})));
+    json = {1, 2};
+    EXPECT_NO_THROW(json.swap(u_multiset2));
+    EXPECT_EQ(json, (decltype(u_multiset2)({"50", "60", "70", "80"})));
+    EXPECT_EQ(u_multiset2, (decltype(u_multiset2)({"1", "2"})));
+    // json = {nullptr, true};
+    // EXPECT_NO_THROW(json.swap(u_multiset3));
+    // EXPECT_EQ(json, (decltype(u_multiset3)({"a", 90, "b", 100})));
+    // EXPECT_EQ(u_multiset3, (decltype(u_multiset3)({nullptr, true})));
+    json = {50, "60", 70, "80"};
+    EXPECT_NO_THROW(json.swap(u_multiset1));
+    EXPECT_EQ(json, (decltype(u_multiset1)({1, 2})));
+    EXPECT_EQ(u_multiset1, (decltype(u_multiset1)({50, 60, 70, 80})));
+
+    std::unordered_set<int> u_set1 = {50, 60, 70, 80};
+    std::unordered_set<std::string> u_set2 = {"50", "60", "70", "80"};
+    // std::unordered_set<fly::Json> u_set3 = {"a", 90, "b", 100};
+    json = {1, 2};
+    EXPECT_NO_THROW(json.swap(u_set1));
+    EXPECT_EQ(json, (decltype(u_set1)({50, 60, 70, 80})));
+    EXPECT_EQ(u_set1, (decltype(u_set1)({1, 2})));
+    json = {1, 2};
+    EXPECT_NO_THROW(json.swap(u_set2));
+    EXPECT_EQ(json, (decltype(u_set2)({"50", "60", "70", "80"})));
+    EXPECT_EQ(u_set2, (decltype(u_set2)({"1", "2"})));
+    // json = {nullptr, true};
+    // EXPECT_NO_THROW(json.swap(u_set3));
+    // EXPECT_EQ(json, (decltype(u_set3)({"a", 90, "b", 100})));
+    // EXPECT_EQ(u_set3, (decltype(u_set3)({nullptr, true})));
+    json = {50, "60", 70, "80"};
+    EXPECT_NO_THROW(json.swap(u_set1));
+    EXPECT_EQ(json, (decltype(u_set1)({1, 2})));
+    EXPECT_EQ(u_set1, (decltype(u_set1)({50, 60, 70, 80})));
+
+    std::vector<int> vector1 = {50, 60, 70, 80};
+    std::vector<std::string> vector2 = {"50", "60", "70", "80"};
+    std::vector<fly::Json> vector3 = {"a", 90, "b", 100};
+    json = {1, 2};
+    EXPECT_NO_THROW(json.swap(vector1));
+    EXPECT_EQ(json, (decltype(vector1)({50, 60, 70, 80})));
+    EXPECT_EQ(vector1, (decltype(vector1)({1, 2})));
+    json = {1, 2};
+    EXPECT_NO_THROW(json.swap(vector2));
+    EXPECT_EQ(json, (decltype(vector2)({"50", "60", "70", "80"})));
+    EXPECT_EQ(vector2, (decltype(vector2)({"1", "2"})));
+    json = {nullptr, true};
+    EXPECT_NO_THROW(json.swap(vector3));
+    EXPECT_EQ(json, (decltype(vector3)({"a", 90, "b", 100})));
+    EXPECT_EQ(vector3, (decltype(vector3)({nullptr, true})));
+    json = {50, "60", 70, "80"};
+    EXPECT_NO_THROW(json.swap(vector1));
+    EXPECT_EQ(json, (decltype(vector1)({1, 2})));
+    EXPECT_EQ(vector1, (decltype(vector1)({50, 60, 70, 80})));
 
     json = true;
     EXPECT_THROW(json.swap(array), fly::JsonException);
+    EXPECT_THROW(json.swap(deque), fly::JsonException);
+    EXPECT_THROW(json.swap(forward_list), fly::JsonException);
+    EXPECT_THROW(json.swap(list), fly::JsonException);
+    EXPECT_THROW(json.swap(multiset), fly::JsonException);
+    EXPECT_THROW(json.swap(set), fly::JsonException);
+    EXPECT_THROW(json.swap(u_multiset), fly::JsonException);
+    EXPECT_THROW(json.swap(u_set), fly::JsonException);
+    EXPECT_THROW(json.swap(vector), fly::JsonException);
 
     json = 1;
     EXPECT_THROW(json.swap(array), fly::JsonException);
+    EXPECT_THROW(json.swap(deque), fly::JsonException);
+    EXPECT_THROW(json.swap(forward_list), fly::JsonException);
+    EXPECT_THROW(json.swap(list), fly::JsonException);
+    EXPECT_THROW(json.swap(multiset), fly::JsonException);
+    EXPECT_THROW(json.swap(set), fly::JsonException);
+    EXPECT_THROW(json.swap(u_multiset), fly::JsonException);
+    EXPECT_THROW(json.swap(u_set), fly::JsonException);
+    EXPECT_THROW(json.swap(vector), fly::JsonException);
 
     json = static_cast<unsigned int>(1);
     EXPECT_THROW(json.swap(array), fly::JsonException);
+    EXPECT_THROW(json.swap(deque), fly::JsonException);
+    EXPECT_THROW(json.swap(forward_list), fly::JsonException);
+    EXPECT_THROW(json.swap(list), fly::JsonException);
+    EXPECT_THROW(json.swap(multiset), fly::JsonException);
+    EXPECT_THROW(json.swap(set), fly::JsonException);
+    EXPECT_THROW(json.swap(u_multiset), fly::JsonException);
+    EXPECT_THROW(json.swap(u_set), fly::JsonException);
+    EXPECT_THROW(json.swap(vector), fly::JsonException);
 
     json = 1.0f;
     EXPECT_THROW(json.swap(array), fly::JsonException);
+    EXPECT_THROW(json.swap(deque), fly::JsonException);
+    EXPECT_THROW(json.swap(forward_list), fly::JsonException);
+    EXPECT_THROW(json.swap(list), fly::JsonException);
+    EXPECT_THROW(json.swap(multiset), fly::JsonException);
+    EXPECT_THROW(json.swap(set), fly::JsonException);
+    EXPECT_THROW(json.swap(u_multiset), fly::JsonException);
+    EXPECT_THROW(json.swap(u_set), fly::JsonException);
+    EXPECT_THROW(json.swap(vector), fly::JsonException);
 
     json = nullptr;
     EXPECT_THROW(json.swap(array), fly::JsonException);
+    EXPECT_THROW(json.swap(deque), fly::JsonException);
+    EXPECT_THROW(json.swap(forward_list), fly::JsonException);
+    EXPECT_THROW(json.swap(list), fly::JsonException);
+    EXPECT_THROW(json.swap(multiset), fly::JsonException);
+    EXPECT_THROW(json.swap(set), fly::JsonException);
+    EXPECT_THROW(json.swap(u_multiset), fly::JsonException);
+    EXPECT_THROW(json.swap(u_set), fly::JsonException);
+    EXPECT_THROW(json.swap(vector), fly::JsonException);
 }
 
 //==============================================================================


### PR DESCRIPTION
Now that the object and array conversion operators accept any matching
STL container, swap can be implemented equally as generic.