### PR TITLE
Add key/value accessors for Json object iterators

### DIFF
--- a/test/types/json.cpp
+++ b/test/types/json.cpp
@@ -1781,15 +1781,17 @@ TEST_F(JsonTest, IteratorEnd)
 }
 
 //==============================================================================
-TEST_F(JsonTest, IteratorIterate)
+TEST_F(JsonTest, ObjectIteratorIterate)
 {
-    fly::Json json {1, 2, 3};
+    fly::Json json {{"a", 1}, {"b", 2}};
     {
         fly::Json::size_type size = 0;
 
-        for (auto it = json.begin(); it < json.end(); ++it, ++size)
+        for (auto it = json.begin(); it != json.end(); ++it, ++size)
         {
-            EXPECT_EQ(*it, json[size]);
+            EXPECT_EQ(*it, size == 0 ? 1 : 2);
+            EXPECT_EQ(it.key(), size == 0 ? "a" : "b");
+            EXPECT_EQ(it.value(), size == 0 ? 1 : 2);
         }
 
         EXPECT_EQ(size, json.size());
@@ -1797,9 +1799,11 @@ TEST_F(JsonTest, IteratorIterate)
     {
         fly::Json::size_type size = 0;
 
-        for (auto it = json.cbegin(); it < json.cend(); ++it, ++size)
+        for (auto it = json.cbegin(); it != json.cend(); ++it, ++size)
         {
-            EXPECT_EQ(*it, json[size]);
+            EXPECT_EQ(*it, size == 0 ? 1 : 2);
+            EXPECT_EQ(it.key(), size == 0 ? "a" : "b");
+            EXPECT_EQ(it.value(), size == 0 ? 1 : 2);
         }
 
         EXPECT_EQ(size, json.size());
@@ -1807,7 +1811,61 @@ TEST_F(JsonTest, IteratorIterate)
 }
 
 //==============================================================================
-TEST_F(JsonTest, IteratorRangeBasedFor)
+TEST_F(JsonTest, ObjectIteratorRangeBasedFor)
+{
+    fly::Json json {{"a", 1}, {"b", 2}};
+    {
+        fly::Json::size_type size = 0;
+
+        for (fly::Json &value : json)
+        {
+            EXPECT_EQ(value, size++ == 0 ? 1 : 2);
+        }
+
+        EXPECT_EQ(size, json.size());
+    }
+    {
+        fly::Json::size_type size = 0;
+
+        for (const fly::Json &value : json)
+        {
+            EXPECT_EQ(value, size++ == 0 ? 1 : 2);
+        }
+
+        EXPECT_EQ(size, json.size());
+    }
+}
+
+//==============================================================================
+TEST_F(JsonTest, ArrayIteratorIterate)
+{
+    fly::Json json {1, 2, 3};
+    {
+        fly::Json::size_type size = 0;
+
+        for (auto it = json.begin(); it != json.end(); ++it, ++size)
+        {
+            EXPECT_EQ(*it, json[size]);
+            EXPECT_EQ(it.value(), json[size]);
+        }
+
+        EXPECT_EQ(size, json.size());
+    }
+    {
+        fly::Json::size_type size = 0;
+
+        for (auto it = json.cbegin(); it != json.cend(); ++it, ++size)
+        {
+            EXPECT_EQ(*it, json[size]);
+            EXPECT_EQ(it.value(), json[size]);
+        }
+
+        EXPECT_EQ(size, json.size());
+    }
+}
+
+//==============================================================================
+TEST_F(JsonTest, ArrayIteratorRangeBasedFor)
 {
     fly::Json json {1, 2, 3};
     {

--- a/test/types/json_iterator.cpp
+++ b/test/types/json_iterator.cpp
@@ -66,6 +66,8 @@ TEST(JsonIteratorTest, NullIterator)
     EXPECT_THROW(FLY_UNUSED(it1 + 1), fly::JsonException);
     EXPECT_THROW(FLY_UNUSED(1 + it1), fly::JsonException);
     EXPECT_THROW(FLY_UNUSED(it1 - 1), fly::JsonException);
+    EXPECT_THROW(FLY_UNUSED(it1.key()), fly::JsonException);
+    EXPECT_THROW(FLY_UNUSED(it1.value()), fly::JsonException);
 
     EXPECT_NO_THROW((fly::Json::iterator(it1)));
     EXPECT_NO_THROW(it2 = it1);
@@ -89,6 +91,8 @@ TEST(JsonIteratorTest, NullIteratorFromNullJson)
     EXPECT_THROW(FLY_UNUSED(it1 + 1), fly::JsonException);
     EXPECT_THROW(FLY_UNUSED(1 + it1), fly::JsonException);
     EXPECT_THROW(FLY_UNUSED(it1 - 1), fly::JsonException);
+    EXPECT_THROW(FLY_UNUSED(it1.key()), fly::JsonException);
+    EXPECT_THROW(FLY_UNUSED(it1.value()), fly::JsonException);
 
     EXPECT_NO_THROW((fly::Json::iterator(it1)));
     EXPECT_NO_THROW(it2 = it1);
@@ -188,6 +192,8 @@ TEST(JsonIteratorTest, OperationsOnObjects)
     EXPECT_THROW(FLY_UNUSED(1 + it1), fly::JsonException);
     EXPECT_THROW(FLY_UNUSED(it1 - 1), fly::JsonException);
     EXPECT_THROW(FLY_UNUSED(it1 - it2), fly::JsonException);
+    EXPECT_NO_THROW(FLY_UNUSED(it1.key()));
+    EXPECT_NO_THROW(FLY_UNUSED(it1.value()));
 }
 
 //==============================================================================
@@ -217,6 +223,8 @@ TEST(JsonIteratorTest, OperationsOnArrays)
     EXPECT_NO_THROW(FLY_UNUSED(1 + it1));
     EXPECT_NO_THROW(FLY_UNUSED(it1 - 1));
     EXPECT_NO_THROW(FLY_UNUSED(it1 - it2));
+    EXPECT_THROW(FLY_UNUSED(it1.key()), fly::JsonException);
+    EXPECT_NO_THROW(FLY_UNUSED(it1.value()));
 }
 
 //==============================================================================
@@ -442,4 +450,37 @@ TEST(JsonIteratorTest, DifferenceOperator)
 
     EXPECT_NE(json2.begin() - json1.begin(), 0);
     EXPECT_NE(json1.begin() - json2.begin(), 0);
+}
+
+//==============================================================================
+TEST(JsonIteratorTest, IteratorKey)
+{
+    fly::Json json {{"a", 1}, {"b", 2}};
+
+    fly::Json::iterator it2 = json.begin();
+    fly::Json::iterator it1 = it2++;
+
+    EXPECT_EQ(it1.key(), "a");
+    EXPECT_EQ(it2.key(), "b");
+}
+
+//==============================================================================
+TEST(JsonIteratorTest, IteratorValue)
+{
+    fly::Json json1 {{"a", 1}, {"b", 2}};
+    fly::Json json2 {4, 5, 6};
+
+    fly::Json::iterator it2 = json1.begin();
+    fly::Json::iterator it1 = it2++;
+
+    fly::Json::iterator it3 = json2.begin();
+    fly::Json::iterator it4 = it3 + 1;
+    fly::Json::iterator it5 = it4 + 1;
+
+    EXPECT_EQ(it1.value(), 1);
+    EXPECT_EQ(it2.value(), 2);
+
+    EXPECT_EQ(it3.value(), 4);
+    EXPECT_EQ(it4.value(), 5);
+    EXPECT_EQ(it5.value(), 6);
 }


### PR DESCRIPTION
Iterators for Json objects only store an object's value. It'd be nice to store
a std::pair<key, value>, but that isn't feasible yet. Providing a separate key
accessor will suffice for now.

So for a Json object, iterator.key() is analogous to iterator->first, and
iterator.value() is analogous to iterator->second.