### PR TITLE
Decay types provided to fly::all_same, fly::any_same

### DIFF
--- a/fly/traits/traits.hpp
+++ b/fly/traits/traits.hpp
@@ -59,10 +59,17 @@ using enable_if_not_all =
  * are the same as a specific type. Example:
  *
  *     constexpr bool same = fly::all_same_v<int, int, int>; // = true
+ *     constexpr bool same = fly::all_same_v<int, int, const int &>; // = true
  *     constexpr bool same = fly::all_same_v<int, int, bool>; // = false
+ *     constexpr bool same = fly::all_same_v<int, bool, bool>; // = false
  */
 template <typename T, typename A, typename... As>
-using all_same = std::conjunction<std::is_same<T, A>, std::is_same<T, As>...>;
+struct all_same :
+    std::conjunction<
+        std::is_same<std::decay_t<T>, std::decay_t<A>>,
+        std::is_same<std::decay_t<T>, std::decay_t<As>>...>
+{
+};
 
 template <typename T, typename A, typename... As>
 inline constexpr bool all_same_v = all_same<T, A, As...>::value;
@@ -72,11 +79,17 @@ inline constexpr bool all_same_v = all_same<T, A, As...>::value;
  * are the same as a specific type. Example:
  *
  *     constexpr bool same = fly::any_same_v<int, int, int>; // = true
+ *     constexpr bool same = fly::any_same_v<int, int, const int &>; // = true
  *     constexpr bool same = fly::any_same_v<int, int, bool>; // = true
  *     constexpr bool same = fly::any_same_v<int, bool, bool>; // = false
  */
 template <typename T, typename A, typename... As>
-using any_same = std::disjunction<std::is_same<T, A>, std::is_same<T, As>...>;
+struct any_same :
+    std::disjunction<
+        std::is_same<std::decay_t<T>, std::decay_t<A>>,
+        std::is_same<std::decay_t<T>, std::decay_t<As>>...>
+{
+};
 
 template <typename T, typename A, typename... As>
 inline constexpr bool any_same_v = any_same<T, A, As...>::value;

--- a/test/traits/traits.cpp
+++ b/test/traits/traits.cpp
@@ -220,12 +220,37 @@ TEST(TraitsTest, EnableIfAny)
 TEST(TraitsTest, AllSame)
 {
     EXPECT_TRUE((fly::all_same_v<int, int>));
+    EXPECT_TRUE((fly::all_same_v<int, const int>));
+    EXPECT_TRUE((fly::all_same_v<const int, int>));
+    EXPECT_TRUE((fly::all_same_v<const int, const int>));
+
+    EXPECT_TRUE((fly::all_same_v<int, int>));
+    EXPECT_TRUE((fly::all_same_v<int, int &>));
+    EXPECT_TRUE((fly::all_same_v<int &, int>));
+    EXPECT_TRUE((fly::all_same_v<int &, int &>));
+
+    EXPECT_TRUE((fly::all_same_v<int, int>));
+    EXPECT_TRUE((fly::all_same_v<int, const int &>));
+    EXPECT_TRUE((fly::all_same_v<const int &, int>));
+    EXPECT_TRUE((fly::all_same_v<const int &, const int &>));
+
+    EXPECT_TRUE((fly::all_same_v<int, int, int>));
+    EXPECT_TRUE((fly::all_same_v<int, int, const int>));
+    EXPECT_TRUE((fly::all_same_v<int, const int, int>));
+    EXPECT_TRUE((fly::all_same_v<int, const int, const int>));
+
+    EXPECT_TRUE((fly::all_same_v<const int, int, int>));
+    EXPECT_TRUE((fly::all_same_v<const int, int, const int>));
+    EXPECT_TRUE((fly::all_same_v<const int, const int, int>));
+    EXPECT_TRUE((fly::all_same_v<const int, const int, const int>));
+
     EXPECT_TRUE((fly::all_same_v<bool, bool, bool>));
     EXPECT_TRUE((fly::all_same_v<float, float, float, float>));
     EXPECT_TRUE((fly::all_same_v<FooClass, FooClass, FooClass>));
     EXPECT_TRUE((fly::all_same_v<std::string, std::string, std::string>));
 
     EXPECT_FALSE((fly::all_same_v<int, char>));
+    EXPECT_FALSE((fly::all_same_v<int *, int>));
     EXPECT_FALSE((fly::all_same_v<bool, bool, char>));
     EXPECT_FALSE((fly::all_same_v<FooClass, FooClass, std::string>));
 }
@@ -234,6 +259,30 @@ TEST(TraitsTest, AllSame)
 TEST(TraitsTest, AnySame)
 {
     EXPECT_TRUE((fly::any_same_v<int, int>));
+    EXPECT_TRUE((fly::any_same_v<int, const int>));
+    EXPECT_TRUE((fly::any_same_v<const int, int>));
+    EXPECT_TRUE((fly::any_same_v<const int, const int>));
+
+    EXPECT_TRUE((fly::any_same_v<int, int>));
+    EXPECT_TRUE((fly::any_same_v<int, int &>));
+    EXPECT_TRUE((fly::any_same_v<int &, int>));
+    EXPECT_TRUE((fly::any_same_v<int &, int &>));
+
+    EXPECT_TRUE((fly::any_same_v<int, int>));
+    EXPECT_TRUE((fly::any_same_v<int, const int &>));
+    EXPECT_TRUE((fly::any_same_v<const int &, int>));
+    EXPECT_TRUE((fly::any_same_v<const int &, const int &>));
+
+    EXPECT_TRUE((fly::any_same_v<int, int, int>));
+    EXPECT_TRUE((fly::any_same_v<int, int, const int>));
+    EXPECT_TRUE((fly::any_same_v<int, const int, int>));
+    EXPECT_TRUE((fly::any_same_v<int, const int, const int>));
+
+    EXPECT_TRUE((fly::any_same_v<const int, int, int>));
+    EXPECT_TRUE((fly::any_same_v<const int, int, const int>));
+    EXPECT_TRUE((fly::any_same_v<const int, const int, int>));
+    EXPECT_TRUE((fly::any_same_v<const int, const int, const int>));
+
     EXPECT_TRUE((fly::any_same_v<bool, bool, bool>));
     EXPECT_TRUE((fly::any_same_v<float, float, float, float>));
     EXPECT_TRUE((fly::any_same_v<FooClass, FooClass, FooClass>));
@@ -243,6 +292,7 @@ TEST(TraitsTest, AnySame)
     EXPECT_TRUE((fly::any_same_v<FooClass, FooClass, std::string>));
 
     EXPECT_FALSE((fly::any_same_v<int, char>));
+    EXPECT_FALSE((fly::any_same_v<int *, int>));
     EXPECT_FALSE((fly::any_same_v<bool, char>));
     EXPECT_FALSE((fly::any_same_v<FooClass, std::string>));
 }


### PR DESCRIPTION
They must also be defined as a struct to support being invoked as:

    template <typename... Ts>
    using some_wrapper = fly::all_same<int, Ts...>;

Because apparently for aliases, pack arguments can only be expanded in
the place of a pack parameter. Structs do not have this restriction.

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=59498