### PR TITLE
Perform BitStream I/O operations on underlying buffers

### DIFF
--- a/fly/types/bit_stream/bit_stream_writer.cpp
+++ b/fly/types/bit_stream/bit_stream_writer.cpp
@@ -7,7 +7,7 @@ namespace fly {
 
 //==============================================================================
 BitStreamWriter::BitStreamWriter(std::ostream &stream) noexcept :
-    BitStream(detail::s_most_significant_bit_position),
+    BitStream(stream.rdbuf(), detail::s_most_significant_bit_position),
     m_stream(stream)
 {
     flush_header(0_u8);
@@ -50,13 +50,11 @@ bool BitStreamWriter::finish() noexcept
 //==============================================================================
 void BitStreamWriter::flush_header(byte_type remainder) noexcept
 {
-    m_stream.seekp(0);
+    m_stream_buffer->pubseekpos(0);
 
     const byte_type header = (detail::s_magic << detail::s_magic_shift) |
         (remainder << detail::s_remainder_shift);
     flush(header, detail::s_byte_type_size);
-
-    m_stream.seekp(0, std::ios::end);
 }
 
 //==============================================================================

--- a/fly/types/bit_stream/bit_stream_writer.hpp
+++ b/fly/types/bit_stream/bit_stream_writer.hpp
@@ -137,11 +137,14 @@ void BitStreamWriter::flush(const DataType &buffer, byte_type bytes) noexcept
         detail::BitStreamTraits::is_unsigned_integer_v<DataType>,
         "DataType must be an unsigned integer type");
 
-    const DataType data = endian_swap<Endian::Big>(buffer);
+    if (m_stream)
+    {
+        const DataType data = endian_swap<Endian::Big>(buffer);
 
-    m_stream.write(
-        reinterpret_cast<const std::ios::char_type *>(&data),
-        static_cast<std::streamsize>(bytes));
+        m_stream_buffer->sputn(
+            reinterpret_cast<const std::ios::char_type *>(&data),
+            static_cast<std::streamsize>(bytes));
+    }
 }
 
 } // namespace fly

--- a/fly/types/bit_stream/detail/bit_stream.cpp
+++ b/fly/types/bit_stream/detail/bit_stream.cpp
@@ -3,9 +3,12 @@
 namespace fly::detail {
 
 //==============================================================================
-BitStream::BitStream(byte_type starting_position) noexcept :
-    m_position(starting_position),
-    m_buffer(0)
+BitStream::BitStream(
+    std::streambuf *stream_buffer,
+    byte_type starting_position) noexcept :
+    m_stream_buffer(stream_buffer),
+    m_buffer(0),
+    m_position(starting_position)
 {
 }
 

--- a/fly/types/bit_stream/detail/bit_stream.hpp
+++ b/fly/types/bit_stream/detail/bit_stream.hpp
@@ -4,6 +4,7 @@
 #include "fly/types/bit_stream/detail/bit_stream_traits.hpp"
 
 #include <limits>
+#include <streambuf>
 
 namespace fly::detail {
 
@@ -41,9 +42,12 @@ protected:
     /**
      * Protected constructor to prevent instantiating this class directly.
      *
+     * @param stream_buffer Pointer to the stream's underlying stream buffer.
      * @param starting_position Initial cursor position.
      */
-    explicit BitStream(byte_type starting_position) noexcept;
+    BitStream(
+        std::streambuf *stream_buffer,
+        byte_type starting_position) noexcept;
 
     /**
      * Create a bit-mask with the least-significant bits set. The size of the
@@ -58,8 +62,10 @@ protected:
     template <typename DataType>
     constexpr inline static DataType bit_mask(const DataType bits);
 
-    byte_type m_position;
+    std::streambuf *m_stream_buffer;
+
     buffer_type m_buffer;
+    byte_type m_position;
 };
 
 //==============================================================================


### PR DESCRIPTION
It seems to be quite a bit faster to perform I/O directly on the stream
buffer returned by rdbuf() than to go through the stream's read/write
methods. I'm guessing this is due to reduced virtual method invocations.

Coding times on a 100MB file decreased as follows:

    Encoding: 0.65s -> 0.54s
    Decoding: 1.10s -> 0.97s