### PR TITLE
Move unicode processing to String

### DIFF
--- a/build/win/libfly/libfly.vcxproj
+++ b/build/win/libfly/libfly.vcxproj
@@ -211,7 +211,9 @@
     <ClInclude Include="..\..\..\fly\types\string\detail\string_converter.hpp" />
     <ClInclude Include="..\..\..\fly\types\string\detail\string_streamer.hpp" />
     <ClInclude Include="..\..\..\fly\types\string\detail\string_traits.hpp" />
+    <ClInclude Include="..\..\..\fly\types\string\detail\string_unicode.hpp" />
     <ClInclude Include="..\..\..\fly\types\string\string.hpp" />
+    <ClInclude Include="..\..\..\fly\types\string\string_exception.hpp" />
     <ClInclude Include="..\..\..\fly\types\string\string_literal.hpp" />
   </ItemGroup>
   <ItemGroup>
@@ -251,6 +253,7 @@
     <ClCompile Include="..\..\..\fly\types\bit_stream\detail\bit_stream.cpp" />
     <ClCompile Include="..\..\..\fly\types\json\json.cpp" />
     <ClCompile Include="..\..\..\fly\types\json\json_exception.cpp" />
+    <ClInclude Include="..\..\..\fly\types\string\string_exception.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/build/win/libfly/libfly.vcxproj
+++ b/build/win/libfly/libfly.vcxproj
@@ -253,7 +253,7 @@
     <ClCompile Include="..\..\..\fly\types\bit_stream\detail\bit_stream.cpp" />
     <ClCompile Include="..\..\..\fly\types\json\json.cpp" />
     <ClCompile Include="..\..\..\fly\types\json\json_exception.cpp" />
-    <ClInclude Include="..\..\..\fly\types\string\string_exception.cpp" />
+    <ClCompile Include="..\..\..\fly\types\string\string_exception.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/build/win/libfly/libfly.vcxproj.filters
+++ b/build/win/libfly/libfly.vcxproj.filters
@@ -241,6 +241,9 @@
     <ClInclude Include="..\..\..\fly\types\string\string.hpp">
       <Filter>types\string</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\fly\types\string\string_exception.hpp">
+      <Filter>types\string</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\..\fly\types\string\string_literal.hpp">
       <Filter>types\string</Filter>
     </ClInclude>
@@ -251,6 +254,9 @@
       <Filter>types\string\detail</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\fly\types\string\detail\string_traits.hpp">
+      <Filter>types\string\detail</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\fly\types\string\detail\string_unicode.hpp">
       <Filter>types\string\detail</Filter>
     </ClInclude>
   </ItemGroup>
@@ -363,5 +369,8 @@
     <ClCompile Include="..\..\..\fly\types\json\json_exception.cpp">
       <Filter>types\json</Filter>
     </ClCompile>
+    <ClInclude Include="..\..\..\fly\types\string\string_exception.cpp">
+      <Filter>types\string</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/build/win/libfly/libfly.vcxproj.filters
+++ b/build/win/libfly/libfly.vcxproj.filters
@@ -369,8 +369,8 @@
     <ClCompile Include="..\..\..\fly\types\json\json_exception.cpp">
       <Filter>types\json</Filter>
     </ClCompile>
-    <ClInclude Include="..\..\..\fly\types\string\string_exception.cpp">
+    <ClCompile Include="..\..\..\fly\types\string\string_exception.cpp">
       <Filter>types\string</Filter>
-    </ClInclude>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/fly/files.mk
+++ b/fly/files.mk
@@ -12,7 +12,8 @@ SRC_DIRS_$(d) := \
     fly/task \
     fly/types/bit_stream \
     fly/types/bit_stream/detail \
-    fly/types/json
+    fly/types/json \
+    fly/types/string
 
 # Add libfly.so to release package
 $(eval $(call ADD_REL_LIB, libfly))

--- a/fly/types/json/json.cpp
+++ b/fly/types/json/json.cpp
@@ -614,11 +614,11 @@ Json::validate_string(const JsonTraits::string_type &str) noexcept(false)
         else
         {
             validate_character(stream, it, end);
-        }
 
-        if (it != end)
-        {
-            ++it;
+            if (it != end)
+            {
+                ++it;
+            }
         }
     }
 
@@ -667,6 +667,8 @@ void Json::read_escaped_character(
         case 'u':
             try
             {
+                // The input sequence is expected to begin with the reverse
+                // solidus character.
                 stream << String::parse_unicode_character(--it, end);
             }
             catch (const StringException &ex)
@@ -674,7 +676,9 @@ void Json::read_escaped_character(
                 throw JsonException(ex.what());
             }
 
-            break;
+            // The iterator is already incremented past the escaped character
+            // sequence.
+            return;
 
         default:
             throw JsonException(String::format(
@@ -682,6 +686,8 @@ void Json::read_escaped_character(
                 *it,
                 int(*it)));
     }
+
+    ++it;
 }
 
 //==============================================================================

--- a/fly/types/json/json.hpp
+++ b/fly/types/json/json.hpp
@@ -743,39 +743,6 @@ private:
         JsonTraits::string_type::value_type ch) noexcept;
 
     /**
-     * After determining the escaped character is a unicode encoding, read the
-     * characters that follow. Replace the entire sequence of characters with
-     * with the unicode character. Accepts UTF-8 encodings and UTF-16 paired
-     * surrogate encodings.
-     *
-     * @param stream_type Stream to pipe the interpreted character into.
-     * @param it Pointer to the escaped character.
-     * @param end Pointer to the end of the original string value.
-     *
-     * @throws JsonException If the interpreted unicode character is not valid
-     *         or there weren't enough available bytes.
-     */
-    static void read_unicode_character(
-        stream_type &stream,
-        JsonTraits::string_type::const_iterator &it,
-        const JsonTraits::string_type::const_iterator &end) noexcept(false);
-
-    /**
-     * Read a single 4-byte unicode encoding.
-     *
-     * @param it Pointer to the escaped character.
-     * @param end Pointer to the end of the original string value.
-     *
-     * @return The read unicode codepoint.
-     *
-     * @throws JsonException If any of the 4 read bytes were non-hexadecimal or
-     *         there weren't enough available bytes.
-     */
-    static int read_unicode_codepoint(
-        JsonTraits::string_type::const_iterator &it,
-        const JsonTraits::string_type::const_iterator &end) noexcept(false);
-
-    /**
      * Validate a single non-escaped character is compliant.
      *
      * @param stream Stream to pipe the interpreted character into.

--- a/fly/types/string/detail/string_traits.hpp
+++ b/fly/types/string/detail/string_traits.hpp
@@ -3,6 +3,7 @@
 #include "fly/traits/traits.hpp"
 #include "fly/types/string/detail/string_streamer.hpp"
 
+#include <cstdint>
 #include <string>
 #include <type_traits>
 

--- a/fly/types/string/detail/string_traits.hpp
+++ b/fly/types/string/detail/string_traits.hpp
@@ -3,7 +3,6 @@
 #include "fly/traits/traits.hpp"
 #include "fly/types/string/detail/string_streamer.hpp"
 
-#include <cstdint>
 #include <string>
 #include <type_traits>
 

--- a/fly/types/string/detail/string_unicode.hpp
+++ b/fly/types/string/detail/string_unicode.hpp
@@ -1,0 +1,226 @@
+#pragma once
+
+#include "fly/types/string/detail/string_traits.hpp"
+#include "fly/types/string/string_exception.hpp"
+
+namespace fly::detail {
+
+/**
+ * Helper class to parse escaped unicode character sequences in a
+ * std::basic_string<>.
+ *
+ * @author Timothy Flynn (trflynn89@pm.me)
+ * @version June 6, 2020
+ */
+template <typename StringType>
+class BasicStringUnicode
+{
+    using traits = detail::BasicStringTraits<StringType>;
+    using char_type = typename traits::char_type;
+
+    using codepoint_type = std::uint32_t;
+
+    static constexpr codepoint_type high_surrogate_min = 0xd800;
+    static constexpr codepoint_type high_surrogate_max = 0xdbff;
+
+    static constexpr codepoint_type low_surrogate_min = 0xdc00;
+    static constexpr codepoint_type low_surrogate_max = 0xdfff;
+
+public:
+    /**
+     * Parse an escaped sequence of unicode characters. Accepts UTF-8 encodings
+     * and UTF-16 paired surrogate encodings.
+     *
+     * Input sequences must be of the form: (\u[0-9a-fA-F]{4}){1,2}
+     *
+     * @param it Pointer to the beginning of the escaped character sequence.
+     * @param end Pointer to the end of the escaped character sequence.
+     *
+     * @return The parsed unicode character.
+     *
+     * @throws UnicodeException If the interpreted unicode character is not
+     *         valid or there weren't enough available bytes.
+     */
+    static StringType parse_character(
+        typename StringType::const_iterator &it,
+        const typename StringType::const_iterator &end) noexcept(false);
+
+private:
+    /**
+     * Parse a single escaped unicode character. Convert the character to a
+     * 32-bit codepoint.
+     *
+     * @param it Pointer to the beginning of the escaped character sequence.
+     * @param end Pointer to the end of the escaped character sequence.
+     *
+     * @return The parsed unicode codepoint.
+     *
+     * @throws UnicodeException If the interpreted unicode character is not
+     *         valid or there weren't enough available bytes.
+     */
+    static codepoint_type parse_codepoint(
+        typename StringType::const_iterator &it,
+        const typename StringType::const_iterator &end) noexcept(false);
+
+    /**
+     * Convert a unicode codepoint to a unicode string.
+     *
+     * @param codepoint The codepoint to convert.
+     *
+     * @return The converted unicode character.
+     */
+    static StringType convert_codepoint(codepoint_type codepoint) noexcept;
+};
+
+//==============================================================================
+template <typename StringType>
+StringType BasicStringUnicode<StringType>::parse_character(
+    typename StringType::const_iterator &it,
+    const typename StringType::const_iterator &end) noexcept(false)
+{
+    auto is_high_surrogate = [](codepoint_type c) -> bool {
+        return (c >= high_surrogate_min) && (c <= high_surrogate_max);
+    };
+    auto is_low_surrogate = [](codepoint_type c) -> bool {
+        return (c >= low_surrogate_min) && (c <= low_surrogate_max);
+    };
+
+    const codepoint_type high_surrogate = parse_codepoint(it, end);
+    codepoint_type codepoint = high_surrogate;
+
+    if (is_high_surrogate(high_surrogate))
+    {
+        const codepoint_type low_surrogate = parse_codepoint(it, end);
+
+        if (is_low_surrogate(low_surrogate))
+        {
+            // The formula to convert a surrogate pair to a single codepoint is:
+            //
+            //     C = ((HS - 0xd800) * 0x400) + (LS - 0xdc00) + 0x10000
+            //
+            // Multiplying by 0x400 (1024) is the same as bit-shifting left by
+            // 10 bits. The formula then simplifies to:
+            codepoint = (high_surrogate << 10) + low_surrogate - 0x35fdc00;
+        }
+        else
+        {
+            throw UnicodeException(
+                "Expected low surrogate to follow high surrogate %x, found %x",
+                high_surrogate,
+                low_surrogate);
+        }
+    }
+    else if (is_low_surrogate(high_surrogate))
+    {
+        throw UnicodeException(
+            "Expected high surrogate to preceed low surrogate %x",
+            high_surrogate);
+    }
+
+    return convert_codepoint(codepoint);
+}
+
+//==============================================================================
+template <typename StringType>
+auto BasicStringUnicode<StringType>::parse_codepoint(
+    typename StringType::const_iterator &it,
+    const typename StringType::const_iterator &end) noexcept(false)
+    -> codepoint_type
+{
+    if ((it == end) || (*it != '\\') || (++it == end) || (*it != 'u'))
+    {
+        throw UnicodeException("Expected codepoint to begin with \\u");
+    }
+
+    codepoint_type codepoint = 0;
+    codepoint_type i = 0;
+    ++it;
+
+    for (i = 0; (i < 4) && (it != end); ++i, ++it)
+    {
+        const codepoint_type shift = (4 * (3 - i));
+
+        if ((*it >= '0') && (*it <= '9'))
+        {
+            codepoint += static_cast<codepoint_type>((*it - 0x30) << shift);
+        }
+        else if ((*it >= 'A') && (*it <= 'F'))
+        {
+            codepoint += static_cast<codepoint_type>((*it - 0x37) << shift);
+        }
+        else if ((*it >= 'a') && (*it <= 'f'))
+        {
+            codepoint += static_cast<codepoint_type>((*it - 0x57) << shift);
+        }
+        else
+        {
+            throw UnicodeException(
+                "Expected %x to be a hexadecimal digit",
+                static_cast<codepoint_type>(*it));
+        }
+    }
+
+    if (i != 4)
+    {
+        throw UnicodeException(
+            "Expected exactly 4 hexadecimals after \\u, only found %u",
+            i);
+    }
+
+    return codepoint;
+}
+
+//==============================================================================
+template <typename StringType>
+StringType BasicStringUnicode<StringType>::convert_codepoint(
+    codepoint_type codepoint) noexcept
+{
+    StringType result;
+
+    if constexpr (sizeof(char_type) == 1)
+    {
+        if (codepoint < 0x80)
+        {
+            result += char_type(codepoint);
+        }
+        else if (codepoint < 0x800)
+        {
+            result += char_type(0xc0 | (codepoint >> 6));
+            result += char_type(0x80 | (codepoint & 0x3f));
+        }
+        else if (codepoint < 0x10000)
+        {
+            result += char_type(0xe0 | (codepoint >> 12));
+            result += char_type(0x80 | ((codepoint >> 6) & 0x3f));
+            result += char_type(0x80 | (codepoint & 0x3f));
+        }
+        else
+        {
+            result += char_type(0xf0 | (codepoint >> 18));
+            result += char_type(0x80 | ((codepoint >> 12) & 0x3f));
+            result += char_type(0x80 | ((codepoint >> 6) & 0x3f));
+            result += char_type(0x80 | (codepoint & 0x3f));
+        }
+    }
+    else if constexpr (sizeof(char_type) == 2)
+    {
+        if (codepoint < 0x10000)
+        {
+            result += char_type(codepoint);
+        }
+        else
+        {
+            codepoint -= 0x10000;
+            result += char_type(high_surrogate_min | (codepoint >> 10));
+            result += char_type(low_surrogate_min | (codepoint & 0x3ff));
+        }
+    }
+    else if constexpr (sizeof(char_type) == 4)
+    {
+        result += char_type(codepoint);
+    }
+
+    return result;
+}
+
+} // namespace fly::detail

--- a/fly/types/string/string.hpp
+++ b/fly/types/string/string.hpp
@@ -3,6 +3,7 @@
 #include "fly/types/string/detail/string_converter.hpp"
 #include "fly/types/string/detail/string_streamer.hpp"
 #include "fly/types/string/detail/string_traits.hpp"
+#include "fly/types/string/detail/string_unicode.hpp"
 #include "fly/types/string/string_literal.hpp"
 
 #include <algorithm>
@@ -171,6 +172,40 @@ public:
     wildcard_match(const StringType &source, const StringType &search) noexcept;
 
     /**
+     * Parse an escaped sequence of unicode characters. Accepts UTF-8 encodings
+     * and UTF-16 paired surrogate encodings.
+     *
+     * Input sequences must be of the form: (\u[0-9a-fA-F]{4}){1,2}
+     *
+     * @param source The string containing the escaped character sequence.
+     *
+     * @return The parsed unicode character.
+     *
+     * @throws UnicodeException If the interpreted unicode character is not
+     *         valid or there weren't enough available bytes.
+     */
+    static StringType
+    parse_unicode_character(const StringType &source) noexcept(false);
+
+    /**
+     * Parse an escaped sequence of unicode characters. Accepts UTF-8 encodings
+     * and UTF-16 paired surrogate encodings.
+     *
+     * Input sequences must be of the form: (\u[0-9a-fA-F]{4}){1,2}
+     *
+     * @param it Pointer to the beginning of the escaped character sequence.
+     * @param end Pointer to the end of the escaped character sequence.
+     *
+     * @return The parsed unicode character.
+     *
+     * @throws UnicodeException If the interpreted unicode character is not
+     *         valid or there weren't enough available bytes.
+     */
+    static StringType parse_unicode_character(
+        typename StringType::const_iterator &it,
+        const typename StringType::const_iterator &end) noexcept(false);
+
+    /**
      * Generate a random string of the given size.
      *
      * @param size The length of the string to generate.
@@ -180,20 +215,20 @@ public:
     static StringType generate_random_string(size_type size) noexcept;
 
     /**
-     * Format a string with variadic template arguments, returning the formatted
-     * string.
+     * Format a string with variadic template arguments, returning the
+     * formatted string.
      *
      * This is type safe in that argument types need not match the format
-     * specifier (i.e. there is no error if %s is given an integer). However,
-     * specifiers such as %x are still attempted to be handled. That is, if the
-     * matching argument for %x is numeric, then it will be converted to a
-     * hexadecimal representation.
+     * specifier (i.e. there is no error if %s is given an integer).
+     * However, specifiers such as %x are still attempted to be handled.
+     * That is, if the matching argument for %x is numeric, then it will be
+     * converted to a hexadecimal representation.
      *
      * There is also no checking done on the number of format specifiers and
-     * the number of arguments. The format specifiers will be replaced one at a
-     * time until all arguments are exhausted, then the rest of the string is
-     * taken as-is. Any extra specifiers will be in the string. Any extra
-     * arguments are dropped.
+     * the number of arguments. The format specifiers will be replaced one
+     * at a time until all arguments are exhausted, then the rest of the
+     * string is taken as-is. Any extra specifiers will be in the string.
+     * Any extra arguments are dropped.
      *
      * @tparam Args Variadic template arguments.
      *
@@ -542,6 +577,26 @@ bool BasicString<StringType>::wildcard_match(
     }
 
     return result;
+}
+
+//==============================================================================
+template <typename StringType>
+StringType BasicString<StringType>::parse_unicode_character(
+    const StringType &source) noexcept(false)
+{
+    auto begin = source.cbegin();
+    const auto end = source.cend();
+
+    return parse_unicode_character(begin, end);
+}
+
+//==============================================================================
+template <typename StringType>
+StringType BasicString<StringType>::parse_unicode_character(
+    typename StringType::const_iterator &it,
+    const typename StringType::const_iterator &end) noexcept(false)
+{
+    return detail::BasicStringUnicode<StringType>::parse_character(it, end);
 }
 
 //==============================================================================

--- a/fly/types/string/string.hpp
+++ b/fly/types/string/string.hpp
@@ -215,20 +215,20 @@ public:
     static StringType generate_random_string(size_type size) noexcept;
 
     /**
-     * Format a string with variadic template arguments, returning the
-     * formatted string.
+     * Format a string with variadic template arguments, returning the formatted
+     * string.
      *
      * This is type safe in that argument types need not match the format
-     * specifier (i.e. there is no error if %s is given an integer).
-     * However, specifiers such as %x are still attempted to be handled.
-     * That is, if the matching argument for %x is numeric, then it will be
-     * converted to a hexadecimal representation.
+     * specifier (i.e. there is no error if %s is given an integer). However,
+     * specifiers such as %x are still attempted to be handled. That is, if the
+     * matching argument for %x is numeric, then it will be converted to a
+     * hexadecimal representation.
      *
      * There is also no checking done on the number of format specifiers and
-     * the number of arguments. The format specifiers will be replaced one
-     * at a time until all arguments are exhausted, then the rest of the
-     * string is taken as-is. Any extra specifiers will be in the string.
-     * Any extra arguments are dropped.
+     * the number of arguments. The format specifiers will be replaced one at a
+     * time until all arguments are exhausted, then the rest of the string is
+     * taken as-is. Any extra specifiers will be in the string. Any extra
+     * arguments are dropped.
      *
      * @tparam Args Variadic template arguments.
      *

--- a/fly/types/string/string_exception.cpp
+++ b/fly/types/string/string_exception.cpp
@@ -1,0 +1,44 @@
+#include "fly/types/string/string_exception.hpp"
+
+#include "fly/types/string/string.hpp"
+
+namespace fly {
+
+//==============================================================================
+StringException::StringException(
+    const char *class_name,
+    std::string &&message) noexcept :
+    m_message(String::format("%s: %s", class_name, message))
+{
+}
+
+//==============================================================================
+const char *StringException::what() const noexcept
+{
+    return m_message.c_str();
+}
+
+//==============================================================================
+UnicodeException::UnicodeException(const char *message) noexcept :
+    StringException("UnicodeException", std::string(message))
+{
+}
+
+//==============================================================================
+UnicodeException::UnicodeException(
+    const char *message,
+    std::uint32_t arg1) noexcept :
+    StringException("UnicodeException", String::format(message, arg1))
+{
+}
+
+//==============================================================================
+UnicodeException::UnicodeException(
+    const char *message,
+    std::uint32_t arg1,
+    std::uint32_t arg2) noexcept :
+    StringException("UnicodeException", String::format(message, arg1, arg2))
+{
+}
+
+} // namespace fly

--- a/fly/types/string/string_exception.hpp
+++ b/fly/types/string/string_exception.hpp
@@ -1,0 +1,73 @@
+#pragma once
+
+#include "fly/types/string/detail/string_traits.hpp"
+
+#include <cstdint>
+#include <exception>
+#include <string>
+
+namespace fly {
+
+/**
+ * Generic exception to be raised for errors operating on BasicString types.
+ *
+ * @author Timothy Flynn (trflynn89@pm.me)
+ * @version June 6, 2020
+ */
+class StringException : public std::exception
+{
+public:
+    /**
+     * @return C-string representing this exception.
+     */
+    virtual const char *what() const noexcept override;
+
+protected:
+    /**
+     * Constructor for subclasses.
+     *
+     * @param class_name Name of the subclass.
+     * @param message Message indicating what error was encountered.
+     */
+    StringException(const char *class_name, std::string &&message) noexcept;
+
+private:
+    const std::string m_message;
+};
+
+/**
+ * Exception to be raised for errors encountered parsing escaped unicode
+ * sequences.
+ */
+class UnicodeException : public StringException
+{
+public:
+    /**
+     * Constructor.
+     *
+     * @param message Message indicating what error was encountered.
+     */
+    explicit UnicodeException(const char *message) noexcept;
+
+    /**
+     * Constructor.
+     *
+     * @param message Message indicating what error was encountered.
+     * @param arg1 First argument to format the exception message with.
+     */
+    UnicodeException(const char *message, std::uint32_t arg1) noexcept;
+
+    /**
+     * Constructor.
+     *
+     * @param message Message indicating what error was encountered.
+     * @param arg1 First argument to format the exception message with.
+     * @param arg2 Second argument to format the exception message with.
+     */
+    UnicodeException(
+        const char *message,
+        std::uint32_t arg1,
+        std::uint32_t arg2) noexcept;
+};
+
+} // namespace fly

--- a/fly/types/string/string_literal.hpp
+++ b/fly/types/string/string_literal.hpp
@@ -10,7 +10,7 @@
  * @version March 23, 2019
  */
 #define FLY_STR(type, str)                                                     \
-    (fly::BasicStringLiteral<type>::literal(str, L##str, u##str, U##str))
+    (fly::BasicStringLiteral<type>::literal(u8##str, L##str, u##str, U##str))
 
 #define FLY_SYS_STR(str) FLY_STR(std::filesystem::path::value_type, str)
 

--- a/test/files.mk
+++ b/test/files.mk
@@ -13,6 +13,7 @@ SRC_DIRS_$(d) := \
     fly/types/bit_stream \
     fly/types/bit_stream/detail \
     fly/types/json \
+    fly/types/string \
     test/mock \
     test/util
 

--- a/test/types/json_unicode.cpp
+++ b/test/types/json_unicode.cpp
@@ -1,29 +1,10 @@
-#include "fly/fly.hpp"
 #include "fly/types/json/json.hpp"
 
 #include <gtest/gtest.h>
 
 #include <sstream>
 
-#if defined(FLY_WINDOWS)
-#    include <Windows.h>
-#    define utf8(str) convert_to_utf8(L##str)
-#else
-#    define utf8(str) str
-#endif
-
 namespace {
-
-#if defined(FLY_WINDOWS)
-const char *convert_to_utf8(const wchar_t *str)
-{
-    static char buff[1024];
-
-    ::WideCharToMultiByte(CP_UTF8, 0, str, -1, buff, sizeof(buff), NULL, NULL);
-
-    return buff;
-}
-#endif
 
 void validate_fail(const std::string &test) noexcept(false)
 {
@@ -69,14 +50,14 @@ TEST(JsonTest, UnicodeConversion)
     validate_fail("\\u000");
     validate_fail("\\u000z");
 
-    validate_pass("\\u0040", utf8("\u0040"));
-    validate_pass("\\u007A", utf8("\u007A"));
-    validate_pass("\\u007a", utf8("\u007a"));
-    validate_pass("\\u00c4", utf8("\u00c4"));
-    validate_pass("\\u00e4", utf8("\u00e4"));
-    validate_pass("\\u0298", utf8("\u0298"));
-    validate_pass("\\u0800", utf8("\u0800"));
-    validate_pass("\\uffff", utf8("\uffff"));
+    validate_pass("\\u0040", u8"\u0040");
+    validate_pass("\\u007A", u8"\u007A");
+    validate_pass("\\u007a", u8"\u007a");
+    validate_pass("\\u00c4", u8"\u00c4");
+    validate_pass("\\u00e4", u8"\u00e4");
+    validate_pass("\\u0298", u8"\u0298");
+    validate_pass("\\u0800", u8"\u0800");
+    validate_pass("\\uffff", u8"\uffff");
 
     validate_fail("\\uDC00");
     validate_fail("\\uDFFF");
@@ -93,10 +74,10 @@ TEST(JsonTest, UnicodeConversion)
     validate_fail("\\uD800\\uE000");
     validate_fail("\\uD800\\uFFFF");
 
-    validate_pass("\\uD800\\uDC00", utf8("\U00010000"));
-    validate_pass("\\uD803\\uDE6D", utf8("\U00010E6D"));
-    validate_pass("\\uD834\\uDD1E", utf8("\U0001D11E"));
-    validate_pass("\\uDBFF\\uDFFF", utf8("\U0010FFFF"));
+    validate_pass("\\uD800\\uDC00", u8"\U00010000");
+    validate_pass("\\uD803\\uDE6D", u8"\U00010E6D");
+    validate_pass("\\uD834\\uDD1E", u8"\U0001D11E");
+    validate_pass("\\uDBFF\\uDFFF", u8"\U0010FFFF");
 }
 
 //==============================================================================

--- a/test/types/string.cpp
+++ b/test/types/string.cpp
@@ -12,26 +12,7 @@
 #include <string>
 #include <vector>
 
-// #if defined(FLY_WINDOWS)
-// #    include <Windows.h>
-// #    define utf8(str) convert_to_utf8(L##str)
-// #else
-// #    define utf8(str) str
-// #endif
-
 namespace {
-
-// #if defined(FLY_WINDOWS)
-// const char *convert_to_utf8(const wchar_t *str)
-// {
-//     static char buff[1024];
-
-//     ::WideCharToMultiByte(CP_UTF8, 0, str, -1, buff, sizeof(buff), NULL,
-//     NULL);
-
-//     return buff;
-// }
-// #endif
 
 #define DECLARE_ALIASES                                                        \
     using string_type [[maybe_unused]] =                                       \

--- a/test/types/string.cpp
+++ b/test/types/string.cpp
@@ -2,6 +2,7 @@
 
 #include "fly/fly.hpp"
 #include "fly/types/numeric/literals.hpp"
+#include "fly/types/string/string_exception.hpp"
 
 #include <gtest/gtest.h>
 
@@ -11,7 +12,37 @@
 #include <string>
 #include <vector>
 
+// #if defined(FLY_WINDOWS)
+// #    include <Windows.h>
+// #    define utf8(str) convert_to_utf8(L##str)
+// #else
+// #    define utf8(str) str
+// #endif
+
 namespace {
+
+// #if defined(FLY_WINDOWS)
+// const char *convert_to_utf8(const wchar_t *str)
+// {
+//     static char buff[1024];
+
+//     ::WideCharToMultiByte(CP_UTF8, 0, str, -1, buff, sizeof(buff), NULL,
+//     NULL);
+
+//     return buff;
+// }
+// #endif
+
+#define DECLARE_ALIASES                                                        \
+    using string_type [[maybe_unused]] =                                       \
+        typename TestFixture::string_base_type;                                \
+    using StringClass [[maybe_unused]] = fly::BasicString<string_type>;        \
+    using char_type [[maybe_unused]] = typename StringClass::char_type;        \
+    using size_type [[maybe_unused]] = typename StringClass::size_type;        \
+    using streamed_type [[maybe_unused]] =                                     \
+        typename StringClass::streamed_type;                                   \
+    using streamed_char [[maybe_unused]] = typename streamed_type::value_type; \
+    using ustreamed_char [[maybe_unused]] = std::make_unsigned_t<streamed_char>;
 
 //==============================================================================
 template <typename StringType>
@@ -102,9 +133,7 @@ TYPED_TEST_SUITE(BasicStringTest, StringTypes, );
 //==============================================================================
 TYPED_TEST(BasicStringTest, Split)
 {
-    using string_type = typename TestFixture::string_base_type;
-    using StringClass = fly::BasicString<string_type>;
-    using char_type = typename StringClass::char_type;
+    DECLARE_ALIASES
 
     static constexpr std::uint32_t s_size = 10;
     std::vector<string_type> input_split(s_size);
@@ -132,9 +161,7 @@ TYPED_TEST(BasicStringTest, Split)
 //==============================================================================
 TYPED_TEST(BasicStringTest, MaxSplit)
 {
-    using string_type = typename TestFixture::string_base_type;
-    using StringClass = fly::BasicString<string_type>;
-    using char_type = typename StringClass::char_type;
+    DECLARE_ALIASES
 
     static constexpr std::uint32_t s_size = 10;
     static constexpr std::uint32_t s_count = 6;
@@ -171,9 +198,7 @@ TYPED_TEST(BasicStringTest, MaxSplit)
 //==============================================================================
 TYPED_TEST(BasicStringTest, Trim)
 {
-    using string_type = typename TestFixture::string_base_type;
-    using StringClass = fly::BasicString<string_type>;
-    using char_type = typename StringClass::char_type;
+    DECLARE_ALIASES
 
     string_type test1;
     string_type test2 = FLY_STR(char_type, "   abc");
@@ -208,9 +233,7 @@ TYPED_TEST(BasicStringTest, Trim)
 //==============================================================================
 TYPED_TEST(BasicStringTest, ReplaceAll)
 {
-    using string_type = typename TestFixture::string_base_type;
-    using StringClass = fly::BasicString<string_type>;
-    using char_type = typename StringClass::char_type;
+    DECLARE_ALIASES
 
     string_type source = FLY_STR(char_type, "To Be Replaced! To Be Replaced!");
     const string_type search = FLY_STR(char_type, "Be Replaced");
@@ -223,9 +246,7 @@ TYPED_TEST(BasicStringTest, ReplaceAll)
 //==============================================================================
 TYPED_TEST(BasicStringTest, ReplaceAllWithChar)
 {
-    using string_type = typename TestFixture::string_base_type;
-    using StringClass = fly::BasicString<string_type>;
-    using char_type = typename StringClass::char_type;
+    DECLARE_ALIASES
 
     string_type source = FLY_STR(char_type, "To Be Replaced! To Be Replaced!");
     const string_type search = FLY_STR(char_type, "Be Replaced");
@@ -238,9 +259,7 @@ TYPED_TEST(BasicStringTest, ReplaceAllWithChar)
 //==============================================================================
 TYPED_TEST(BasicStringTest, ReplaceAllWithEmpty)
 {
-    using string_type = typename TestFixture::string_base_type;
-    using StringClass = fly::BasicString<string_type>;
-    using char_type = typename StringClass::char_type;
+    DECLARE_ALIASES
 
     string_type source = FLY_STR(char_type, "To Be Replaced! To Be Replaced!");
     const string_type replace = FLY_STR(char_type, "new value");
@@ -252,9 +271,7 @@ TYPED_TEST(BasicStringTest, ReplaceAllWithEmpty)
 //==============================================================================
 TYPED_TEST(BasicStringTest, RemoveAll)
 {
-    using string_type = typename TestFixture::string_base_type;
-    using StringClass = fly::BasicString<string_type>;
-    using char_type = typename StringClass::char_type;
+    DECLARE_ALIASES
 
     string_type source = FLY_STR(char_type, "To Be Replaced! To Be Replaced!");
     const string_type search = FLY_STR(char_type, "Be Rep");
@@ -266,9 +283,7 @@ TYPED_TEST(BasicStringTest, RemoveAll)
 //==============================================================================
 TYPED_TEST(BasicStringTest, RemoveAllWithEmpty)
 {
-    using string_type = typename TestFixture::string_base_type;
-    using StringClass = fly::BasicString<string_type>;
-    using char_type = typename StringClass::char_type;
+    DECLARE_ALIASES
 
     string_type source = FLY_STR(char_type, "To Be Replaced! To Be Replaced!");
 
@@ -279,9 +294,7 @@ TYPED_TEST(BasicStringTest, RemoveAllWithEmpty)
 //==============================================================================
 TYPED_TEST(BasicStringTest, StartsWith)
 {
-    using string_type = typename TestFixture::string_base_type;
-    using StringClass = fly::BasicString<string_type>;
-    using char_type = typename StringClass::char_type;
+    DECLARE_ALIASES
 
     string_type test1, test2;
 
@@ -334,9 +347,7 @@ TYPED_TEST(BasicStringTest, StartsWith)
 //==============================================================================
 TYPED_TEST(BasicStringTest, EndsWith)
 {
-    using string_type = typename TestFixture::string_base_type;
-    using StringClass = fly::BasicString<string_type>;
-    using char_type = typename StringClass::char_type;
+    DECLARE_ALIASES
 
     string_type test1, test2;
 
@@ -386,9 +397,7 @@ TYPED_TEST(BasicStringTest, EndsWith)
 //==============================================================================
 TYPED_TEST(BasicStringTest, Wildcard)
 {
-    using string_type = typename TestFixture::string_base_type;
-    using StringClass = fly::BasicString<string_type>;
-    using char_type = typename StringClass::char_type;
+    DECLARE_ALIASES
 
     string_type test1, test2;
 
@@ -474,11 +483,74 @@ TYPED_TEST(BasicStringTest, Wildcard)
 }
 
 //==============================================================================
+TYPED_TEST(BasicStringTest, UnicodeConversion)
+{
+    DECLARE_ALIASES
+
+    auto validate_fail = [](const char_type *test) {
+        SCOPED_TRACE(test);
+
+        EXPECT_THROW(
+            StringClass::parse_unicode_character(test),
+            fly::UnicodeException);
+    };
+
+    auto validate_pass = [](const char_type *test, string_type &&expected) {
+        SCOPED_TRACE(test);
+
+        string_type actual;
+        EXPECT_NO_THROW(actual = StringClass::parse_unicode_character(test));
+        EXPECT_EQ(actual, expected);
+    };
+
+    validate_fail(FLY_STR(char_type, "\\u"));
+    validate_fail(FLY_STR(char_type, "\\u0"));
+    validate_fail(FLY_STR(char_type, "\\u00"));
+    validate_fail(FLY_STR(char_type, "\\u000"));
+    validate_fail(FLY_STR(char_type, "\\u000z"));
+
+    validate_pass(FLY_STR(char_type, "\\u0040"), FLY_STR(char_type, "\u0040"));
+    validate_pass(FLY_STR(char_type, "\\u007A"), FLY_STR(char_type, "\u007A"));
+    validate_pass(FLY_STR(char_type, "\\u007a"), FLY_STR(char_type, "\u007a"));
+    validate_pass(FLY_STR(char_type, "\\u00c4"), FLY_STR(char_type, "\u00c4"));
+    validate_pass(FLY_STR(char_type, "\\u00e4"), FLY_STR(char_type, "\u00e4"));
+    validate_pass(FLY_STR(char_type, "\\u0298"), FLY_STR(char_type, "\u0298"));
+    validate_pass(FLY_STR(char_type, "\\u0800"), FLY_STR(char_type, "\u0800"));
+    validate_pass(FLY_STR(char_type, "\\uffff"), FLY_STR(char_type, "\uffff"));
+
+    validate_fail(FLY_STR(char_type, "\\uDC00"));
+    validate_fail(FLY_STR(char_type, "\\uDFFF"));
+    validate_fail(FLY_STR(char_type, "\\uD800"));
+    validate_fail(FLY_STR(char_type, "\\uDBFF"));
+    validate_fail(FLY_STR(char_type, "\\uD800\\u"));
+    validate_fail(FLY_STR(char_type, "\\uD800\\z"));
+    validate_fail(FLY_STR(char_type, "\\uD800\\u0"));
+    validate_fail(FLY_STR(char_type, "\\uD800\\u00"));
+    validate_fail(FLY_STR(char_type, "\\uD800\\u000"));
+    validate_fail(FLY_STR(char_type, "\\uD800\\u0000"));
+    validate_fail(FLY_STR(char_type, "\\uD800\\u000z"));
+    validate_fail(FLY_STR(char_type, "\\uD800\\uDBFF"));
+    validate_fail(FLY_STR(char_type, "\\uD800\\uE000"));
+    validate_fail(FLY_STR(char_type, "\\uD800\\uFFFF"));
+
+    validate_pass(
+        FLY_STR(char_type, "\\uD800\\uDC00"),
+        FLY_STR(char_type, "\U00010000"));
+    validate_pass(
+        FLY_STR(char_type, "\\uD803\\uDE6D"),
+        FLY_STR(char_type, "\U00010E6D"));
+    validate_pass(
+        FLY_STR(char_type, "\\uD834\\uDD1E"),
+        FLY_STR(char_type, "\U0001D11E"));
+    validate_pass(
+        FLY_STR(char_type, "\\uDBFF\\uDFFF"),
+        FLY_STR(char_type, "\U0010FFFF"));
+}
+
+//==============================================================================
 TYPED_TEST(BasicStringTest, GenerateRandomString)
 {
-    using string_type = typename TestFixture::string_base_type;
-    using StringClass = fly::BasicString<string_type>;
-    using size_type = typename StringClass::size_type;
+    DECLARE_ALIASES
 
     static constexpr size_type s_size = (1 << 10);
 
@@ -489,12 +561,7 @@ TYPED_TEST(BasicStringTest, GenerateRandomString)
 //==============================================================================
 TYPED_TEST(BasicStringTest, Format)
 {
-    using string_type = typename TestFixture::string_base_type;
-    using StringClass = fly::BasicString<string_type>;
-    using char_type = typename StringClass::char_type;
-
-    using streamed_type = typename StringClass::streamed_type;
-    using streamed_char = typename streamed_type::value_type;
+    DECLARE_ALIASES
 
     streamed_type expected;
     const char_type *format;
@@ -539,12 +606,7 @@ TYPED_TEST(BasicStringTest, Format)
 //==============================================================================
 TYPED_TEST(BasicStringTest, FormatTest_d)
 {
-    using string_type = typename TestFixture::string_base_type;
-    using StringClass = fly::BasicString<string_type>;
-    using char_type = typename StringClass::char_type;
-
-    using streamed_type = typename StringClass::streamed_type;
-    using streamed_char = typename streamed_type::value_type;
+    DECLARE_ALIASES
 
     const char_type *format;
 
@@ -556,12 +618,7 @@ TYPED_TEST(BasicStringTest, FormatTest_d)
 //==============================================================================
 TYPED_TEST(BasicStringTest, FormatTest_i)
 {
-    using string_type = typename TestFixture::string_base_type;
-    using StringClass = fly::BasicString<string_type>;
-    using char_type = typename StringClass::char_type;
-
-    using streamed_type = typename StringClass::streamed_type;
-    using streamed_char = typename streamed_type::value_type;
+    DECLARE_ALIASES
 
     const char_type *format;
 
@@ -573,12 +630,7 @@ TYPED_TEST(BasicStringTest, FormatTest_i)
 //==============================================================================
 TYPED_TEST(BasicStringTest, FormatTest_x)
 {
-    using string_type = typename TestFixture::string_base_type;
-    using StringClass = fly::BasicString<string_type>;
-    using char_type = typename StringClass::char_type;
-
-    using streamed_type = typename StringClass::streamed_type;
-    using streamed_char = typename streamed_type::value_type;
+    DECLARE_ALIASES
 
     const char_type *format;
 
@@ -594,12 +646,7 @@ TYPED_TEST(BasicStringTest, FormatTest_x)
 //==============================================================================
 TYPED_TEST(BasicStringTest, FormatTest_o)
 {
-    using string_type = typename TestFixture::string_base_type;
-    using StringClass = fly::BasicString<string_type>;
-    using char_type = typename StringClass::char_type;
-
-    using streamed_type = typename StringClass::streamed_type;
-    using streamed_char = typename streamed_type::value_type;
+    DECLARE_ALIASES
 
     const char_type *format;
 
@@ -611,12 +658,7 @@ TYPED_TEST(BasicStringTest, FormatTest_o)
 //==============================================================================
 TYPED_TEST(BasicStringTest, FormatTest_a)
 {
-    using string_type = typename TestFixture::string_base_type;
-    using StringClass = fly::BasicString<string_type>;
-    using char_type = typename StringClass::char_type;
-
-    using streamed_type = typename StringClass::streamed_type;
-    using streamed_char = typename streamed_type::value_type;
+    DECLARE_ALIASES
 
     const char_type *format;
 
@@ -652,12 +694,7 @@ TYPED_TEST(BasicStringTest, FormatTest_a)
 //==============================================================================
 TYPED_TEST(BasicStringTest, FormatTest_f)
 {
-    using string_type = typename TestFixture::string_base_type;
-    using StringClass = fly::BasicString<string_type>;
-    using char_type = typename StringClass::char_type;
-
-    using streamed_type = typename StringClass::streamed_type;
-    using streamed_char = typename streamed_type::value_type;
+    DECLARE_ALIASES
 
     const char_type *format;
 
@@ -690,12 +727,7 @@ TYPED_TEST(BasicStringTest, FormatTest_f)
 //==============================================================================
 TYPED_TEST(BasicStringTest, FormatTest_g)
 {
-    using string_type = typename TestFixture::string_base_type;
-    using StringClass = fly::BasicString<string_type>;
-    using char_type = typename StringClass::char_type;
-
-    using streamed_type = typename StringClass::streamed_type;
-    using streamed_char = typename streamed_type::value_type;
+    DECLARE_ALIASES
 
     const char_type *format;
 
@@ -723,12 +755,7 @@ TYPED_TEST(BasicStringTest, FormatTest_g)
 //==============================================================================
 TYPED_TEST(BasicStringTest, FormatTest_e)
 {
-    using string_type = typename TestFixture::string_base_type;
-    using StringClass = fly::BasicString<string_type>;
-    using char_type = typename StringClass::char_type;
-
-    using streamed_type = typename StringClass::streamed_type;
-    using streamed_char = typename streamed_type::value_type;
+    DECLARE_ALIASES
 
     const char_type *format;
 
@@ -748,12 +775,7 @@ TYPED_TEST(BasicStringTest, FormatTest_e)
 //==============================================================================
 TYPED_TEST(BasicStringTest, Join)
 {
-    using string_type = typename TestFixture::string_base_type;
-    using StringClass = fly::BasicString<string_type>;
-    using char_type = typename StringClass::char_type;
-
-    using streamed_type = typename StringClass::streamed_type;
-    using streamed_char = typename streamed_type::value_type;
+    DECLARE_ALIASES
 
     string_type str = FLY_STR(char_type, "a");
     const char_type *ctr = FLY_STR(char_type, "b");
@@ -801,9 +823,7 @@ TYPED_TEST(BasicStringTest, Join)
 //==============================================================================
 TYPED_TEST(BasicStringTest, ConvertString)
 {
-    using string_type = typename TestFixture::string_base_type;
-    using StringClass = fly::BasicString<string_type>;
-    using char_type = typename StringClass::char_type;
+    DECLARE_ALIASES
 
     string_type s = FLY_STR(char_type, "abc");
     EXPECT_EQ(StringClass::template convert<string_type>(s), s);
@@ -818,9 +838,7 @@ TYPED_TEST(BasicStringTest, ConvertString)
 //==============================================================================
 TYPED_TEST(BasicStringTest, ConvertBool)
 {
-    using string_type = typename TestFixture::string_base_type;
-    using StringClass = fly::BasicString<string_type>;
-    using char_type = typename StringClass::char_type;
+    DECLARE_ALIASES
 
     string_type s;
 
@@ -846,13 +864,7 @@ TYPED_TEST(BasicStringTest, ConvertBool)
 //==============================================================================
 TYPED_TEST(BasicStringTest, ConvertChar)
 {
-    using string_type = typename TestFixture::string_base_type;
-    using StringClass = fly::BasicString<string_type>;
-    using char_type = typename StringClass::char_type;
-
-    using streamed_type = typename StringClass::streamed_type;
-    using streamed_char = typename streamed_type::value_type;
-    using ustreamed_char = std::make_unsigned_t<streamed_char>;
+    DECLARE_ALIASES
 
     string_type s;
 
@@ -907,9 +919,7 @@ TYPED_TEST(BasicStringTest, ConvertChar)
 //==============================================================================
 TYPED_TEST(BasicStringTest, ConvertInt8)
 {
-    using string_type = typename TestFixture::string_base_type;
-    using StringClass = fly::BasicString<string_type>;
-    using char_type = typename StringClass::char_type;
+    DECLARE_ALIASES
 
     string_type s;
 
@@ -968,9 +978,7 @@ TYPED_TEST(BasicStringTest, ConvertInt8)
 //==============================================================================
 TYPED_TEST(BasicStringTest, ConvertInt16)
 {
-    using string_type = typename TestFixture::string_base_type;
-    using StringClass = fly::BasicString<string_type>;
-    using char_type = typename StringClass::char_type;
+    DECLARE_ALIASES
 
     string_type s;
 
@@ -1029,9 +1037,7 @@ TYPED_TEST(BasicStringTest, ConvertInt16)
 //==============================================================================
 TYPED_TEST(BasicStringTest, ConvertInt32)
 {
-    using string_type = typename TestFixture::string_base_type;
-    using StringClass = fly::BasicString<string_type>;
-    using char_type = typename StringClass::char_type;
+    DECLARE_ALIASES
 
     string_type s;
 
@@ -1090,9 +1096,7 @@ TYPED_TEST(BasicStringTest, ConvertInt32)
 //==============================================================================
 TYPED_TEST(BasicStringTest, ConvertInt64)
 {
-    using string_type = typename TestFixture::string_base_type;
-    using StringClass = fly::BasicString<string_type>;
-    using char_type = typename StringClass::char_type;
+    DECLARE_ALIASES
 
     string_type s;
 
@@ -1127,9 +1131,7 @@ TYPED_TEST(BasicStringTest, ConvertInt64)
 //==============================================================================
 TYPED_TEST(BasicStringTest, ConvertDecimal)
 {
-    using string_type = typename TestFixture::string_base_type;
-    using StringClass = fly::BasicString<string_type>;
-    using char_type = typename StringClass::char_type;
+    DECLARE_ALIASES
 
     string_type s;
 
@@ -1169,9 +1171,7 @@ TYPED_TEST(BasicStringTest, ConvertDecimal)
 //==============================================================================
 TYPED_TEST(BasicStringTest, BasicStringStreamer)
 {
-    using string_type = typename TestFixture::string_base_type;
-    using StringClass = fly::BasicString<string_type>;
-    using char_type = typename StringClass::char_type;
+    DECLARE_ALIASES
 
     // Extra test to make sure the hexadecimal conversion for std::u16string and
     // std::u32string in detail::BasicStringStreamer is exercised correctly.


### PR DESCRIPTION
Rather than performing Unicode processing in the Json class, it is better
to do this work in String. This allows for handling Unicode processing in
all string types (std::string, std::wstring, std::u16string, std::u32string).

As for being a full-fledged Unicode implementation, the new String method
is pretty limiting and incomplete. But it serves as a good starting point
to make Unicode processing generic.