### PR TITLE
Support parsing escaped UTF-32 sequences

### DIFF
--- a/fly/types/string/string.hpp
+++ b/fly/types/string/string.hpp
@@ -159,17 +159,19 @@ public:
     static bool wildcard_match(const StringType &source, const StringType &search) noexcept;
 
     /**
-     * Parse an escaped sequence of unicode characters. Accepts UTF-8 encodings and UTF-16 paired
-     * surrogate encodings.
+     * Parse an escaped sequence of unicode characters. Accepts the following unicode encodings:
      *
-     * Input sequences must be of the form: (\u[0-9a-fA-F]{4}){1,2}
+     *     UTF-8 encodings of the form: \unnnn
+     *     UTF-16 paried surrogate encodings of the form: \unnnn\unnnn
+     *     UTF-32 encodings of the form: \Unnnnnnnn
+     *
+     * Where each character n is a hexadecimal digit.
      *
      * @param source The string containing the escaped character sequence.
      *
      * @return The parsed unicode character.
      *
-     * @throws UnicodeException If the interpreted unicode character is not valid or there weren't
-     *         enough available bytes.
+     * @throws UnicodeException If the escaped sequence is not a valid unicode character.
      */
     static StringType parse_unicode_character(const StringType &source) noexcept(false);
 

--- a/fly/types/string/string_literal.hpp
+++ b/fly/types/string/string_literal.hpp
@@ -9,15 +9,60 @@
  * @author Timothy Flynn (trflynn89@pm.me)
  * @version March 23, 2019
  */
+#define FLY_CHR(type, ch) (fly::BasicCharacterLiteral<type>::literal(u8##ch, L##ch, u##ch, U##ch))
 #define FLY_STR(type, str) (fly::BasicStringLiteral<type>::literal(u8##str, L##str, u##str, U##str))
 
+#define FLY_SYS_CHR(str) FLY_CH(std::filesystem::path::value_type, str)
 #define FLY_SYS_STR(str) FLY_STR(std::filesystem::path::value_type, str)
 
 namespace fly {
 
 //==================================================================================================
 template <typename CharType>
+struct BasicCharacterLiteral;
+
+template <typename CharType>
 struct BasicStringLiteral;
+
+//==================================================================================================
+template <>
+struct BasicCharacterLiteral<char>
+{
+    static constexpr char literal(const char ch, const wchar_t, const char16_t, const char32_t)
+    {
+        return ch;
+    }
+};
+
+//==================================================================================================
+template <>
+struct BasicCharacterLiteral<wchar_t>
+{
+    static constexpr wchar_t literal(const char, const wchar_t ch, const char16_t, const char32_t)
+    {
+        return ch;
+    }
+};
+
+//==================================================================================================
+template <>
+struct BasicCharacterLiteral<char16_t>
+{
+    static constexpr char16_t literal(const char, const wchar_t, const char16_t ch, const char32_t)
+    {
+        return ch;
+    }
+};
+
+//==================================================================================================
+template <>
+struct BasicCharacterLiteral<char32_t>
+{
+    static constexpr char32_t literal(const char, const wchar_t, const char16_t, const char32_t ch)
+    {
+        return ch;
+    }
+};
 
 //==================================================================================================
 template <>

--- a/test/types/string.cpp
+++ b/test/types/string.cpp
@@ -461,7 +461,7 @@ TYPED_TEST(BasicStringTest, Wildcard)
 }
 
 //==================================================================================================
-TYPED_TEST(BasicStringTest, UnicodeConversion)
+TYPED_TEST(BasicStringTest, Utf8Conversion)
 {
     DECLARE_ALIASES
 
@@ -475,9 +475,12 @@ TYPED_TEST(BasicStringTest, UnicodeConversion)
         SCOPED_TRACE(test);
 
         string_type actual;
-        EXPECT_NO_THROW(actual = StringClass::parse_unicode_character(test));
+        actual = StringClass::parse_unicode_character(test);
         EXPECT_EQ(actual, expected);
     };
+
+    validate_fail(FLY_STR(char_type, "f"));
+    validate_fail(FLY_STR(char_type, "\\f"));
 
     validate_fail(FLY_STR(char_type, "\\u"));
     validate_fail(FLY_STR(char_type, "\\u0"));
@@ -498,6 +501,27 @@ TYPED_TEST(BasicStringTest, UnicodeConversion)
     validate_fail(FLY_STR(char_type, "\\uDFFF"));
     validate_fail(FLY_STR(char_type, "\\uD800"));
     validate_fail(FLY_STR(char_type, "\\uDBFF"));
+}
+
+//==================================================================================================
+TYPED_TEST(BasicStringTest, Utf16Conversion)
+{
+    DECLARE_ALIASES
+
+    auto validate_fail = [](const char_type *test) {
+        SCOPED_TRACE(test);
+
+        EXPECT_THROW(StringClass::parse_unicode_character(test), fly::UnicodeException);
+    };
+
+    auto validate_pass = [](const char_type *test, string_type &&expected) {
+        SCOPED_TRACE(test);
+
+        string_type actual;
+        actual = StringClass::parse_unicode_character(test);
+        EXPECT_EQ(actual, expected);
+    };
+
     validate_fail(FLY_STR(char_type, "\\uD800\\u"));
     validate_fail(FLY_STR(char_type, "\\uD800\\z"));
     validate_fail(FLY_STR(char_type, "\\uD800\\u0"));
@@ -513,6 +537,41 @@ TYPED_TEST(BasicStringTest, UnicodeConversion)
     validate_pass(FLY_STR(char_type, "\\uD803\\uDE6D"), FLY_STR(char_type, "\U00010E6D"));
     validate_pass(FLY_STR(char_type, "\\uD834\\uDD1E"), FLY_STR(char_type, "\U0001D11E"));
     validate_pass(FLY_STR(char_type, "\\uDBFF\\uDFFF"), FLY_STR(char_type, "\U0010FFFF"));
+}
+
+//==================================================================================================
+TYPED_TEST(BasicStringTest, Utf32Conversion)
+{
+    DECLARE_ALIASES
+
+    auto validate_fail = [](const char_type *test) {
+        SCOPED_TRACE(test);
+
+        EXPECT_THROW(StringClass::parse_unicode_character(test), fly::UnicodeException);
+    };
+
+    auto validate_pass = [](const char_type *test, string_type &&expected) {
+        SCOPED_TRACE(test);
+
+        string_type actual;
+        actual = StringClass::parse_unicode_character(test);
+        EXPECT_EQ(actual, expected);
+    };
+
+    validate_fail(FLY_STR(char_type, "\\U"));
+    validate_fail(FLY_STR(char_type, "\\U0"));
+    validate_fail(FLY_STR(char_type, "\\U00"));
+    validate_fail(FLY_STR(char_type, "\\U000"));
+    validate_fail(FLY_STR(char_type, "\\U0000"));
+    validate_fail(FLY_STR(char_type, "\\U00000"));
+    validate_fail(FLY_STR(char_type, "\\U000000"));
+    validate_fail(FLY_STR(char_type, "\\U0000000"));
+    validate_fail(FLY_STR(char_type, "\\U0000000z"));
+
+    validate_pass(FLY_STR(char_type, "\\U00010000"), FLY_STR(char_type, "\U00010000"));
+    validate_pass(FLY_STR(char_type, "\\U00010E6D"), FLY_STR(char_type, "\U00010E6D"));
+    validate_pass(FLY_STR(char_type, "\\U0001D11E"), FLY_STR(char_type, "\U0001D11E"));
+    validate_pass(FLY_STR(char_type, "\\U0010FFFF"), FLY_STR(char_type, "\U0010FFFF"));
 }
 
 //==================================================================================================


### PR DESCRIPTION
BasicString previously supported only UTF-8 and UTF-16 surrogate pairs
of the form \unnnn and \unnnn\unnnn, respectively. Add support for UTF-32
sequences of the form \Unnnnnnnn.