### PR TITLE
Better Unicode validation in JSON

### DIFF
--- a/fly/types/json/json.cpp
+++ b/fly/types/json/json.cpp
@@ -506,11 +506,12 @@ bool operator!=(Json::const_reference json1, Json::const_reference json2) noexce
 std::ostream &operator<<(std::ostream &stream, Json::const_reference json) noexcept
 {
     auto serialize_string = [&stream](const JsonTraits::string_type &value) {
+        const auto end = value.cend();
         stream << '"';
 
-        for (const auto &ch : value)
+        for (auto it = value.cbegin(); it != end;)
         {
-            Json::write_escaped_charater(stream, ch);
+            Json::write_escaped_charater(stream, it, end);
         }
 
         stream << '"';
@@ -660,9 +661,10 @@ void Json::read_escaped_character(
 //==================================================================================================
 void Json::write_escaped_charater(
     std::ostream &stream,
-    JsonTraits::string_type::value_type ch) noexcept
+    JsonTraits::string_type::const_iterator &it,
+    const JsonTraits::string_type::const_iterator &end) noexcept
 {
-    switch (ch)
+    switch (*it)
     {
         case '\"':
             stream << "\\\"";
@@ -693,10 +695,11 @@ void Json::write_escaped_charater(
             break;
 
         default:
-            // TODO unicode should also be escaped.
-            stream << ch;
-            break;
+            stream << String::escape_unicode_character<'u'>(it, end);
+            return;
     }
+
+    ++it;
 }
 
 //==================================================================================================

--- a/fly/types/json/json_traits.hpp
+++ b/fly/types/json/json_traits.hpp
@@ -107,28 +107,31 @@ struct JsonTraits
      */
     struct ObjectTraits
     {
+        template <typename Key>
+        using is_string_key = std::bool_constant<is_string_v<Key>>;
+
         template <typename>
         struct IsObject : std::false_type
         {
         };
 
-        template <typename... Args>
-        struct IsObject<std::map<Args...>> : std::true_type
+        template <typename Key, typename... Args>
+        struct IsObject<std::map<Key, Args...>> : is_string_key<Key>
         {
         };
 
-        template <typename... Args>
-        struct IsObject<std::multimap<Args...>> : std::true_type
+        template <typename Key, typename... Args>
+        struct IsObject<std::multimap<Key, Args...>> : is_string_key<Key>
         {
         };
 
-        template <typename... Args>
-        struct IsObject<std::unordered_map<Args...>> : std::true_type
+        template <typename Key, typename... Args>
+        struct IsObject<std::unordered_map<Key, Args...>> : is_string_key<Key>
         {
         };
 
-        template <typename... Args>
-        struct IsObject<std::unordered_multimap<Args...>> : std::true_type
+        template <typename Key, typename... Args>
+        struct IsObject<std::unordered_multimap<Key, Args...>> : is_string_key<Key>
         {
         };
     };

--- a/test/types/json_traits.cpp
+++ b/test/types/json_traits.cpp
@@ -251,6 +251,11 @@ TEST(JsonTraitsTest, Object)
     EXPECT_TRUE(is_object(s_unordered_map));
     EXPECT_TRUE(is_object(s_unordered_multimap));
 
+    EXPECT_FALSE(is_object(std::map<int, int>()));
+    EXPECT_FALSE(is_object(std::multimap<int, int>()));
+    EXPECT_FALSE(is_object(std::unordered_map<int, int>()));
+    EXPECT_FALSE(is_object(std::unordered_multimap<int, int>()));
+
     EXPECT_FALSE(is_object(s_array));
     EXPECT_FALSE(is_object(s_deque));
     EXPECT_FALSE(is_object(s_forward_list));


### PR DESCRIPTION
Key values of JSON objects need to be validated as valid JSON strings.
Also update the JSON object type trait to protect against object-like
types with non-string keys (e.g. std::map<int, int>);