### PR TITLE
Remove noexcept qualifiers where not needed

### DIFF
--- a/build/nix/flags.mk
+++ b/build/nix/flags.mk
@@ -59,7 +59,6 @@ ifeq ($(toolchain), clang)
 else ifeq ($(toolchain), gcc)
     CF_ALL += \
         -Wlogical-op \
-        -Wnoexcept \
         -Wnull-dereference \
         -Wredundant-decls \
         -Wsign-promo \

--- a/fly/coders/base64/base64_coder.cpp
+++ b/fly/coders/base64/base64_coder.cpp
@@ -44,7 +44,7 @@ namespace {
 } // namespace
 
 //==================================================================================================
-bool Base64Coder::encode_internal(std::istream &decoded, std::ostream &encoded) noexcept
+bool Base64Coder::encode_internal(std::istream &decoded, std::ostream &encoded)
 {
     DecodedChunk chunk {};
 
@@ -72,7 +72,7 @@ bool Base64Coder::encode_internal(std::istream &decoded, std::ostream &encoded) 
 }
 
 //==================================================================================================
-bool Base64Coder::decode_internal(std::istream &encoded, std::ostream &decoded) noexcept
+bool Base64Coder::decode_internal(std::istream &encoded, std::ostream &decoded)
 {
     EncodedChunk chunk {};
 
@@ -97,7 +97,7 @@ bool Base64Coder::decode_internal(std::istream &encoded, std::ostream &decoded) 
 
 //==================================================================================================
 void Base64Coder::encode_chunk(const DecodedChunk &chunk, std::size_t bytes, std::ostream &encoded)
-    const noexcept
+    const
 {
     const EncodedChunk data = {
         // Front 6 bits of the first symbol.
@@ -119,7 +119,7 @@ void Base64Coder::encode_chunk(const DecodedChunk &chunk, std::size_t bytes, std
 }
 
 //==================================================================================================
-void Base64Coder::decode_chunk(EncodedChunk &chunk, std::ostream &decoded) const noexcept
+void Base64Coder::decode_chunk(EncodedChunk &chunk, std::ostream &decoded) const
 {
     const std::size_t bytes = std::tuple_size<DecodedChunk>::value - parse_chunk(chunk);
 
@@ -144,7 +144,7 @@ void Base64Coder::decode_chunk(EncodedChunk &chunk, std::ostream &decoded) const
 }
 
 //==================================================================================================
-std::size_t Base64Coder::parse_chunk(EncodedChunk &chunk) const noexcept
+std::size_t Base64Coder::parse_chunk(EncodedChunk &chunk) const
 {
     for (std::size_t i = 0; i < chunk.size(); ++i)
     {

--- a/fly/coders/base64/base64_coder.hpp
+++ b/fly/coders/base64/base64_coder.hpp
@@ -28,7 +28,7 @@ protected:
      *
      * @return True if the input stream was successfully encoded.
      */
-    bool encode_internal(std::istream &decoded, std::ostream &encoded) noexcept override;
+    bool encode_internal(std::istream &decoded, std::ostream &encoded) override;
 
     /**
      * Base64 decode a stream.
@@ -38,7 +38,7 @@ protected:
      *
      * @return True if the input stream was successfully decoded.
      */
-    bool decode_internal(std::istream &encoded, std::ostream &decoded) noexcept override;
+    bool decode_internal(std::istream &encoded, std::ostream &decoded) override;
 
 private:
     /**
@@ -48,8 +48,7 @@ private:
      * @param bytes Number of bytes from the input buffer to encode.
      * @param encoded Stream to store the encoded contents.
      */
-    void encode_chunk(const DecodedChunk &chunk, std::size_t bytes, std::ostream &encoded)
-        const noexcept;
+    void encode_chunk(const DecodedChunk &chunk, std::size_t bytes, std::ostream &encoded) const;
 
     /**
      * Decode a chunk of Base64 symbols.
@@ -57,7 +56,7 @@ private:
      * @param chunk Buffer holding the contents to decode.
      * @param encoded Stream to store the decoded contents.
      */
-    void decode_chunk(EncodedChunk &chunk, std::ostream &decoded) const noexcept;
+    void decode_chunk(EncodedChunk &chunk, std::ostream &decoded) const;
 
     /**
      * Covert a buffer of Base64 symbols to ASCII codes, validating that each symbol is valid
@@ -68,7 +67,7 @@ private:
      * @return The number of Base64 padding symbols in the buffer. If an invalid symbol is parsed,
      *         returns a value as if every symbol was padding.
      */
-    std::size_t parse_chunk(EncodedChunk &chunk) const noexcept;
+    std::size_t parse_chunk(EncodedChunk &chunk) const;
 };
 
 } // namespace fly

--- a/fly/coders/coder.cpp
+++ b/fly/coders/coder.cpp
@@ -21,7 +21,7 @@ namespace {
     void log_encoder_stats(
         std::chrono::time_point<std::chrono::system_clock> start,
         SizeType decoded_size,
-        SizeType encoded_size) noexcept
+        SizeType encoded_size)
     {
         const auto end = std::chrono::system_clock::now();
         const auto ratio = (static_cast<double>(decoded_size) - encoded_size) / decoded_size;
@@ -38,7 +38,7 @@ namespace {
     void log_decoder_stats(
         std::chrono::time_point<std::chrono::system_clock> start,
         SizeType encoded_size,
-        SizeType decoded_size) noexcept
+        SizeType decoded_size)
     {
         const auto end = std::chrono::system_clock::now();
 
@@ -52,7 +52,7 @@ namespace {
 } // namespace
 
 //==================================================================================================
-bool Encoder::encode_string(const std::string &decoded, std::string &encoded) noexcept
+bool Encoder::encode_string(const std::string &decoded, std::string &encoded)
 {
     const auto start = std::chrono::system_clock::now();
     bool successful = false;
@@ -77,7 +77,7 @@ bool Encoder::encode_string(const std::string &decoded, std::string &encoded) no
 //==================================================================================================
 bool Encoder::encode_file(
     const std::filesystem::path &decoded,
-    const std::filesystem::path &encoded) noexcept
+    const std::filesystem::path &encoded)
 {
     const auto start = std::chrono::system_clock::now();
     bool successful = false;
@@ -103,14 +103,14 @@ bool Encoder::encode_file(
 }
 
 //==================================================================================================
-bool BinaryEncoder::encode_internal(std::istream &decoded, std::ostream &encoded) noexcept
+bool BinaryEncoder::encode_internal(std::istream &decoded, std::ostream &encoded)
 {
     BitStreamWriter stream(encoded);
     return encode_binary(decoded, stream);
 }
 
 //==================================================================================================
-bool Decoder::decode_string(const std::string &encoded, std::string &decoded) noexcept
+bool Decoder::decode_string(const std::string &encoded, std::string &decoded)
 {
     const auto start = std::chrono::system_clock::now();
     bool successful = false;
@@ -135,7 +135,7 @@ bool Decoder::decode_string(const std::string &encoded, std::string &decoded) no
 //==================================================================================================
 bool Decoder::decode_file(
     const std::filesystem::path &encoded,
-    const std::filesystem::path &decoded) noexcept
+    const std::filesystem::path &decoded)
 {
     const auto start = std::chrono::system_clock::now();
     bool successful = false;
@@ -161,7 +161,7 @@ bool Decoder::decode_file(
 }
 
 //==================================================================================================
-bool BinaryDecoder::decode_internal(std::istream &encoded, std::ostream &decoded) noexcept
+bool BinaryDecoder::decode_internal(std::istream &encoded, std::ostream &decoded)
 {
     BitStreamReader stream(encoded);
     return decode_binary(stream, decoded);

--- a/fly/coders/coder.hpp
+++ b/fly/coders/coder.hpp
@@ -33,7 +33,7 @@ public:
      *
      * @return True if the input string was successfully encoded.
      */
-    virtual bool encode_string(const std::string &decoded, std::string &encoded) noexcept;
+    virtual bool encode_string(const std::string &decoded, std::string &encoded);
 
     /**
      * Encode a file.
@@ -43,9 +43,8 @@ public:
      *
      * @return True if the input file was successfully encoded.
      */
-    virtual bool encode_file(
-        const std::filesystem::path &decoded,
-        const std::filesystem::path &encoded) noexcept;
+    virtual bool
+    encode_file(const std::filesystem::path &decoded, const std::filesystem::path &encoded);
 
 protected:
     /**
@@ -56,7 +55,7 @@ protected:
      *
      * @return True if the input stream was successfully encoded.
      */
-    virtual bool encode_internal(std::istream &decoded, std::ostream &encoded) noexcept = 0;
+    virtual bool encode_internal(std::istream &decoded, std::ostream &encoded) = 0;
 };
 
 /**
@@ -69,7 +68,7 @@ protected:
 class BinaryEncoder : public Encoder
 {
 protected:
-    bool encode_internal(std::istream &decoded, std::ostream &encoded) noexcept final;
+    bool encode_internal(std::istream &decoded, std::ostream &encoded) final;
 
     /**
      * Encode a stream.
@@ -79,7 +78,7 @@ protected:
      *
      * @return True if the input stream was successfully encoded.
      */
-    virtual bool encode_binary(std::istream &decoded, BitStreamWriter &encoded) noexcept = 0;
+    virtual bool encode_binary(std::istream &decoded, BitStreamWriter &encoded) = 0;
 };
 
 /**
@@ -105,7 +104,7 @@ public:
      *
      * @return True if the input string was successfully decoded.
      */
-    bool decode_string(const std::string &encoded, std::string &decoded) noexcept;
+    bool decode_string(const std::string &encoded, std::string &decoded);
 
     /**
      * Decode a file.
@@ -115,9 +114,7 @@ public:
      *
      * @return True if the input file was successfully decoded.
      */
-    bool decode_file(
-        const std::filesystem::path &encoded,
-        const std::filesystem::path &decoded) noexcept;
+    bool decode_file(const std::filesystem::path &encoded, const std::filesystem::path &decoded);
 
 protected:
     /**
@@ -128,7 +125,7 @@ protected:
      *
      * @return bool True if the input stream was successfully decoded.
      */
-    virtual bool decode_internal(std::istream &encoded, std::ostream &decoded) noexcept = 0;
+    virtual bool decode_internal(std::istream &encoded, std::ostream &decoded) = 0;
 };
 
 /**
@@ -141,7 +138,7 @@ protected:
 class BinaryDecoder : public Decoder
 {
 protected:
-    bool decode_internal(std::istream &encoded, std::ostream &decoded) noexcept final;
+    bool decode_internal(std::istream &encoded, std::ostream &decoded) final;
 
     /**
      * Decode a stream.
@@ -151,7 +148,7 @@ protected:
      *
      * @return True if the input stream was successfully decoded.
      */
-    virtual bool decode_binary(BitStreamReader &encoded, std::ostream &decoded) noexcept = 0;
+    virtual bool decode_binary(BitStreamReader &encoded, std::ostream &decoded) = 0;
 };
 
 } // namespace fly

--- a/fly/coders/huffman/huffman_config.cpp
+++ b/fly/coders/huffman/huffman_config.cpp
@@ -12,7 +12,7 @@ HuffmanConfig::HuffmanConfig() noexcept :
 }
 
 //==================================================================================================
-std::uint32_t HuffmanConfig::encoder_chunk_size() const noexcept
+std::uint32_t HuffmanConfig::encoder_chunk_size() const
 {
     auto encoder_chunk_size_kb =
         get_value<std::uint16_t>("encoder_chunk_size_kb", m_default_encoder_chunk_size_kb);
@@ -21,7 +21,7 @@ std::uint32_t HuffmanConfig::encoder_chunk_size() const noexcept
 }
 
 //==================================================================================================
-length_type HuffmanConfig::encoder_max_code_length() const noexcept
+length_type HuffmanConfig::encoder_max_code_length() const
 {
     return get_value<length_type>("encoder_max_code_length", m_default_encoder_max_code_length);
 }

--- a/fly/coders/huffman/huffman_config.hpp
+++ b/fly/coders/huffman/huffman_config.hpp
@@ -27,12 +27,12 @@ public:
     /**
      * @return Huffman encoder chunk size (in bytes).
      */
-    std::uint32_t encoder_chunk_size() const noexcept;
+    std::uint32_t encoder_chunk_size() const;
 
     /**
      * @return Maximum Huffman code length (in bits) for encoding.
      */
-    length_type encoder_max_code_length() const noexcept;
+    length_type encoder_max_code_length() const;
 
 protected:
     std::uint16_t m_default_encoder_chunk_size_kb;

--- a/fly/coders/huffman/huffman_decoder.cpp
+++ b/fly/coders/huffman/huffman_decoder.cpp
@@ -9,12 +9,12 @@
 namespace fly {
 
 //==================================================================================================
-HuffmanDecoder::HuffmanDecoder() : m_huffman_codes_size(0)
+HuffmanDecoder::HuffmanDecoder() noexcept : m_huffman_codes_size(0)
 {
 }
 
 //==================================================================================================
-bool HuffmanDecoder::decode_binary(BitStreamReader &encoded, std::ostream &decoded) noexcept
+bool HuffmanDecoder::decode_binary(BitStreamReader &encoded, std::ostream &decoded)
 {
     std::uint32_t chunk_size;
     length_type max_code_length;
@@ -56,7 +56,7 @@ bool HuffmanDecoder::decode_binary(BitStreamReader &encoded, std::ostream &decod
 bool HuffmanDecoder::decode_header(
     BitStreamReader &encoded,
     std::uint32_t &chunk_size,
-    length_type &max_code_length) const noexcept
+    length_type &max_code_length) const
 {
     // Decode the Huffman coder version.
     byte_type huffman_version;
@@ -84,7 +84,7 @@ bool HuffmanDecoder::decode_header(
 bool HuffmanDecoder::decode_header_version1(
     BitStreamReader &encoded,
     std::uint32_t &chunk_size,
-    length_type &max_code_length) const noexcept
+    length_type &max_code_length) const
 {
     // Decode the chunk size.
     word_type encoded_chunk_size_kb;
@@ -128,7 +128,7 @@ bool HuffmanDecoder::decode_header_version1(
 bool HuffmanDecoder::decode_codes(
     BitStreamReader &encoded,
     length_type global_max_code_length,
-    length_type &local_max_code_length) noexcept
+    length_type &local_max_code_length)
 {
     m_huffman_codes_size = 0;
 
@@ -208,7 +208,7 @@ bool HuffmanDecoder::decode_codes(
 }
 
 //==================================================================================================
-void HuffmanDecoder::convert_to_prefix_table(length_type max_code_length) noexcept
+void HuffmanDecoder::convert_to_prefix_table(length_type max_code_length)
 {
     for (std::uint16_t i = 0; i < m_huffman_codes_size; ++i)
     {
@@ -229,7 +229,7 @@ bool HuffmanDecoder::decode_symbols(
     BitStreamReader &encoded,
     length_type max_code_length,
     std::uint32_t chunk_size,
-    std::ostream &decoded) const noexcept
+    std::ostream &decoded) const
 {
     std::uint32_t bytes = 0;
     code_type index;

--- a/fly/coders/huffman/huffman_decoder.hpp
+++ b/fly/coders/huffman/huffman_decoder.hpp
@@ -23,7 +23,7 @@ public:
     /**
      * Constructor.
      */
-    HuffmanDecoder();
+    HuffmanDecoder() noexcept;
 
 protected:
     /**
@@ -53,7 +53,7 @@ protected:
      *
      * @return True if the input stream was successfully decoded.
      */
-    bool decode_binary(BitStreamReader &encoded, std::ostream &decoded) noexcept override;
+    bool decode_binary(BitStreamReader &encoded, std::ostream &decoded) override;
 
 private:
     /**
@@ -69,7 +69,7 @@ private:
     bool decode_header(
         BitStreamReader &encoded,
         std::uint32_t &chunk_size,
-        length_type &max_code_length) const noexcept;
+        length_type &max_code_length) const;
 
     /**
      * Decode version 1 of the header. Extract the maximum chunk length and the global maximum
@@ -84,7 +84,7 @@ private:
     bool decode_header_version1(
         BitStreamReader &encoded,
         std::uint32_t &chunk_size,
-        length_type &max_code_length) const noexcept;
+        length_type &max_code_length) const;
 
     /**
      * Decode Huffman codes from an encoded input stream. The list of codes will be stored as a
@@ -99,14 +99,14 @@ private:
     bool decode_codes(
         BitStreamReader &encoded,
         length_type global_max_code_length,
-        length_type &local_max_code_length) noexcept;
+        length_type &local_max_code_length);
 
     /**
      * Convert the decoded list of Huffman codes into a prefix table.
      *
      * @param max_code_length The maximum length of the decoded Huffman codes.
      */
-    void convert_to_prefix_table(length_type max_code_length) noexcept;
+    void convert_to_prefix_table(length_type max_code_length);
 
     /**
      * Decode symbols from an encoded input stream with a Huffman tree. Store decoded data into a
@@ -124,7 +124,7 @@ private:
         BitStreamReader &encoded,
         length_type max_code_length,
         std::uint32_t chunk_size,
-        std::ostream &decoded) const noexcept;
+        std::ostream &decoded) const;
 
     std::unique_ptr<symbol_type[]> m_chunk_buffer;
 

--- a/fly/coders/huffman/huffman_encoder.cpp
+++ b/fly/coders/huffman/huffman_encoder.cpp
@@ -27,7 +27,7 @@ HuffmanEncoder::HuffmanEncoder(const std::shared_ptr<HuffmanConfig> &config) noe
 }
 
 //==================================================================================================
-bool HuffmanEncoder::encode_binary(std::istream &decoded, BitStreamWriter &encoded) noexcept
+bool HuffmanEncoder::encode_binary(std::istream &decoded, BitStreamWriter &encoded)
 {
     if (m_max_code_length >= std::numeric_limits<code_type>::digits)
     {
@@ -55,7 +55,7 @@ bool HuffmanEncoder::encode_binary(std::istream &decoded, BitStreamWriter &encod
 }
 
 //==================================================================================================
-std::uint32_t HuffmanEncoder::read_stream(std::istream &decoded) const noexcept
+std::uint32_t HuffmanEncoder::read_stream(std::istream &decoded) const
 {
     decoded.read(
         reinterpret_cast<std::ios::char_type *>(m_chunk_buffer.get()),
@@ -65,7 +65,7 @@ std::uint32_t HuffmanEncoder::read_stream(std::istream &decoded) const noexcept
 }
 
 //==================================================================================================
-void HuffmanEncoder::create_tree(std::uint32_t chunk_size) noexcept
+void HuffmanEncoder::create_tree(std::uint32_t chunk_size)
 {
     std::uint16_t index = 0;
 
@@ -112,7 +112,7 @@ void HuffmanEncoder::create_tree(std::uint32_t chunk_size) noexcept
 }
 
 //==================================================================================================
-void HuffmanEncoder::create_codes() noexcept
+void HuffmanEncoder::create_codes()
 {
     std::stack<const HuffmanNode *> pending;
     std::stack<const HuffmanNode *> path;
@@ -167,7 +167,7 @@ void HuffmanEncoder::create_codes() noexcept
 }
 
 //==================================================================================================
-void HuffmanEncoder::insert_code(HuffmanCode &&code) noexcept
+void HuffmanEncoder::insert_code(HuffmanCode &&code)
 {
     std::uint16_t pos = m_huffman_codes_size++;
 
@@ -180,7 +180,7 @@ void HuffmanEncoder::insert_code(HuffmanCode &&code) noexcept
 }
 
 //==================================================================================================
-void HuffmanEncoder::limit_code_lengths() noexcept
+void HuffmanEncoder::limit_code_lengths()
 {
     auto compute_kraft = [this](const HuffmanCode &code) -> code_type {
         return 1_u16 << (m_max_code_length - code.m_length);
@@ -228,7 +228,7 @@ void HuffmanEncoder::limit_code_lengths() noexcept
 }
 
 //==================================================================================================
-void HuffmanEncoder::convert_to_canonical_form() noexcept
+void HuffmanEncoder::convert_to_canonical_form()
 {
     // First code is always set to zero. Its length does not change.
     m_huffman_codes[0].m_code = 0;
@@ -253,7 +253,7 @@ void HuffmanEncoder::convert_to_canonical_form() noexcept
 }
 
 //==================================================================================================
-void HuffmanEncoder::encode_header(BitStreamWriter &encoded) const noexcept
+void HuffmanEncoder::encode_header(BitStreamWriter &encoded) const
 {
     // Encode the Huffman coder version.
     encoded.write_byte(static_cast<byte_type>(s_huffman_version));
@@ -266,7 +266,7 @@ void HuffmanEncoder::encode_header(BitStreamWriter &encoded) const noexcept
 }
 
 //==================================================================================================
-void HuffmanEncoder::encode_codes(BitStreamWriter &encoded) const noexcept
+void HuffmanEncoder::encode_codes(BitStreamWriter &encoded) const
 {
     // At the least, encode that there were zero Huffman codes of length zero.
     std::vector<std::uint16_t> counts(1);
@@ -301,7 +301,7 @@ void HuffmanEncoder::encode_codes(BitStreamWriter &encoded) const noexcept
 }
 
 //==================================================================================================
-void HuffmanEncoder::encode_symbols(std::uint32_t chunk_size, BitStreamWriter &encoded) noexcept
+void HuffmanEncoder::encode_symbols(std::uint32_t chunk_size, BitStreamWriter &encoded)
 {
     decltype(m_huffman_codes) symbols;
 

--- a/fly/coders/huffman/huffman_encoder.hpp
+++ b/fly/coders/huffman/huffman_encoder.hpp
@@ -86,7 +86,7 @@ protected:
      *
      * @return True if the input stream was successfully encoded.
      */
-    bool encode_binary(std::istream &decoded, BitStreamWriter &encoded) noexcept override;
+    bool encode_binary(std::istream &decoded, BitStreamWriter &encoded) override;
 
 private:
     /**
@@ -97,27 +97,27 @@ private:
      *
      * @return The number of bytes that were read.
      */
-    std::uint32_t read_stream(std::istream &decoded) const noexcept;
+    std::uint32_t read_stream(std::istream &decoded) const;
 
     /**
      * Create a Huffman tree from the current chunk buffer.
      *
      * @param chunk_size The number of bytes the chunk buffer holds.
      */
-    void create_tree(std::uint32_t chunk_size) noexcept;
+    void create_tree(std::uint32_t chunk_size);
 
     /**
      * Create a list of Huffman codes from the generated Huffman tree. The list of codes will be in
      * canonical form.
      */
-    void create_codes() noexcept;
+    void create_codes();
 
     /**
      * Insert a new Huffman code into the list of already sorted codes.
      *
      * @param code The Huffman code to insert.
      */
-    void insert_code(HuffmanCode &&code) noexcept;
+    void insert_code(HuffmanCode &&code);
 
     /**
      * Length-limit the generated Huffman codes to a static maximum size, using a method described
@@ -125,27 +125,27 @@ private:
      *
      * https://cbloomrants.blogspot.com/2010/07/07-03-10-length-limitted-huffman-codes.html
      */
-    void limit_code_lengths() noexcept;
+    void limit_code_lengths();
 
     /**
      * Convert the generated list of standard Huffman codes into canonical form. It is assumed that
      * the codes are already sorted in accordance with canonical form.
      */
-    void convert_to_canonical_form() noexcept;
+    void convert_to_canonical_form();
 
     /**
      * Encode the header to the output stream.
      *
      * @param encoded Stream to store the encoded header.
      */
-    void encode_header(BitStreamWriter &encoded) const noexcept;
+    void encode_header(BitStreamWriter &encoded) const;
 
     /**
      * Encode the generated Huffman codes to the output stream.
      *
      * @param encoded Stream to store the encoded codes.
      */
-    void encode_codes(BitStreamWriter &encoded) const noexcept;
+    void encode_codes(BitStreamWriter &encoded) const;
 
     /**
      * Encode symbols from the current chunk buffer with the generated list of Huffman codes. The
@@ -154,7 +154,7 @@ private:
      * @param chunk_size The number of bytes the chunk buffer holds.
      * @param encoded Stream to store the encoded symbols.
      */
-    void encode_symbols(std::uint32_t chunk_size, BitStreamWriter &encoded) noexcept;
+    void encode_symbols(std::uint32_t chunk_size, BitStreamWriter &encoded);
 
     // Configuration.
     const std::uint32_t m_chunk_size;

--- a/fly/coders/huffman/huffman_types.cpp
+++ b/fly/coders/huffman/huffman_types.cpp
@@ -19,7 +19,7 @@ HuffmanNode &HuffmanNode::operator=(HuffmanNode &&node) noexcept
 }
 
 //==================================================================================================
-void HuffmanNode::become_symbol(symbol_type symbol, frequency_type frequency) noexcept
+void HuffmanNode::become_symbol(symbol_type symbol, frequency_type frequency)
 {
     m_symbol = symbol;
     m_frequency = frequency;
@@ -28,7 +28,7 @@ void HuffmanNode::become_symbol(symbol_type symbol, frequency_type frequency) no
 }
 
 //==================================================================================================
-void HuffmanNode::become_intermediate(HuffmanNode *left, HuffmanNode *right) noexcept
+void HuffmanNode::become_intermediate(HuffmanNode *left, HuffmanNode *right)
 {
     m_symbol = 0;
     m_frequency = left->m_frequency + right->m_frequency;
@@ -37,7 +37,7 @@ void HuffmanNode::become_intermediate(HuffmanNode *left, HuffmanNode *right) noe
 }
 
 //==================================================================================================
-bool HuffmanNodeComparator::operator()(const HuffmanNode *left, const HuffmanNode *right) noexcept
+bool HuffmanNodeComparator::operator()(const HuffmanNode *left, const HuffmanNode *right)
 {
     return left->m_frequency > right->m_frequency;
 }

--- a/fly/coders/huffman/huffman_types.hpp
+++ b/fly/coders/huffman/huffman_types.hpp
@@ -57,7 +57,7 @@ struct HuffmanNode
      * @param symbol The symbol from the input stream.
      * @param frequency The frequency of the symbol in the input stream.
      */
-    void become_symbol(symbol_type symbol, frequency_type frequency) noexcept;
+    void become_symbol(symbol_type symbol, frequency_type frequency);
 
     /**
      * Change this node to represent an intermediate, non-symbol. Its frequency is set to the sum of
@@ -66,7 +66,7 @@ struct HuffmanNode
      * @param left Pointer to the intermediate's left child.
      * @param right Pointer to the intermediate's right child.
      */
-    void become_intermediate(HuffmanNode *left, HuffmanNode *right) noexcept;
+    void become_intermediate(HuffmanNode *left, HuffmanNode *right);
 
     symbol_type m_symbol;
     frequency_type m_frequency;
@@ -84,7 +84,7 @@ struct HuffmanNode
  */
 struct HuffmanNodeComparator
 {
-    bool operator()(const HuffmanNode *left, const HuffmanNode *right) noexcept;
+    bool operator()(const HuffmanNode *left, const HuffmanNode *right);
 };
 
 /**

--- a/fly/config/config.cpp
+++ b/fly/config/config.cpp
@@ -3,7 +3,7 @@
 namespace fly {
 
 //==================================================================================================
-void Config::update(const Json &values) noexcept
+void Config::update(const Json &values)
 {
     std::unique_lock<std::shared_timed_mutex> lock(m_values_mutex);
     m_values = values;

--- a/fly/config/config.hpp
+++ b/fly/config/config.hpp
@@ -23,11 +23,6 @@ protected:
     friend class ConfigManager;
 
     /**
-     * Constructor.
-     */
-    Config() noexcept = default;
-
-    /**
      * Destructor.
      */
     virtual ~Config() = default;
@@ -44,12 +39,12 @@ protected:
      * @return The converted value or the default value.
      */
     template <typename T>
-    T get_value(const std::string &name, T def) const noexcept;
+    T get_value(const std::string &name, T def) const;
 
     /**
      * Update this configuration with a new set of parsed values.
      */
-    void update(const Json &) noexcept;
+    void update(const Json &);
 
 private:
     mutable std::shared_timed_mutex m_values_mutex;
@@ -58,7 +53,7 @@ private:
 
 //==================================================================================================
 template <typename T>
-T Config::get_value(const std::string &name, T def) const noexcept
+T Config::get_value(const std::string &name, T def) const
 {
     std::shared_lock<std::shared_timed_mutex> lock(m_values_mutex);
 

--- a/fly/config/config_manager.cpp
+++ b/fly/config/config_manager.cpp
@@ -46,7 +46,7 @@ ConfigManager::~ConfigManager()
 }
 
 //==================================================================================================
-ConfigManager::ConfigMap::size_type ConfigManager::prune() noexcept
+ConfigManager::ConfigMap::size_type ConfigManager::prune()
 {
     std::lock_guard<std::mutex> lock(m_configs_mutex);
 
@@ -68,7 +68,7 @@ ConfigManager::ConfigMap::size_type ConfigManager::prune() noexcept
 }
 
 //==================================================================================================
-bool ConfigManager::start() noexcept
+bool ConfigManager::start()
 {
     if (m_parser)
     {
@@ -105,7 +105,7 @@ bool ConfigManager::start() noexcept
 }
 
 //==================================================================================================
-void ConfigManager::update_config() noexcept
+void ConfigManager::update_config()
 {
     std::lock_guard<std::mutex> lock(m_configs_mutex);
 
@@ -151,7 +151,7 @@ ConfigUpdateTask::ConfigUpdateTask(std::weak_ptr<ConfigManager> weak_config_mana
 }
 
 //==================================================================================================
-void ConfigUpdateTask::run() noexcept
+void ConfigUpdateTask::run()
 {
     std::shared_ptr<ConfigManager> config_manager = m_weak_config_manager.lock();
 

--- a/fly/config/config_manager.hpp
+++ b/fly/config/config_manager.hpp
@@ -70,27 +70,27 @@ public:
      * @return A reference to the created/found configuration.
      */
     template <typename T>
-    std::shared_ptr<T> create_config() noexcept;
+    std::shared_ptr<T> create_config();
 
     /**
      * Erase any expired configuration objects.
      *
      * @return The remaining number of configurations.
      */
-    ConfigMap::size_type prune() noexcept;
+    ConfigMap::size_type prune();
 
     /**
      * Start the configuration manager and underlying objects.
      *
      * @return True if the monitor could be started.
      */
-    bool start() noexcept;
+    bool start();
 
 private:
     /**
      * Parse the configuration file and store the parsed values in memory.
      */
-    void update_config() noexcept;
+    void update_config();
 
     std::shared_ptr<PathMonitor> m_monitor;
     std::unique_ptr<Parser> m_parser;
@@ -120,7 +120,7 @@ protected:
     /**
      * Call back into the config manager to re-parse the configuration file.
      */
-    void run() noexcept override;
+    void run() override;
 
 private:
     std::weak_ptr<ConfigManager> m_weak_config_manager;
@@ -128,7 +128,7 @@ private:
 
 //==================================================================================================
 template <typename T>
-std::shared_ptr<T> ConfigManager::create_config() noexcept
+std::shared_ptr<T> ConfigManager::create_config()
 {
     static_assert(std::is_base_of_v<Config, T>);
 

--- a/fly/logger/log.cpp
+++ b/fly/logger/log.cpp
@@ -49,7 +49,7 @@ Log &Log::operator=(Log &&log) noexcept
 }
 
 //==================================================================================================
-std::ostream &operator<<(std::ostream &stream, const Log &log) noexcept
+std::ostream &operator<<(std::ostream &stream, const Log &log)
 {
     stream << log.m_level << '\t';
     stream << log.m_time << '\t';
@@ -62,7 +62,7 @@ std::ostream &operator<<(std::ostream &stream, const Log &log) noexcept
 }
 
 //==================================================================================================
-std::ostream &operator<<(std::ostream &stream, const Log::Level &level) noexcept
+std::ostream &operator<<(std::ostream &stream, const Log::Level &level)
 {
     stream << static_cast<int>(level);
     return stream;

--- a/fly/logger/log.hpp
+++ b/fly/logger/log.hpp
@@ -68,9 +68,9 @@ struct Log
     std::uint32_t m_line;
     std::string m_message;
 
-    friend std::ostream &operator<<(std::ostream &stream, const Log &log) noexcept;
+    friend std::ostream &operator<<(std::ostream &stream, const Log &log);
 
-    friend std::ostream &operator<<(std::ostream &stream, const Level &level) noexcept;
+    friend std::ostream &operator<<(std::ostream &stream, const Level &level);
 };
 
 } // namespace fly

--- a/fly/logger/logger.cpp
+++ b/fly/logger/logger.cpp
@@ -28,13 +28,13 @@ Logger::Logger(
 }
 
 //==================================================================================================
-void Logger::set_instance(const std::shared_ptr<Logger> &logger) noexcept
+void Logger::set_instance(const std::shared_ptr<Logger> &logger)
 {
     s_weak_instance = logger;
 }
 
 //==================================================================================================
-void Logger::console_log(bool acquire_lock, const std::string &message) noexcept
+void Logger::console_log(bool acquire_lock, const std::string &message)
 {
     std::unique_lock<std::mutex> lock(s_console_mutex, std::defer_lock);
     const std::string time_str = System::local_time();
@@ -53,7 +53,7 @@ void Logger::add_log(
     const char *file,
     const char *function,
     std::uint32_t line,
-    const std::string &message) noexcept
+    const std::string &message)
 {
     std::shared_ptr<Logger> logger = s_weak_instance.lock();
 
@@ -68,7 +68,7 @@ void Logger::add_log(
 }
 
 //==================================================================================================
-bool Logger::start() noexcept
+bool Logger::start()
 {
     if (create_log_file())
     {
@@ -84,13 +84,13 @@ bool Logger::start() noexcept
 }
 
 //==================================================================================================
-std::filesystem::path Logger::get_log_file_path() const noexcept
+std::filesystem::path Logger::get_log_file_path() const
 {
     return m_log_file;
 }
 
 //==================================================================================================
-bool Logger::poll() noexcept
+bool Logger::poll()
 {
     Log log;
 
@@ -114,7 +114,7 @@ void Logger::add_log_internal(
     const char *file,
     const char *function,
     std::uint32_t line,
-    const std::string &message) noexcept
+    const std::string &message)
 {
     auto now = std::chrono::high_resolution_clock::now();
     auto log_time = std::chrono::duration_cast<std::chrono::duration<double>>(now - m_start_time);
@@ -135,7 +135,7 @@ void Logger::add_log_internal(
 }
 
 //==================================================================================================
-bool Logger::create_log_file() noexcept
+bool Logger::create_log_file()
 {
     const std::string rand_str = String::generate_random_string(10);
     std::string time_str = System::local_time();
@@ -165,7 +165,7 @@ LoggerTask::LoggerTask(std::weak_ptr<Logger> weak_logger) noexcept :
 }
 
 //==================================================================================================
-void LoggerTask::run() noexcept
+void LoggerTask::run()
 {
     std::shared_ptr<Logger> logger = m_weak_logger.lock();
 

--- a/fly/logger/logger.hpp
+++ b/fly/logger/logger.hpp
@@ -115,7 +115,7 @@ public:
      *
      * @param logger The logger instance.
      */
-    static void set_instance(const std::shared_ptr<Logger> &logger) noexcept;
+    static void set_instance(const std::shared_ptr<Logger> &logger);
 
     /**
      * Log to the console in a thread-safe manner.
@@ -123,7 +123,7 @@ public:
      * @param acquire_lock Whether to acquire lock before logging.
      * @param message The message to log.
      */
-    static void console_log(bool acquire_lock, const std::string &message) noexcept;
+    static void console_log(bool acquire_lock, const std::string &message);
 
     /**
      * Add a log to the static logger instance.
@@ -139,19 +139,19 @@ public:
         const char *file,
         const char *function,
         std::uint32_t line,
-        const std::string &message) noexcept;
+        const std::string &message);
 
     /**
      * Create the logger's log file on disk and initialize the logger task.
      *
      * @return True if the logger is in a valid state.
      */
-    bool start() noexcept;
+    bool start();
 
     /**
      * @return Path to the current log file.
      */
-    std::filesystem::path get_log_file_path() const noexcept;
+    std::filesystem::path get_log_file_path() const;
 
 private:
     /**
@@ -159,7 +159,7 @@ private:
      *
      * @return True if the current log file is still open and healthy.
      */
-    bool poll() noexcept;
+    bool poll();
 
     /**
      * Add a log to this logger instance.
@@ -175,14 +175,14 @@ private:
         const char *file,
         const char *function,
         std::uint32_t line,
-        const std::string &message) noexcept;
+        const std::string &message);
 
     /**
      * Create the log file. If a log file is already open, close it.
      *
      * @return True if the log file could be opened.
      */
-    bool create_log_file() noexcept;
+    bool create_log_file();
 
     static std::weak_ptr<Logger> s_weak_instance;
     static std::mutex s_console_mutex;
@@ -218,7 +218,7 @@ protected:
     /**
      * Call back into the logger to check for new log entries. The task re-arms itself.
      */
-    void run() noexcept override;
+    void run() override;
 
 private:
     std::weak_ptr<Logger> m_weak_logger;

--- a/fly/logger/logger_config.cpp
+++ b/fly/logger/logger_config.cpp
@@ -13,19 +13,19 @@ LoggerConfig::LoggerConfig() noexcept :
 }
 
 //==================================================================================================
-std::uintmax_t LoggerConfig::max_log_file_size() const noexcept
+std::uintmax_t LoggerConfig::max_log_file_size() const
 {
     return get_value<std::uintmax_t>("max_log_file_size", m_default_max_log_file_size);
 }
 
 //==================================================================================================
-std::uint32_t LoggerConfig::max_message_size() const noexcept
+std::uint32_t LoggerConfig::max_message_size() const
 {
     return get_value<std::uint32_t>("max_message_size", m_default_max_message_size);
 }
 
 //==================================================================================================
-std::chrono::milliseconds LoggerConfig::queue_wait_time() const noexcept
+std::chrono::milliseconds LoggerConfig::queue_wait_time() const
 {
     return std::chrono::milliseconds(
         get_value<std::chrono::milliseconds::rep>("queue_wait_time", m_default_queue_wait_time));

--- a/fly/logger/logger_config.hpp
+++ b/fly/logger/logger_config.hpp
@@ -26,17 +26,17 @@ public:
     /**
      * @return Max log file size (in bytes) before rotating the log file.
      */
-    std::uintmax_t max_log_file_size() const noexcept;
+    std::uintmax_t max_log_file_size() const;
 
     /**
      * @return Max message size (in bytes) per log.
      */
-    std::uint32_t max_message_size() const noexcept;
+    std::uint32_t max_message_size() const;
 
     /**
      * @return Sleep time for logger IO thread.
      */
-    std::chrono::milliseconds queue_wait_time() const noexcept;
+    std::chrono::milliseconds queue_wait_time() const;
 
 protected:
     std::uintmax_t m_default_max_log_file_size;

--- a/fly/parser/ini_parser.cpp
+++ b/fly/parser/ini_parser.cpp
@@ -8,7 +8,7 @@
 namespace fly {
 
 //==================================================================================================
-Json IniParser::parse_internal(std::istream &stream) noexcept(false)
+Json IniParser::parse_internal(std::istream &stream)
 {
     std::string line, section;
     Json values;
@@ -40,7 +40,7 @@ Json IniParser::parse_internal(std::istream &stream) noexcept(false)
 }
 
 //==================================================================================================
-std::string IniParser::on_section(const std::string &line) noexcept(false)
+std::string IniParser::on_section(const std::string &line)
 {
     std::string section = line;
     String::trim(section);
@@ -54,7 +54,7 @@ std::string IniParser::on_section(const std::string &line) noexcept(false)
 }
 
 //==================================================================================================
-void IniParser::on_value(Json &section, const std::string &line) noexcept(false)
+void IniParser::on_value(Json &section, const std::string &line)
 {
     static constexpr std::uint32_t s_size = 2;
 
@@ -84,13 +84,13 @@ void IniParser::on_value(Json &section, const std::string &line) noexcept(false)
 }
 
 //==================================================================================================
-bool IniParser::trim_value(std::string &str, char ch) const noexcept(false)
+bool IniParser::trim_value(std::string &str, char ch) const
 {
     return trim_value(str, ch, ch);
 }
 
 //==================================================================================================
-bool IniParser::trim_value(std::string &str, char start, char end) const noexcept(false)
+bool IniParser::trim_value(std::string &str, char start, char end) const
 {
     bool starts_with_char = String::starts_with(str, start);
     bool ends_with_char = String::ends_with(str, end);

--- a/fly/parser/ini_parser.hpp
+++ b/fly/parser/ini_parser.hpp
@@ -26,7 +26,7 @@ protected:
      *
      * @throws ParserException Thrown if an error occurs parsing the stream.
      */
-    Json parse_internal(std::istream &stream) noexcept(false) override;
+    Json parse_internal(std::istream &stream) override;
 
 private:
     /**
@@ -38,7 +38,7 @@ private:
      *
      * @throws ParserException Thrown if the section name is quoted.
      */
-    std::string on_section(const std::string &line) noexcept(false);
+    std::string on_section(const std::string &line);
 
     /**
      * Parse a line containing a name/value pair.
@@ -49,7 +49,7 @@ private:
      * @throws ParserException Thrown if the value name is quoted, or the line both a name and value
      *         are not found.
      */
-    void on_value(Json &section, const std::string &line) noexcept(false);
+    void on_value(Json &section, const std::string &line);
 
     /**
      * If the given string begins and ends with the given character, remove that character from each
@@ -63,7 +63,7 @@ private:
      * @throws ParserException Thrown if the character was found at one end of the string, but not
      *         the other.
      */
-    bool trim_value(std::string &str, char ch) const noexcept(false);
+    bool trim_value(std::string &str, char ch) const;
 
     /**
      * If the given string begins with the first given character and ends with the second given
@@ -78,7 +78,7 @@ private:
      * @throws ParserException Thrown if the one of the start/end characters was found, but not the
      *         other.
      */
-    bool trim_value(std::string &str, char start, char end) const noexcept(false);
+    bool trim_value(std::string &str, char start, char end) const;
 };
 
 } // namespace fly

--- a/fly/parser/json_parser.cpp
+++ b/fly/parser/json_parser.cpp
@@ -18,7 +18,7 @@ JsonParser::JsonParser(const Features features) noexcept : Parser(), m_features(
 }
 
 //==================================================================================================
-Json JsonParser::parse_internal(std::istream &stream) noexcept(false)
+Json JsonParser::parse_internal(std::istream &stream)
 {
     Json json;
 
@@ -49,7 +49,7 @@ Json JsonParser::parse_internal(std::istream &stream) noexcept(false)
 }
 
 //==================================================================================================
-Json JsonParser::parse_json(std::istream &stream) noexcept(false)
+Json JsonParser::parse_json(std::istream &stream)
 {
     consume_whitespace_and_comments(stream);
 
@@ -67,12 +67,12 @@ Json JsonParser::parse_json(std::istream &stream) noexcept(false)
 }
 
 //==================================================================================================
-Json JsonParser::parse_object(std::istream &stream) noexcept(false)
+Json JsonParser::parse_object(std::istream &stream)
 {
     Json object = JsonTraits::object_type();
     consume_token(stream, Token::StartBrace);
 
-    auto stop_parsing = [&stream, this]() noexcept(false) {
+    auto stop_parsing = [&stream, this]() {
         consume_whitespace_and_comments(stream);
         const Token token = peek(stream);
 
@@ -102,12 +102,12 @@ Json JsonParser::parse_object(std::istream &stream) noexcept(false)
 }
 
 //==================================================================================================
-Json JsonParser::parse_array(std::istream &stream) noexcept(false)
+Json JsonParser::parse_array(std::istream &stream)
 {
     Json array = JsonTraits::array_type();
     consume_token(stream, Token::StartBracket);
 
-    auto stop_parsing = [&stream, this]() noexcept(false) {
+    auto stop_parsing = [&stream, this]() {
         consume_whitespace_and_comments(stream);
         const Token token = peek(stream);
 
@@ -129,7 +129,7 @@ Json JsonParser::parse_array(std::istream &stream) noexcept(false)
 }
 
 //==================================================================================================
-Json JsonParser::parse_value(std::istream &stream) noexcept(false)
+Json JsonParser::parse_value(std::istream &stream)
 {
     const bool is_string = peek(stream) == Token::Quote;
 
@@ -179,7 +179,7 @@ Json JsonParser::parse_value(std::istream &stream) noexcept(false)
 }
 
 //==================================================================================================
-void JsonParser::consume_token(std::istream &stream, const Token &token) noexcept(false)
+void JsonParser::consume_token(std::istream &stream, const Token &token)
 {
     consume_whitespace(stream);
 
@@ -192,9 +192,7 @@ void JsonParser::consume_token(std::istream &stream, const Token &token) noexcep
 }
 
 //==================================================================================================
-bool JsonParser::consume_comma(
-    std::istream &stream,
-    const std::function<bool()> &stop_parsing) noexcept(false)
+bool JsonParser::consume_comma(std::istream &stream, const std::function<bool()> &stop_parsing)
 {
     consume_token(stream, Token::Comma);
 
@@ -212,13 +210,12 @@ bool JsonParser::consume_comma(
 }
 
 //==================================================================================================
-JsonTraits::string_type
-JsonParser::consume_value(std::istream &stream, JsonType type) noexcept(false)
+JsonTraits::string_type JsonParser::consume_value(std::istream &stream, JsonType type)
 {
     Json::stream_type parsing;
     Token token;
 
-    auto stop_parsing = [&token, &type, this]() noexcept {
+    auto stop_parsing = [&token, &type, this]() {
         if (type == JsonType::JsonString)
         {
             return token == Token::Quote;
@@ -264,7 +261,7 @@ JsonParser::consume_value(std::istream &stream, JsonType type) noexcept(false)
 }
 
 //==================================================================================================
-void JsonParser::consume_whitespace_and_comments(std::istream &stream) noexcept(false)
+void JsonParser::consume_whitespace_and_comments(std::istream &stream)
 {
     consume_whitespace(stream);
 
@@ -279,7 +276,7 @@ void JsonParser::consume_whitespace_and_comments(std::istream &stream) noexcept(
 }
 
 //==================================================================================================
-void JsonParser::consume_whitespace(std::istream &stream) noexcept
+void JsonParser::consume_whitespace(std::istream &stream)
 {
     Token token;
 
@@ -290,7 +287,7 @@ void JsonParser::consume_whitespace(std::istream &stream) noexcept
 }
 
 //==================================================================================================
-void JsonParser::consume_comment(std::istream &stream) noexcept(false)
+void JsonParser::consume_comment(std::istream &stream)
 {
     if (!is_feature_allowed(Features::AllowComments))
     {
@@ -330,13 +327,13 @@ void JsonParser::consume_comment(std::istream &stream) noexcept(false)
 }
 
 //==================================================================================================
-JsonParser::Token JsonParser::peek(std::istream &stream) noexcept
+JsonParser::Token JsonParser::peek(std::istream &stream)
 {
     return static_cast<Token>(stream.peek());
 }
 
 //==================================================================================================
-JsonParser::Token JsonParser::consume(std::istream &stream) noexcept
+JsonParser::Token JsonParser::consume(std::istream &stream)
 {
     const Token token = static_cast<Token>(stream.get());
 
@@ -354,26 +351,26 @@ JsonParser::Token JsonParser::consume(std::istream &stream) noexcept
 }
 
 //==================================================================================================
-void JsonParser::discard(std::istream &stream) noexcept
+void JsonParser::discard(std::istream &stream)
 {
     FLY_UNUSED(consume(stream));
 }
 
 //==================================================================================================
 JsonParser::NumericType JsonParser::validate_number(const JsonTraits::string_type &value) const
-    noexcept(false)
+
 {
     const bool is_signed = value[0] == '-';
 
     const auto signless = std::basic_string_view<JsonTraits::string_type::value_type>(value).substr(
         is_signed ? 1 : 0);
 
-    auto is_octal = [&signless]() noexcept -> bool {
+    auto is_octal = [&signless]() -> bool {
         return (signless.size() > 1) && (signless[0] == '0') &&
             std::isdigit(static_cast<unsigned char>(signless[1]));
     };
 
-    auto is_float = [this, &value, &signless]() noexcept(false) -> bool {
+    auto is_float = [this, &value, &signless]() -> bool {
         const JsonTraits::string_type::size_type d = signless.find('.');
         const JsonTraits::string_type::size_type e1 = signless.find('e');
         const JsonTraits::string_type::size_type e2 = signless.find('E');
@@ -422,7 +419,7 @@ JsonParser::NumericType JsonParser::validate_number(const JsonTraits::string_typ
 }
 
 //==================================================================================================
-bool JsonParser::is_whitespace(const Token &token) const noexcept
+bool JsonParser::is_whitespace(const Token &token) const
 {
     switch (token)
     {
@@ -439,13 +436,13 @@ bool JsonParser::is_whitespace(const Token &token) const noexcept
 }
 
 //==================================================================================================
-bool JsonParser::is_feature_allowed(Features feature) const noexcept
+bool JsonParser::is_feature_allowed(Features feature) const
 {
     return (m_features & feature) != Features::Strict;
 }
 
 //==================================================================================================
-JsonParser::Features operator&(JsonParser::Features a, JsonParser::Features b) noexcept
+JsonParser::Features operator&(JsonParser::Features a, JsonParser::Features b)
 {
     return static_cast<JsonParser::Features>(
         static_cast<std::underlying_type_t<JsonParser::Features>>(a) &
@@ -453,7 +450,7 @@ JsonParser::Features operator&(JsonParser::Features a, JsonParser::Features b) n
 }
 
 //==================================================================================================
-JsonParser::Features operator|(JsonParser::Features a, JsonParser::Features b) noexcept
+JsonParser::Features operator|(JsonParser::Features a, JsonParser::Features b)
 {
     return static_cast<JsonParser::Features>(
         static_cast<std::underlying_type_t<JsonParser::Features>>(a) |
@@ -464,7 +461,7 @@ JsonParser::Features operator|(JsonParser::Features a, JsonParser::Features b) n
 JsonParser::UnexpectedTokenException::UnexpectedTokenException(
     std::uint32_t line,
     std::uint32_t column,
-    JsonParser::Token token) :
+    JsonParser::Token token) noexcept :
     UnexpectedCharacterException(line, column, static_cast<int>(token))
 {
 }

--- a/fly/parser/json_parser.hpp
+++ b/fly/parser/json_parser.hpp
@@ -68,7 +68,7 @@ protected:
      * @throws UnexpectedCharacterException A parsed symbol was unexpected.
      * @throws BadConversionException A parsed value could not be converted to a JSON type.
      */
-    Json parse_internal(std::istream &stream) noexcept(false) override;
+    Json parse_internal(std::istream &stream) override;
 
 private:
     /**
@@ -125,7 +125,10 @@ private:
     class UnexpectedTokenException : public UnexpectedCharacterException
     {
     public:
-        UnexpectedTokenException(std::uint32_t line, std::uint32_t column, JsonParser::Token token);
+        UnexpectedTokenException(
+            std::uint32_t line,
+            std::uint32_t column,
+            JsonParser::Token token) noexcept;
     };
 
     /**
@@ -138,7 +141,7 @@ private:
      * @throws UnexpectedCharacterException A parsed symbol was unexpected.
      * @throws BadConversionException A parsed value could not be converted to a JSON type.
      */
-    Json parse_json(std::istream &stream) noexcept(false);
+    Json parse_json(std::istream &stream);
 
     /**
      * Parse a JSON object from a stream.
@@ -150,7 +153,7 @@ private:
      * @throws UnexpectedCharacterException A parsed symbol was unexpected.
      * @throws BadConversionException A parsed value could not be converted to a JSON type.
      */
-    Json parse_object(std::istream &stream) noexcept(false);
+    Json parse_object(std::istream &stream);
 
     /**
      * Parse a JSON array from a stream.
@@ -162,7 +165,7 @@ private:
      * @throws UnexpectedCharacterException A parsed symbol was unexpected.
      * @throws BadConversionException A parsed value could not be converted to a JSON type.
      */
-    Json parse_array(std::istream &stream) noexcept(false);
+    Json parse_array(std::istream &stream);
 
     /**
      * Parse a JSON string, number, boolean, or null value from a stream.
@@ -174,7 +177,7 @@ private:
      * @throws UnexpectedCharacterException A parsed symbol was unexpected.
      * @throws BadConversionException A parsed value could not be converted to a JSON type.
      */
-    Json parse_value(std::istream &stream) noexcept(false);
+    Json parse_value(std::istream &stream);
 
     /**
      * Extract a single symbol from a stream. Ensure that symbol is equal to an expected token.
@@ -183,7 +186,7 @@ private:
      *
      * @throws UnexpectedCharacterException A parsed symbol was unexpected.
      */
-    void consume_token(std::istream &stream, const Token &token) noexcept(false);
+    void consume_token(std::istream &stream, const Token &token);
 
     /**
      * Extract a comma from a stream. Handles any trailing commas, allowing a single trailing comma
@@ -197,8 +200,7 @@ private:
      * @throws UnexpectedCharacterException A trailing comma was found, but the feature is not
      *         enabled.
      */
-    bool
-    consume_comma(std::istream &stream, const std::function<bool()> &stop_parsing) noexcept(false);
+    bool consume_comma(std::istream &stream, const std::function<bool()> &stop_parsing);
 
     /**
      * Extract a string, number, boolean, or null value from a stream. If parsing a string, escaped
@@ -212,7 +214,7 @@ private:
      *
      * @throws UnexpectedCharacterException A parsed symbol was unexpected.
      */
-    JsonTraits::string_type consume_value(std::istream &stream, JsonType type) noexcept(false);
+    JsonTraits::string_type consume_value(std::istream &stream, JsonType type);
 
     /**
      * Extract all consecutive whitespace symbols and comments (if enabled in the feature set) from
@@ -222,7 +224,7 @@ private:
      *
      * @throws UnexpectedCharacterException A parsed symbol was unexpected.
      */
-    void consume_whitespace_and_comments(std::istream &stream) noexcept(false);
+    void consume_whitespace_and_comments(std::istream &stream);
 
     /**
      * Extract all consecutive whitespace symbols from a stream until a non- whitespace symbol is
@@ -230,7 +232,7 @@ private:
      *
      * @param stream Stream holding the contents to parse.
      */
-    void consume_whitespace(std::istream &stream) noexcept;
+    void consume_whitespace(std::istream &stream);
 
     /**
      * Extract a single- or multi-line comment from a stream, if enabled in the feature set.
@@ -240,7 +242,7 @@ private:
      * @throws UnexpectedCharacterException A parsed symbol was unexpected, or the comment feature
      *         is not enabled.
      */
-    void consume_comment(std::istream &stream) noexcept(false);
+    void consume_comment(std::istream &stream);
 
     /**
      * Read the next symbol in a stream without extracting it.
@@ -249,7 +251,7 @@ private:
      *
      * @return The peeked symbol.
      */
-    Token peek(std::istream &stream) noexcept;
+    Token peek(std::istream &stream);
 
     /**
      * Extract the next symbol in a stream.
@@ -258,14 +260,14 @@ private:
      *
      * @return The extracted symbol.
      */
-    Token consume(std::istream &stream) noexcept;
+    Token consume(std::istream &stream);
 
     /**
      * Extract the next symbol in a stream and discard it.
      *
      * @param stream Stream holding the contents to parse.
      */
-    void discard(std::istream &stream) noexcept;
+    void discard(std::istream &stream);
 
     /**
      * Validate that a parsed number is valid and interpret its numeric JSON type.
@@ -276,7 +278,7 @@ private:
      *
      * @throws BadConversionException The parsed number is not valid.
      */
-    NumericType validate_number(const JsonTraits::string_type &value) const noexcept(false);
+    NumericType validate_number(const JsonTraits::string_type &value) const;
 
     /**
      * Check if a symbol is a whitespace symbol.
@@ -285,7 +287,7 @@ private:
      *
      * @return True if the symbol is whitespace.
      */
-    bool is_whitespace(const Token &token) const noexcept;
+    bool is_whitespace(const Token &token) const;
 
     /**
      * Check if a feature has been allowed.
@@ -294,7 +296,7 @@ private:
      *
      * @return True if the feature is allowed.
      */
-    bool is_feature_allowed(Features feature) const noexcept;
+    bool is_feature_allowed(Features feature) const;
 
     const Features m_features;
 };
@@ -302,11 +304,11 @@ private:
 /**
  * Combine two Features instances into a single instance via bitwise-and.
  */
-JsonParser::Features operator&(JsonParser::Features a, JsonParser::Features b) noexcept;
+JsonParser::Features operator&(JsonParser::Features a, JsonParser::Features b);
 
 /**
  * Combine two Features instances into a single instance via bitwise-or.
  */
-JsonParser::Features operator|(JsonParser::Features a, JsonParser::Features b) noexcept;
+JsonParser::Features operator|(JsonParser::Features a, JsonParser::Features b);
 
 } // namespace fly

--- a/fly/parser/parser.cpp
+++ b/fly/parser/parser.cpp
@@ -6,7 +6,7 @@
 namespace fly {
 
 //==================================================================================================
-Json Parser::parse_string(const std::string &contents) noexcept(false)
+Json Parser::parse_string(const std::string &contents)
 {
     std::istringstream stream(contents);
 
@@ -18,7 +18,7 @@ Json Parser::parse_string(const std::string &contents) noexcept(false)
 }
 
 //==================================================================================================
-Json Parser::parse_file(const std::filesystem::path &path) noexcept(false)
+Json Parser::parse_file(const std::filesystem::path &path)
 {
     std::ifstream stream(path);
 
@@ -30,7 +30,7 @@ Json Parser::parse_file(const std::filesystem::path &path) noexcept(false)
 }
 
 //==================================================================================================
-void Parser::consume_byte_order_mark(std::istream &stream) const noexcept
+void Parser::consume_byte_order_mark(std::istream &stream) const
 {
     if (stream && (stream.peek() != EOF))
     {

--- a/fly/parser/parser.hpp
+++ b/fly/parser/parser.hpp
@@ -33,7 +33,7 @@ public:
      *
      * @throws ParserException Thrown if an error occurs parsing the string.
      */
-    Json parse_string(const std::string &contents) noexcept(false);
+    Json parse_string(const std::string &contents);
 
     /**
      * Parse a file and retrieve parsed values.
@@ -44,7 +44,7 @@ public:
      *
      * @throws ParserException Thrown if an error occurs parsing the file.
      */
-    Json parse_file(const std::filesystem::path &path) noexcept(false);
+    Json parse_file(const std::filesystem::path &path);
 
 protected:
     /**
@@ -56,7 +56,7 @@ protected:
      *
      * @throws ParserException Thrown if an error occurs parsing the stream.
      */
-    virtual Json parse_internal(std::istream &stream) noexcept(false) = 0;
+    virtual Json parse_internal(std::istream &stream) = 0;
 
     std::uint32_t m_line;
     std::uint32_t m_column;
@@ -68,7 +68,7 @@ private:
      *
      * @param stream Stream holding the contents to parse.
      */
-    void consume_byte_order_mark(std::istream &stream) const noexcept;
+    void consume_byte_order_mark(std::istream &stream) const;
 };
 
 } // namespace fly

--- a/fly/path/nix/path_monitor_impl.cpp
+++ b/fly/path/nix/path_monitor_impl.cpp
@@ -44,13 +44,13 @@ PathMonitorImpl::~PathMonitorImpl()
 }
 
 //==================================================================================================
-bool PathMonitorImpl::is_valid() const noexcept
+bool PathMonitorImpl::is_valid() const
 {
     return m_monitor_descriptor != -1;
 }
 
 //==================================================================================================
-void PathMonitorImpl::poll(const std::chrono::milliseconds &timeout) noexcept
+void PathMonitorImpl::poll(const std::chrono::milliseconds &timeout)
 {
     pollfd poll_fd;
 
@@ -75,7 +75,7 @@ void PathMonitorImpl::poll(const std::chrono::milliseconds &timeout) noexcept
 
 //==================================================================================================
 std::unique_ptr<PathMonitor::PathInfo>
-PathMonitorImpl::create_path_info(const std::filesystem::path &path) const noexcept
+PathMonitorImpl::create_path_info(const std::filesystem::path &path) const
 {
     std::unique_ptr<PathMonitor::PathInfo> info;
 
@@ -88,7 +88,7 @@ PathMonitorImpl::create_path_info(const std::filesystem::path &path) const noexc
 }
 
 //==================================================================================================
-bool PathMonitorImpl::read_events() const noexcept
+bool PathMonitorImpl::read_events() const
 {
     static constexpr const std::size_t s_event_size = sizeof(inotify_event);
 
@@ -125,7 +125,7 @@ bool PathMonitorImpl::read_events() const noexcept
 }
 
 //==================================================================================================
-void PathMonitorImpl::handle_event(const inotify_event *event) const noexcept
+void PathMonitorImpl::handle_event(const inotify_event *event) const
 {
     auto path_it = std::find_if(
         m_path_info.begin(),
@@ -168,7 +168,7 @@ void PathMonitorImpl::handle_event(const inotify_event *event) const noexcept
 }
 
 //==================================================================================================
-PathMonitor::PathEvent PathMonitorImpl::convert_to_event(std::uint32_t mask) const noexcept
+PathMonitor::PathEvent PathMonitorImpl::convert_to_event(std::uint32_t mask) const
 {
     PathMonitor::PathEvent path_event = PathMonitor::PathEvent::None;
 
@@ -216,7 +216,7 @@ PathMonitorImpl::PathInfoImpl::~PathInfoImpl()
 }
 
 //==================================================================================================
-bool PathMonitorImpl::PathInfoImpl::is_valid() const noexcept
+bool PathMonitorImpl::PathInfoImpl::is_valid() const
 {
     return m_watch_descriptor != -1;
 }

--- a/fly/path/nix/path_monitor_impl.hpp
+++ b/fly/path/nix/path_monitor_impl.hpp
@@ -40,7 +40,7 @@ protected:
      *
      * @return True if the inotify handle is valid.
      */
-    bool is_valid() const noexcept override;
+    bool is_valid() const override;
 
     /**
      * Check if the path monitor's inotify handle has any events to be read, and handle any that are
@@ -48,10 +48,10 @@ protected:
      *
      * @param timeout Max time allow for an event to be readable.
      */
-    void poll(const std::chrono::milliseconds &timeout) noexcept override;
+    void poll(const std::chrono::milliseconds &timeout) override;
 
     std::unique_ptr<PathMonitor::PathInfo>
-    create_path_info(const std::filesystem::path &path) const noexcept override;
+    create_path_info(const std::filesystem::path &path) const override;
 
 private:
     /**
@@ -66,7 +66,7 @@ private:
         /**
          * @return True if initialization was sucessful.
          */
-        bool is_valid() const noexcept override;
+        bool is_valid() const override;
 
         int m_monitor_descriptor;
         int m_watch_descriptor;
@@ -77,14 +77,14 @@ private:
      *
      * @return True if any events were read.
      */
-    bool read_events() const noexcept;
+    bool read_events() const;
 
     /**
      * Handle a single inotify event. Find a monitored path that corresponds
      * to the event and trigger its callback. If no path was found, drop the
      * event.
      */
-    void handle_event(const inotify_event *event) const noexcept;
+    void handle_event(const inotify_event *event) const;
 
     /**
      * Convert an inotify event mask to a PathEvent.
@@ -93,7 +93,7 @@ private:
      *
      * @return A PathEvent that matches the event mask.
      */
-    PathMonitor::PathEvent convert_to_event(std::uint32_t mask) const noexcept;
+    PathMonitor::PathEvent convert_to_event(std::uint32_t mask) const;
 
     int m_monitor_descriptor;
 };

--- a/fly/path/path_config.cpp
+++ b/fly/path/path_config.cpp
@@ -10,7 +10,7 @@ PathConfig::PathConfig() noexcept : m_default_poll_interval(1000_i64)
 }
 
 //==================================================================================================
-std::chrono::milliseconds PathConfig::poll_interval() const noexcept
+std::chrono::milliseconds PathConfig::poll_interval() const
 {
     return std::chrono::milliseconds(
         get_value<std::chrono::milliseconds::rep>("poll_interval", m_default_poll_interval));

--- a/fly/path/path_config.hpp
+++ b/fly/path/path_config.hpp
@@ -25,7 +25,7 @@ public:
     /**
      * @return Delay between path monitor poll intervals.
      */
-    virtual std::chrono::milliseconds poll_interval() const noexcept;
+    virtual std::chrono::milliseconds poll_interval() const;
 
 protected:
     std::chrono::milliseconds::rep m_default_poll_interval;

--- a/fly/path/path_monitor.cpp
+++ b/fly/path/path_monitor.cpp
@@ -24,7 +24,7 @@ PathMonitor::~PathMonitor()
 }
 
 //==================================================================================================
-bool PathMonitor::start() noexcept
+bool PathMonitor::start()
 {
     if (is_valid())
     {
@@ -40,7 +40,7 @@ bool PathMonitor::start() noexcept
 }
 
 //==================================================================================================
-bool PathMonitor::add_path(const std::filesystem::path &path, PathEventCallback callback) noexcept
+bool PathMonitor::add_path(const std::filesystem::path &path, PathEventCallback callback)
 {
     std::error_code error;
 
@@ -70,7 +70,7 @@ bool PathMonitor::add_path(const std::filesystem::path &path, PathEventCallback 
 }
 
 //==================================================================================================
-bool PathMonitor::remove_path(const std::filesystem::path &path) noexcept
+bool PathMonitor::remove_path(const std::filesystem::path &path)
 {
     std::lock_guard<std::mutex> lock(m_mutex);
     auto it = m_path_info.find(path);
@@ -88,7 +88,7 @@ bool PathMonitor::remove_path(const std::filesystem::path &path) noexcept
 }
 
 //==================================================================================================
-void PathMonitor::remove_all_paths() noexcept
+void PathMonitor::remove_all_paths()
 {
     std::lock_guard<std::mutex> lock(m_mutex);
 
@@ -97,7 +97,7 @@ void PathMonitor::remove_all_paths() noexcept
 }
 
 //==================================================================================================
-bool PathMonitor::add_file(const std::filesystem::path &file, PathEventCallback callback) noexcept
+bool PathMonitor::add_file(const std::filesystem::path &file, PathEventCallback callback)
 {
     std::error_code error;
 
@@ -131,7 +131,7 @@ bool PathMonitor::add_file(const std::filesystem::path &file, PathEventCallback 
 }
 
 //==================================================================================================
-bool PathMonitor::remove_file(const std::filesystem::path &file) noexcept
+bool PathMonitor::remove_file(const std::filesystem::path &file)
 {
     bool prune_path = false;
     {
@@ -163,8 +163,7 @@ bool PathMonitor::remove_file(const std::filesystem::path &file) noexcept
 }
 
 //==================================================================================================
-PathMonitor::PathInfo *
-PathMonitor::get_or_create_path_info(const std::filesystem::path &path) noexcept
+PathMonitor::PathInfo *PathMonitor::get_or_create_path_info(const std::filesystem::path &path)
 {
     PathInfo *info = nullptr;
 
@@ -189,7 +188,7 @@ PathMonitor::get_or_create_path_info(const std::filesystem::path &path) noexcept
 }
 
 //==================================================================================================
-std::ostream &operator<<(std::ostream &stream, PathMonitor::PathEvent event) noexcept
+std::ostream &operator<<(std::ostream &stream, PathMonitor::PathEvent event)
 {
     switch (event)
     {
@@ -221,7 +220,7 @@ PathMonitorTask::PathMonitorTask(std::weak_ptr<PathMonitor> weak_path_monitor) n
 }
 
 //==================================================================================================
-void PathMonitorTask::run() noexcept
+void PathMonitorTask::run()
 {
     std::shared_ptr<PathMonitor> path_monitor = m_weak_path_monitor.lock();
 

--- a/fly/path/path_monitor.hpp
+++ b/fly/path/path_monitor.hpp
@@ -65,7 +65,7 @@ public:
      *
      * @return True if the path monitor is in a valid state.
      */
-    bool start() noexcept;
+    bool start();
 
     /**
      * Monitor for changes to all files under a directory. Callbacks registered with AddFile take
@@ -76,7 +76,7 @@ public:
      *
      * @return True if the directory could be added.
      */
-    bool add_path(const std::filesystem::path &path, PathEventCallback callback) noexcept;
+    bool add_path(const std::filesystem::path &path, PathEventCallback callback);
 
     /**
      * Stop monitoring for changes to all files under a directory.
@@ -85,12 +85,12 @@ public:
      *
      * @return True if the directory was removed.
      */
-    bool remove_path(const std::filesystem::path &path) noexcept;
+    bool remove_path(const std::filesystem::path &path);
 
     /**
      * Stop monitoring all paths.
      */
-    void remove_all_paths() noexcept;
+    void remove_all_paths();
 
     /**
      * Monitor for changes to a single file. Callbacks registered with AddFile take precendence over
@@ -101,7 +101,7 @@ public:
      *
      * @return True if the file could be added.
      */
-    bool add_file(const std::filesystem::path &file, PathEventCallback callback) noexcept;
+    bool add_file(const std::filesystem::path &file, PathEventCallback callback);
 
     /**
      * Stop monitoring for changes to a single file. If there are no more files monitored in the
@@ -112,7 +112,7 @@ public:
      *
      * @return True if the file was removed.
      */
-    bool remove_file(const std::filesystem::path &file) noexcept;
+    bool remove_file(const std::filesystem::path &file);
 
 protected:
     /**
@@ -131,7 +131,7 @@ protected:
          *
          * @return True if the monitored path is healthy.
          */
-        virtual bool is_valid() const noexcept = 0;
+        virtual bool is_valid() const = 0;
 
         PathEventCallback m_path_handler;
         std::map<std::filesystem::path, PathEventCallback> m_file_handlers;
@@ -149,22 +149,21 @@ protected:
      *
      * @return Up-casted pointer to the PathInfo struct.
      */
-    virtual std::unique_ptr<PathInfo>
-    create_path_info(const std::filesystem::path &path) const noexcept = 0;
+    virtual std::unique_ptr<PathInfo> create_path_info(const std::filesystem::path &path) const = 0;
 
     /**
      * Check if the path monitor implementation is valid.
      *
      * @return True if the implementation is valid.
      */
-    virtual bool is_valid() const noexcept = 0;
+    virtual bool is_valid() const = 0;
 
     /**
      * Check the path monitor implementation for any changes to the monitored paths.
      *
      * @param timeout Max time allow for an event to be occur.
      */
-    virtual void poll(const std::chrono::milliseconds &timeout) noexcept = 0;
+    virtual void poll(const std::chrono::milliseconds &timeout) = 0;
 
     mutable std::mutex m_mutex;
     PathInfoMap m_path_info;
@@ -178,12 +177,12 @@ private:
      *
      * @return Shared pointer to the PathInfo struct.
      */
-    PathInfo *get_or_create_path_info(const std::filesystem::path &path) noexcept;
+    PathInfo *get_or_create_path_info(const std::filesystem::path &path);
 
     /**
      * Stream the name of a PathEvent instance.
      */
-    friend std::ostream &operator<<(std::ostream &stream, PathEvent event) noexcept;
+    friend std::ostream &operator<<(std::ostream &stream, PathEvent event);
 
     std::shared_ptr<SequencedTaskRunner> m_task_runner;
     std::shared_ptr<Task> m_task;
@@ -207,7 +206,7 @@ protected:
      * Call back into the path monitor to check for any changes to the monitored paths. If the path
      * monitor implementation is still valid, the task re-arms itself.
      */
-    void run() noexcept override;
+    void run() override;
 
 private:
     std::weak_ptr<PathMonitor> m_weak_path_monitor;

--- a/fly/path/win/path_monitor_impl.cpp
+++ b/fly/path/win/path_monitor_impl.cpp
@@ -49,13 +49,13 @@ PathMonitorImpl::~PathMonitorImpl()
 }
 
 //==================================================================================================
-bool PathMonitorImpl::is_valid() const noexcept
+bool PathMonitorImpl::is_valid() const
 {
     return m_iocp != nullptr;
 }
 
 //==================================================================================================
-void PathMonitorImpl::poll(const std::chrono::milliseconds &timeout) noexcept
+void PathMonitorImpl::poll(const std::chrono::milliseconds &timeout)
 {
     DWORD bytes = 0;
     ULONG_PTR key = 0;
@@ -97,7 +97,7 @@ void PathMonitorImpl::poll(const std::chrono::milliseconds &timeout) noexcept
 
 //==================================================================================================
 std::unique_ptr<PathMonitor::PathInfo>
-PathMonitorImpl::create_path_info(const std::filesystem::path &path) const noexcept
+PathMonitorImpl::create_path_info(const std::filesystem::path &path) const
 {
     std::unique_ptr<PathMonitor::PathInfo> info;
 
@@ -111,7 +111,7 @@ PathMonitorImpl::create_path_info(const std::filesystem::path &path) const noexc
 
 //==================================================================================================
 void PathMonitorImpl::handle_events(const PathInfoImpl *info, const std::filesystem::path &path)
-    const noexcept
+    const
 {
     PFILE_NOTIFY_INFORMATION file_info = info->m_file_info;
 
@@ -161,7 +161,7 @@ void PathMonitorImpl::handle_events(const PathInfoImpl *info, const std::filesys
 }
 
 //==================================================================================================
-PathMonitor::PathEvent PathMonitorImpl::convert_to_event(DWORD action) const noexcept
+PathMonitor::PathEvent PathMonitorImpl::convert_to_event(DWORD action) const
 {
     PathMonitor::PathEvent path_event = PathMonitor::PathEvent::None;
 
@@ -242,13 +242,13 @@ PathMonitorImpl::PathInfoImpl::~PathInfoImpl()
 }
 
 //==================================================================================================
-bool PathMonitorImpl::PathInfoImpl::is_valid() const noexcept
+bool PathMonitorImpl::PathInfoImpl::is_valid() const
 {
     return m_valid && (m_handle != INVALID_HANDLE_VALUE);
 }
 
 //==================================================================================================
-bool PathMonitorImpl::PathInfoImpl::refresh(const std::filesystem::path &path) noexcept
+bool PathMonitorImpl::PathInfoImpl::refresh(const std::filesystem::path &path)
 {
     static const DWORD size = (s_buff_size * sizeof(FILE_NOTIFY_INFORMATION));
     DWORD bytes = 0;

--- a/fly/path/win/path_monitor_impl.hpp
+++ b/fly/path/win/path_monitor_impl.hpp
@@ -41,7 +41,7 @@ protected:
      *
      * @return True if the IOCP is valid.
      */
-    bool is_valid() const noexcept override;
+    bool is_valid() const override;
 
     /**
      * Check if the path monitor's IOCP has any posted completions, and handle any that have been
@@ -49,10 +49,10 @@ protected:
      *
      * @param timeout Max time allow for a completion to be posted.
      */
-    void poll(const std::chrono::milliseconds &timeout) noexcept override;
+    void poll(const std::chrono::milliseconds &timeout) override;
 
     std::unique_ptr<PathMonitor::PathInfo>
-    create_path_info(const std::filesystem::path &path) const noexcept override;
+    create_path_info(const std::filesystem::path &path) const override;
 
 private:
     /**
@@ -68,7 +68,7 @@ private:
         /**
          * @return True if initialization was sucessful.
          */
-        bool is_valid() const noexcept override;
+        bool is_valid() const override;
 
         /**
          * Call the ReadDirectoryChangesW API for this path. Should be called after initialization
@@ -76,7 +76,7 @@ private:
          *
          * @param path Name of the monitored path.
          */
-        bool refresh(const std::filesystem::path &path) noexcept;
+        bool refresh(const std::filesystem::path &path);
 
         bool m_valid;
         HANDLE m_handle;
@@ -90,7 +90,7 @@ private:
      * @param info The path's entry in the PathInfo map.
      * @param path Name of the path.
      */
-    void handle_events(const PathInfoImpl *info, const std::filesystem::path &path) const noexcept;
+    void handle_events(const PathInfoImpl *info, const std::filesystem::path &path) const;
 
     /**
      * Convert a FILE_NOTIFY_INFORMATION event to a PathEvent.
@@ -99,7 +99,7 @@ private:
      *
      * @return A PathEvent that matches the given event.
      */
-    PathMonitor::PathEvent convert_to_event(DWORD action) const noexcept;
+    PathMonitor::PathEvent convert_to_event(DWORD action) const;
 
     HANDLE m_iocp;
 };

--- a/fly/socket/async_request.cpp
+++ b/fly/socket/async_request.cpp
@@ -68,43 +68,43 @@ AsyncRequest &AsyncRequest::operator=(AsyncRequest &&request) noexcept
 }
 
 //==================================================================================================
-bool AsyncRequest::is_valid() const noexcept
+bool AsyncRequest::is_valid() const
 {
     return m_socket_id != s_invalid_id;
 }
 
 //==================================================================================================
-int AsyncRequest::get_socket_id() const noexcept
+int AsyncRequest::get_socket_id() const
 {
     return m_socket_id;
 }
 
 //==================================================================================================
-void AsyncRequest::increment_request_offset(std::string::size_type offset) noexcept
+void AsyncRequest::increment_request_offset(std::string::size_type offset)
 {
     m_request_offset += offset;
 }
 
 //==================================================================================================
-const std::string &AsyncRequest::get_request() const noexcept
+const std::string &AsyncRequest::get_request() const
 {
     return m_request;
 }
 
 //==================================================================================================
-std::string AsyncRequest::get_request_remaining() const noexcept
+std::string AsyncRequest::get_request_remaining() const
 {
     return m_request.substr(m_request_offset, std::string::npos);
 }
 
 //==================================================================================================
-address_type AsyncRequest::get_address() const noexcept
+address_type AsyncRequest::get_address() const
 {
     return m_address;
 }
 
 //==================================================================================================
-port_type AsyncRequest::get_port() const noexcept
+port_type AsyncRequest::get_port() const
 {
     return m_port;
 }

--- a/fly/socket/async_request.hpp
+++ b/fly/socket/async_request.hpp
@@ -52,39 +52,39 @@ public:
     /**
      * @return True if the socket ID is valid (i.e. has been explicitly set).
      */
-    bool is_valid() const noexcept;
+    bool is_valid() const;
 
     /**
      * @return The ID of the socket who owns this structure.
      */
-    int get_socket_id() const noexcept;
+    int get_socket_id() const;
 
     /**
      * Increase the current offset into the request message to mark how much data has been sent.
      *
      * @param offset The offset to set.
      */
-    void increment_request_offset(std::string::size_type offset) noexcept;
+    void increment_request_offset(std::string::size_type offset);
 
     /**
      * @return The request message - the message to be sent or received.
      */
-    const std::string &get_request() const noexcept;
+    const std::string &get_request() const;
 
     /**
      * @return The request message starting at its current offset.
      */
-    std::string get_request_remaining() const noexcept;
+    std::string get_request_remaining() const;
 
     /**
      * @return The request address (for UDP sockets).
      */
-    address_type get_address() const noexcept;
+    address_type get_address() const;
 
     /**
      * @return The request port (for UDP sockets).
      */
-    port_type get_port() const noexcept;
+    port_type get_port() const;
 
 private:
     int m_socket_id;

--- a/fly/socket/nix/socket_impl.cpp
+++ b/fly/socket/nix/socket_impl.cpp
@@ -17,7 +17,7 @@ namespace fly {
 
 namespace {
 
-    struct sockaddr_in create_socket_address(address_type address, port_type port) noexcept
+    struct sockaddr_in create_socket_address(address_type address, port_type port)
     {
         struct sockaddr_in socket_address;
         memset(&socket_address, 0, sizeof(socket_address));
@@ -54,7 +54,7 @@ SocketImpl::~SocketImpl()
 }
 
 //==================================================================================================
-bool SocketImpl::hostname_to_address(const std::string &hostname, address_type &address) noexcept
+bool SocketImpl::hostname_to_address(const std::string &hostname, address_type &address)
 {
     struct hostent *ip_address = ::gethostbyname(hostname.c_str());
 
@@ -76,19 +76,19 @@ bool SocketImpl::hostname_to_address(const std::string &hostname, address_type &
 }
 
 //==================================================================================================
-address_type SocketImpl::in_addr_any() noexcept
+address_type SocketImpl::in_addr_any()
 {
     return INADDR_ANY;
 }
 
 //==================================================================================================
-socket_type SocketImpl::invalid_socket() noexcept
+socket_type SocketImpl::invalid_socket()
 {
     return -1;
 }
 
 //==================================================================================================
-void SocketImpl::close() noexcept
+void SocketImpl::close()
 {
     if (is_valid())
     {
@@ -98,7 +98,7 @@ void SocketImpl::close() noexcept
 }
 
 //==================================================================================================
-bool SocketImpl::is_error_free() noexcept
+bool SocketImpl::is_error_free()
 {
     int opt = -1;
     socklen_t len = sizeof(opt);
@@ -112,7 +112,7 @@ bool SocketImpl::is_error_free() noexcept
 }
 
 //==================================================================================================
-bool SocketImpl::set_async() noexcept
+bool SocketImpl::set_async()
 {
     int flags = ::fcntl(m_socket_handle, F_GETFL, 0);
 
@@ -132,7 +132,7 @@ bool SocketImpl::set_async() noexcept
 }
 
 //==================================================================================================
-bool SocketImpl::bind(address_type address, port_type port, BindOption option) const noexcept
+bool SocketImpl::bind(address_type address, port_type port, BindOption option) const
 {
     static const int s_bind_for_reuse_option = 1;
     static const socklen_t s_bind_for_reuse_option_length = sizeof(s_bind_for_reuse_option);
@@ -170,7 +170,7 @@ bool SocketImpl::bind(address_type address, port_type port, BindOption option) c
 }
 
 //==================================================================================================
-bool SocketImpl::listen() noexcept
+bool SocketImpl::listen()
 {
     if (::listen(m_socket_handle, 100) == -1)
     {
@@ -183,7 +183,7 @@ bool SocketImpl::listen() noexcept
 }
 
 //==================================================================================================
-bool SocketImpl::connect(address_type address, port_type port) noexcept
+bool SocketImpl::connect(address_type address, port_type port)
 {
     struct sockaddr_in socket_address = create_socket_address(address, port);
     auto *p_socket_address = reinterpret_cast<sockaddr *>(&socket_address);
@@ -208,7 +208,7 @@ bool SocketImpl::connect(address_type address, port_type port) noexcept
 }
 
 //==================================================================================================
-std::shared_ptr<Socket> SocketImpl::accept() const noexcept
+std::shared_ptr<Socket> SocketImpl::accept() const
 {
     auto ret = std::make_shared<SocketImpl>(m_protocol, m_config);
 
@@ -237,7 +237,7 @@ std::shared_ptr<Socket> SocketImpl::accept() const noexcept
 }
 
 //==================================================================================================
-std::size_t SocketImpl::send(const std::string &message, bool &would_block) const noexcept
+std::size_t SocketImpl::send(const std::string &message, bool &would_block) const
 {
     std::string to_send = message + std::string(1, m_socket_eom);
 
@@ -285,7 +285,7 @@ std::size_t SocketImpl::send_to(
     const std::string &message,
     address_type address,
     port_type port,
-    bool &would_block) const noexcept
+    bool &would_block) const
 {
     std::string to_send = message + std::string(1, m_socket_eom);
 
@@ -338,7 +338,7 @@ std::size_t SocketImpl::send_to(
 }
 
 //==================================================================================================
-std::string SocketImpl::recv(bool &would_block, bool &is_complete) const noexcept
+std::string SocketImpl::recv(bool &would_block, bool &is_complete) const
 {
     std::string ret;
 
@@ -380,7 +380,7 @@ std::string SocketImpl::recv(bool &would_block, bool &is_complete) const noexcep
 }
 
 //==================================================================================================
-std::string SocketImpl::recv_from(bool &would_block, bool &is_complete) const noexcept
+std::string SocketImpl::recv_from(bool &would_block, bool &is_complete) const
 {
     std::string ret;
 

--- a/fly/socket/nix/socket_impl.hpp
+++ b/fly/socket/nix/socket_impl.hpp
@@ -22,36 +22,36 @@ public:
     SocketImpl(Protocol protocol, const std::shared_ptr<SocketConfig> &config) noexcept;
     ~SocketImpl() override;
 
-    static bool hostname_to_address(const std::string &hostname, address_type &address) noexcept;
+    static bool hostname_to_address(const std::string &hostname, address_type &address);
 
-    static address_type in_addr_any() noexcept;
+    static address_type in_addr_any();
 
-    static socket_type invalid_socket() noexcept;
+    static socket_type invalid_socket();
 
-    void close() noexcept override;
+    void close() override;
 
-    bool is_error_free() noexcept override;
+    bool is_error_free() override;
 
-    bool set_async() noexcept override;
+    bool set_async() override;
 
-    bool bind(address_type address, port_type port, BindOption option) const noexcept override;
+    bool bind(address_type address, port_type port, BindOption option) const override;
 
-    bool listen() noexcept override;
+    bool listen() override;
 
-    bool connect(address_type address, port_type port) noexcept override;
+    bool connect(address_type address, port_type port) override;
 
-    std::shared_ptr<Socket> accept() const noexcept override;
+    std::shared_ptr<Socket> accept() const override;
 
 protected:
-    size_t send(const std::string &message, bool &would_block) const noexcept override;
+    size_t send(const std::string &message, bool &would_block) const override;
 
     size_t
     send_to(const std::string &message, address_type address, port_type port, bool &would_block)
-        const noexcept override;
+        const override;
 
-    std::string recv(bool &would_block, bool &is_complete) const noexcept override;
+    std::string recv(bool &would_block, bool &is_complete) const override;
 
-    std::string recv_from(bool &would_block, bool &is_complete) const noexcept override;
+    std::string recv_from(bool &would_block, bool &is_complete) const override;
 };
 
 } // namespace fly

--- a/fly/socket/nix/socket_manager_impl.cpp
+++ b/fly/socket/nix/socket_manager_impl.cpp
@@ -17,7 +17,7 @@ SocketManagerImpl::SocketManagerImpl(
 }
 
 //==================================================================================================
-void SocketManagerImpl::poll(const std::chrono::microseconds &timeout) noexcept
+void SocketManagerImpl::poll(const std::chrono::microseconds &timeout)
 {
     fd_set read_fd, write_fd;
 
@@ -41,7 +41,7 @@ void SocketManagerImpl::poll(const std::chrono::microseconds &timeout) noexcept
 }
 
 //==================================================================================================
-socket_type SocketManagerImpl::set_read_and_write_masks(fd_set *read_fd, fd_set *write_fd) noexcept
+socket_type SocketManagerImpl::set_read_and_write_masks(fd_set *read_fd, fd_set *write_fd)
 {
     socket_type max_fd = -1;
 
@@ -65,7 +65,7 @@ socket_type SocketManagerImpl::set_read_and_write_masks(fd_set *read_fd, fd_set 
 }
 
 //==================================================================================================
-void SocketManagerImpl::handle_socket_io(fd_set *read_fd, fd_set *write_fd) noexcept
+void SocketManagerImpl::handle_socket_io(fd_set *read_fd, fd_set *write_fd)
 {
     SocketList new_clients, connected_clients, closed_clients;
 

--- a/fly/socket/nix/socket_manager_impl.hpp
+++ b/fly/socket/nix/socket_manager_impl.hpp
@@ -26,12 +26,12 @@ public:
         const std::shared_ptr<SocketConfig> &config) noexcept;
 
 protected:
-    void poll(const std::chrono::microseconds &timeout) noexcept override;
+    void poll(const std::chrono::microseconds &timeout) override;
 
 private:
-    socket_type set_read_and_write_masks(fd_set *read_fd, fd_set *write_fd) noexcept;
+    socket_type set_read_and_write_masks(fd_set *read_fd, fd_set *write_fd);
 
-    void handle_socket_io(fd_set *read_fd, fd_set *write_fd) noexcept;
+    void handle_socket_io(fd_set *read_fd, fd_set *write_fd);
 };
 
 } // namespace fly

--- a/fly/socket/socket.cpp
+++ b/fly/socket/socket.cpp
@@ -26,91 +26,91 @@ Socket::Socket(Protocol protocol, const std::shared_ptr<SocketConfig> &config) n
 }
 
 //==================================================================================================
-bool Socket::hostname_to_address(const std::string &hostname, address_type &address) noexcept
+bool Socket::hostname_to_address(const std::string &hostname, address_type &address)
 {
     return SocketImpl::hostname_to_address(hostname, address);
 }
 
 //==================================================================================================
-address_type Socket::in_addr_any() noexcept
+address_type Socket::in_addr_any()
 {
     return SocketImpl::in_addr_any();
 }
 
 //==================================================================================================
-socket_type Socket::invalid_socket() noexcept
+socket_type Socket::invalid_socket()
 {
     return SocketImpl::invalid_socket();
 }
 
 //==================================================================================================
-bool Socket::is_valid() const noexcept
+bool Socket::is_valid() const
 {
     return m_socket_handle != invalid_socket();
 }
 
 //==================================================================================================
-socket_type Socket::get_handle() const noexcept
+socket_type Socket::get_handle() const
 {
     return m_socket_handle;
 }
 
 //==================================================================================================
-address_type Socket::get_client_ip() const noexcept
+address_type Socket::get_client_ip() const
 {
     return m_client_ip;
 }
 
 //==================================================================================================
-port_type Socket::get_client_port() const noexcept
+port_type Socket::get_client_port() const
 {
     return m_client_port;
 }
 
 //==================================================================================================
-int Socket::get_socket_id() const noexcept
+int Socket::get_socket_id() const
 {
     return m_socket_id;
 }
 
 //==================================================================================================
-bool Socket::is_tcp() const noexcept
+bool Socket::is_tcp() const
 {
     return m_protocol == Protocol::TCP;
 }
 
 //==================================================================================================
-bool Socket::is_udp() const noexcept
+bool Socket::is_udp() const
 {
     return m_protocol == Protocol::UDP;
 }
 
 //==================================================================================================
-bool Socket::is_async() const noexcept
+bool Socket::is_async() const
 {
     return m_is_async;
 }
 
 //==================================================================================================
-bool Socket::is_listening() const noexcept
+bool Socket::is_listening() const
 {
     return m_is_listening;
 }
 
 //==================================================================================================
-bool Socket::is_connecting() const noexcept
+bool Socket::is_connecting() const
 {
     return m_connected_state.load() == ConnectedState::Connecting;
 }
 
 //==================================================================================================
-bool Socket::is_connected() const noexcept
+bool Socket::is_connected() const
 {
     return m_connected_state.load() == ConnectedState::Connected;
 }
 
 //==================================================================================================
-bool Socket::bind(const std::string &hostname, port_type port, BindOption option) const noexcept
+bool Socket::bind(const std::string &hostname, port_type port, BindOption option) const
 {
     address_type address = 0;
 
@@ -123,7 +123,7 @@ bool Socket::bind(const std::string &hostname, port_type port, BindOption option
 }
 
 //==================================================================================================
-bool Socket::connect(const std::string &hostname, port_type port) noexcept
+bool Socket::connect(const std::string &hostname, port_type port)
 {
     address_type address = 0;
 
@@ -136,7 +136,7 @@ bool Socket::connect(const std::string &hostname, port_type port) noexcept
 }
 
 //==================================================================================================
-ConnectedState Socket::connect_async(address_type address, port_type port) noexcept
+ConnectedState Socket::connect_async(address_type address, port_type port)
 {
     ConnectedState state = ConnectedState::Disconnected;
 
@@ -164,7 +164,7 @@ ConnectedState Socket::connect_async(address_type address, port_type port) noexc
 }
 
 //==================================================================================================
-ConnectedState Socket::connect_async(const std::string &hostname, port_type port) noexcept
+ConnectedState Socket::connect_async(const std::string &hostname, port_type port)
 {
     address_type address = 0;
 
@@ -177,7 +177,7 @@ ConnectedState Socket::connect_async(const std::string &hostname, port_type port
 }
 
 //==================================================================================================
-bool Socket::finish_connect() noexcept
+bool Socket::finish_connect()
 {
     if (is_valid() & is_connecting() && is_error_free())
     {
@@ -196,23 +196,22 @@ bool Socket::finish_connect() noexcept
 }
 
 //==================================================================================================
-size_t Socket::send(const std::string &message) const noexcept
+size_t Socket::send(const std::string &message) const
 {
     bool would_block = false;
     return send(message, would_block);
 }
 
 //==================================================================================================
-size_t
-Socket::send_to(const std::string &message, address_type address, port_type port) const noexcept
+size_t Socket::send_to(const std::string &message, address_type address, port_type port) const
 {
     bool would_block = false;
     return send_to(message, address, port, would_block);
 }
 
 //==================================================================================================
-size_t Socket::send_to(const std::string &message, const std::string &hostname, port_type port)
-    const noexcept
+size_t
+Socket::send_to(const std::string &message, const std::string &hostname, port_type port) const
 {
     bool would_block = false;
     return send_to(message, hostname, port, would_block);
@@ -223,7 +222,7 @@ size_t Socket::send_to(
     const std::string &message,
     const std::string &hostname,
     port_type port,
-    bool &would_block) const noexcept
+    bool &would_block) const
 {
     address_type address = 0;
 
@@ -236,7 +235,7 @@ size_t Socket::send_to(
 }
 
 //==================================================================================================
-bool Socket::send_async(std::string &&message) noexcept
+bool Socket::send_async(std::string &&message)
 {
     if (is_tcp() && is_async())
     {
@@ -250,7 +249,7 @@ bool Socket::send_async(std::string &&message) noexcept
 }
 
 //==================================================================================================
-bool Socket::send_to_async(std::string &&message, address_type address, port_type port) noexcept
+bool Socket::send_to_async(std::string &&message, address_type address, port_type port)
 {
     if (is_udp() && is_async())
     {
@@ -264,10 +263,7 @@ bool Socket::send_to_async(std::string &&message, address_type address, port_typ
 }
 
 //==================================================================================================
-bool Socket::send_to_async(
-    std::string &&message,
-    const std::string &hostname,
-    port_type port) noexcept
+bool Socket::send_to_async(std::string &&message, const std::string &hostname, port_type port)
 {
     address_type address = 0;
 
@@ -280,21 +276,21 @@ bool Socket::send_to_async(
 }
 
 //==================================================================================================
-std::string Socket::recv() const noexcept
+std::string Socket::recv() const
 {
     bool would_block = false, is_complete = false;
     return recv(would_block, is_complete);
 }
 
 //==================================================================================================
-std::string Socket::recv_from() const noexcept
+std::string Socket::recv_from() const
 {
     bool would_block = false, is_complete = false;
     return recv_from(would_block, is_complete);
 }
 
 //==================================================================================================
-void Socket::service_send_requests(AsyncRequest::RequestQueue &completed_sends) noexcept
+void Socket::service_send_requests(AsyncRequest::RequestQueue &completed_sends)
 {
     bool would_block = false;
 
@@ -346,7 +342,7 @@ void Socket::service_send_requests(AsyncRequest::RequestQueue &completed_sends) 
 }
 
 //==================================================================================================
-void Socket::service_recv_requests(AsyncRequest::RequestQueue &completed_reads) noexcept
+void Socket::service_recv_requests(AsyncRequest::RequestQueue &completed_reads)
 {
     bool would_block = false;
     bool is_complete = false;

--- a/fly/socket/socket.hpp
+++ b/fly/socket/socket.hpp
@@ -43,7 +43,7 @@ public:
      *
      * @return True if the hostname/address string could be converted.
      */
-    static bool hostname_to_address(const std::string &hostname, address_type &address) noexcept;
+    static bool hostname_to_address(const std::string &hostname, address_type &address);
 
     /**
      * INADDR_ANY may be different depending on the OS. This function will return the value for the
@@ -51,7 +51,7 @@ public:
      *
      * @return INADDR_ANY for the target system.
      */
-    static address_type in_addr_any() noexcept;
+    static address_type in_addr_any();
 
     /**
      * Invalid socket handles may be different depending on the OS. This function will return the
@@ -59,81 +59,81 @@ public:
      *
      * @return Invalid socket handle for the target system.
      */
-    static socket_type invalid_socket() noexcept;
+    static socket_type invalid_socket();
 
     /**
      * A socket is valid if it's handle has been properly set.
      *
      * @return True if this is a valid socket.
      */
-    bool is_valid() const noexcept;
+    bool is_valid() const;
 
     /**
      * Check if there is any errors on the socket.
      */
-    virtual bool is_error_free() noexcept = 0;
+    virtual bool is_error_free() = 0;
 
     /**
      * Close this socket's handle.
      */
-    virtual void close() noexcept = 0;
+    virtual void close() = 0;
 
     /**
      * Set the socket to be asynchronous.
      *
      * @return True if the operation was successful.
      */
-    virtual bool set_async() noexcept = 0;
+    virtual bool set_async() = 0;
 
     /**
      * @return Return this socket's handle.
      */
-    socket_type get_handle() const noexcept;
+    socket_type get_handle() const;
 
     /**
      * @return Return the client IP this socket is connected to.
      */
-    address_type get_client_ip() const noexcept;
+    address_type get_client_ip() const;
 
     /**
      * @return Return the client port this socket is connected to.
      */
-    port_type get_client_port() const noexcept;
+    port_type get_client_port() const;
 
     /**
      * @return This socket's ID.
      */
-    int get_socket_id() const noexcept;
+    int get_socket_id() const;
 
     /**
      * @return True if this is a TCP socket.
      */
-    bool is_tcp() const noexcept;
+    bool is_tcp() const;
 
     /**
      * @return True if this is a UDP socket.
      */
-    bool is_udp() const noexcept;
+    bool is_udp() const;
 
     /**
      * @return True if this is an asynchronous socket.
      */
-    bool is_async() const noexcept;
+    bool is_async() const;
 
     /**
      * @return True if this socket is a listener socket.
      */
-    bool is_listening() const noexcept;
+    bool is_listening() const;
 
     /**
      * @return True if this socket is connecting to a remote endpoint.
      */
-    bool is_connecting() const noexcept;
+    bool is_connecting() const;
 
     /**
      * @return True if this socket is connected to a remote endpoint.
      */
-    bool is_connected() const noexcept;
+    bool is_connected() const;
 
     /**
      * Bind this socket to an address.
@@ -144,7 +144,7 @@ public:
      *
      * @return True if the binding was successful.
      */
-    virtual bool bind(address_type address, port_type port, BindOption option) const noexcept = 0;
+    virtual bool bind(address_type address, port_type port, BindOption option) const = 0;
 
     /**
      * Bind this socket to an address.
@@ -155,12 +155,12 @@ public:
      *
      * @return True if the binding was successful.
      */
-    bool bind(const std::string &hostname, port_type port, BindOption option) const noexcept;
+    bool bind(const std::string &hostname, port_type port, BindOption option) const;
 
     /**
      * Allow socket to listen for incoming connections.
      */
-    virtual bool listen() noexcept = 0;
+    virtual bool listen() = 0;
 
     /**
      * Connect to a listening socket.
@@ -170,7 +170,7 @@ public:
      *
      * @return True if the connection was successful.
      */
-    virtual bool connect(address_type address, port_type port) noexcept = 0;
+    virtual bool connect(address_type address, port_type port) = 0;
 
     /**
      * Connect to a listening socket.
@@ -180,7 +180,7 @@ public:
      *
      * @return True if the connection was successful.
      */
-    bool connect(const std::string &hostname, port_type port) noexcept;
+    bool connect(const std::string &hostname, port_type port);
 
     /**
      * Asynchronously connect to a listening socket. The connect may finish immediately, so the
@@ -192,7 +192,7 @@ public:
      *
      * @return The connection state (not connected, connecting, or connected).
      */
-    ConnectedState connect_async(address_type address, port_type port) noexcept;
+    ConnectedState connect_async(address_type address, port_type port);
 
     /**
      * Asynchronously connect to a listening socket. The connect may finish immediately, so the
@@ -204,7 +204,7 @@ public:
      *
      * @return The connection state (not connected, connecting, or connected).
      */
-    ConnectedState connect_async(const std::string &hostname, port_type port) noexcept;
+    ConnectedState connect_async(const std::string &hostname, port_type port);
 
     /**
      * After an asynchronous socket in a connecting state becomes available for writing, verify the
@@ -212,14 +212,14 @@ public:
      *
      * @return True if the socket is healthy and connected.
      */
-    bool finish_connect() noexcept;
+    bool finish_connect();
 
     /**
      * Accept an incoming client connection.
      *
      * @return The accepted client socket.
      */
-    virtual std::shared_ptr<Socket> accept() const noexcept = 0;
+    virtual std::shared_ptr<Socket> accept() const = 0;
 
     /**
      * Write data on the socket.
@@ -228,7 +228,7 @@ public:
      *
      * @return The number of bytes sent.
      */
-    std::size_t send(const std::string &message) const noexcept;
+    std::size_t send(const std::string &message) const;
 
     /**
      * Write data on the socket.
@@ -239,8 +239,7 @@ public:
      *
      * @return The number of bytes sent.
      */
-    std::size_t
-    send_to(const std::string &message, address_type address, port_type port) const noexcept;
+    std::size_t send_to(const std::string &message, address_type address, port_type port) const;
 
     /**
      * Write data on the socket.
@@ -252,7 +251,7 @@ public:
      * @return The number of bytes sent.
      */
     std::size_t
-    send_to(const std::string &message, const std::string &hostname, port_type port) const noexcept;
+    send_to(const std::string &message, const std::string &hostname, port_type port) const;
 
     /**
      * Request data to be written on the socket asynchronously. If this is not an ansynchronous
@@ -262,7 +261,7 @@ public:
      *
      * @return True if the request was made.
      */
-    bool send_async(std::string &&message) noexcept;
+    bool send_async(std::string &&message);
 
     /**
      * Request data to be written on the socket asynchronously. If this is not an ansynchronous
@@ -274,7 +273,7 @@ public:
      *
      * @return True if the request was made.
      */
-    bool send_to_async(std::string &&message, address_type address, port_type port) noexcept;
+    bool send_to_async(std::string &&message, address_type address, port_type port);
 
     /**
      * Request data to be written on the socket asynchronously. If this is not an ansynchronous
@@ -286,21 +285,21 @@ public:
      *
      * @return True if the request was made.
      */
-    bool send_to_async(std::string &&message, const std::string &hostname, port_type port) noexcept;
+    bool send_to_async(std::string &&message, const std::string &hostname, port_type port);
 
     /**
      * Read data on this socket until the end-of-message character is received.
      *
      * @return The data received.
      */
-    std::string recv() const noexcept;
+    std::string recv() const;
 
     /**
      * Read data on this socket until the end-of-message character is received.
      *
      * @return The data received.
      */
-    std::string recv_from() const noexcept;
+    std::string recv_from() const;
 
     /**
      * Iterate thru all pending asynchronous sends. Service each request until one would block, or
@@ -308,7 +307,7 @@ public:
      *
      * @param completed_sends Queue of completed sends to post to on success.
      */
-    void service_send_requests(AsyncRequest::RequestQueue &completed_sends) noexcept;
+    void service_send_requests(AsyncRequest::RequestQueue &completed_sends);
 
     /**
      * Read on this socket until a read would block, or some other error occurs (in which case, this
@@ -316,7 +315,7 @@ public:
      *
      * @param completed_reads Queue of completed received to post to on success.
      */
-    void service_recv_requests(AsyncRequest::RequestQueue &completed_reads) noexcept;
+    void service_recv_requests(AsyncRequest::RequestQueue &completed_reads);
 
 protected:
     /**
@@ -327,7 +326,7 @@ protected:
      *
      * @return The number of bytes sent.
      */
-    virtual std::size_t send(const std::string &message, bool &would_block) const noexcept = 0;
+    virtual std::size_t send(const std::string &message, bool &would_block) const = 0;
 
     /**
      * Write data on the socket.
@@ -341,7 +340,7 @@ protected:
      */
     virtual std::size_t
     send_to(const std::string &message, address_type address, port_type port, bool &would_block)
-        const noexcept = 0;
+        const = 0;
 
     /**
      * Write data on the socket.
@@ -357,7 +356,7 @@ protected:
         const std::string &message,
         const std::string &hostname,
         port_type port,
-        bool &would_block) const noexcept;
+        bool &would_block) const;
 
     /**
      * Read data on this socket until the end-of-message character is received.
@@ -367,7 +366,7 @@ protected:
      *
      * @return The data received.
      */
-    virtual std::string recv(bool &would_block, bool &is_complete) const noexcept = 0;
+    virtual std::string recv(bool &would_block, bool &is_complete) const = 0;
 
     /**
      * Read data on this socket until the end-of-message character is received.
@@ -377,7 +376,7 @@ protected:
      *
      * @return The data received.
      */
-    virtual std::string recv_from(bool &would_block, bool &is_complete) const noexcept = 0;
+    virtual std::string recv_from(bool &would_block, bool &is_complete) const = 0;
 
     // Socket protocol.
     Protocol m_protocol;

--- a/fly/socket/socket_config.cpp
+++ b/fly/socket/socket_config.cpp
@@ -13,20 +13,20 @@ SocketConfig::SocketConfig() noexcept :
 }
 
 //==================================================================================================
-std::chrono::microseconds SocketConfig::io_wait_time() const noexcept
+std::chrono::microseconds SocketConfig::io_wait_time() const
 {
     return std::chrono::microseconds(
         get_value<std::chrono::microseconds::rep>("io_wait_time", m_default_io_wait_time));
 }
 
 //==================================================================================================
-char SocketConfig::end_of_message() const noexcept
+char SocketConfig::end_of_message() const
 {
     return get_value<char>("end_of_message", m_default_end_of_message);
 }
 
 //==================================================================================================
-std::size_t SocketConfig::packet_size() const noexcept
+std::size_t SocketConfig::packet_size() const
 {
     return get_value<std::size_t>("packet_size", m_default_packet_size);
 }

--- a/fly/socket/socket_config.hpp
+++ b/fly/socket/socket_config.hpp
@@ -25,17 +25,17 @@ public:
     /**
      * @return Sleep time for socket IO thread.
      */
-    std::chrono::microseconds io_wait_time() const noexcept;
+    std::chrono::microseconds io_wait_time() const;
 
     /**
      * @return Character signifying the end of a message received over a socket.
      */
-    char end_of_message() const noexcept;
+    char end_of_message() const;
 
     /**
      * Size of packet to use for send/receive operations.
      */
-    std::size_t packet_size() const noexcept;
+    std::size_t packet_size() const;
 
 protected:
     std::chrono::microseconds::rep m_default_io_wait_time;

--- a/fly/socket/socket_manager.cpp
+++ b/fly/socket/socket_manager.cpp
@@ -30,7 +30,7 @@ SocketManager::~SocketManager()
 }
 
 //==================================================================================================
-void SocketManager::start() noexcept
+void SocketManager::start()
 {
     std::shared_ptr<SocketManager> socket_manager = shared_from_this();
 
@@ -39,9 +39,7 @@ void SocketManager::start() noexcept
 }
 
 //==================================================================================================
-void SocketManager::set_client_callbacks(
-    SocketCallback new_client,
-    SocketCallback closed_client) noexcept
+void SocketManager::set_client_callbacks(SocketCallback new_client, SocketCallback closed_client)
 {
     std::lock_guard<std::mutex> lock(m_callback_mutex);
 
@@ -50,13 +48,13 @@ void SocketManager::set_client_callbacks(
 }
 
 //==================================================================================================
-void SocketManager::clear_client_callbacks() noexcept
+void SocketManager::clear_client_callbacks()
 {
     set_client_callbacks(nullptr, nullptr);
 }
 
 //==================================================================================================
-std::shared_ptr<Socket> SocketManager::create_socket(Protocol protocol) noexcept
+std::shared_ptr<Socket> SocketManager::create_socket(Protocol protocol)
 {
     auto socket = std::make_shared<SocketImpl>(protocol, m_config);
 
@@ -69,7 +67,7 @@ std::shared_ptr<Socket> SocketManager::create_socket(Protocol protocol) noexcept
 }
 
 //==================================================================================================
-std::weak_ptr<Socket> SocketManager::create_async_socket(Protocol protocol) noexcept
+std::weak_ptr<Socket> SocketManager::create_async_socket(Protocol protocol)
 {
     auto socket = create_socket(protocol);
 
@@ -92,7 +90,7 @@ std::weak_ptr<Socket> SocketManager::create_async_socket(Protocol protocol) noex
 //==================================================================================================
 void SocketManager::handle_new_and_closed_sockets(
     const SocketList &new_sockets,
-    const SocketList &closed_sockets) noexcept
+    const SocketList &closed_sockets)
 {
     // Add new sockets to the socket system.
     m_async_sockets.insert(m_async_sockets.end(), new_sockets.begin(), new_sockets.end());
@@ -113,7 +111,7 @@ void SocketManager::handle_new_and_closed_sockets(
 //==================================================================================================
 void SocketManager::trigger_callbacks(
     const SocketList &connected_clients,
-    const SocketList &closed_clients) noexcept
+    const SocketList &closed_clients)
 {
     if (!connected_clients.empty() || !closed_clients.empty())
     {
@@ -145,7 +143,7 @@ SocketManagerTask::SocketManagerTask(std::weak_ptr<SocketManager> weak_socket_ma
 }
 
 //==================================================================================================
-void SocketManagerTask::run() noexcept
+void SocketManagerTask::run()
 {
     std::shared_ptr<SocketManager> socket_manager = m_weak_socket_manager.lock();
 

--- a/fly/socket/socket_manager.hpp
+++ b/fly/socket/socket_manager.hpp
@@ -54,7 +54,7 @@ public:
     /**
      * Initialize the socket manager task.
      */
-    void start() noexcept;
+    void start();
 
     /**
      * Set callbacks for when a client connects or disconnects.
@@ -62,12 +62,12 @@ public:
      * @param new_client Callback for when a new client connects.
      * @param closed_client Callback for when a client disconnects.
      */
-    void set_client_callbacks(SocketCallback new_client, SocketCallback closed_client) noexcept;
+    void set_client_callbacks(SocketCallback new_client, SocketCallback closed_client);
 
     /**
      * Remove the callbacks for when a client connects or disconnects.
      */
-    void clear_client_callbacks() noexcept;
+    void clear_client_callbacks();
 
     /**
      * Create and initialize a synchronous socket.
@@ -76,7 +76,7 @@ public:
      *
      * @return Shared pointer to the socket.
      */
-    std::shared_ptr<Socket> create_socket(Protocol protocol) noexcept;
+    std::shared_ptr<Socket> create_socket(Protocol protocol);
 
     /**
      * Create and initialize an asynchronous socket. The socket manager will own this socket.
@@ -85,7 +85,7 @@ public:
      *
      * @return Weak pointer to the socket.
      */
-    std::weak_ptr<Socket> create_async_socket(Protocol protocol) noexcept;
+    std::weak_ptr<Socket> create_async_socket(Protocol protocol);
 
     /**
      * Wait for an asynchronous read to complete.
@@ -96,9 +96,7 @@ public:
      * @return True if a completed receive was found in the given duration.
      */
     template <typename R, typename P>
-    bool wait_for_completed_receive(
-        AsyncRequest &request,
-        std::chrono::duration<R, P> wait_time) noexcept;
+    bool wait_for_completed_receive(AsyncRequest &request, std::chrono::duration<R, P> wait_time);
 
     /**
      * Wait for an asynchronous send to complete.
@@ -109,8 +107,7 @@ public:
      * @return True if a completed send was found in the given duration.
      */
     template <typename R, typename P>
-    bool
-    wait_for_completed_send(AsyncRequest &request, std::chrono::duration<R, P> wait_time) noexcept;
+    bool wait_for_completed_send(AsyncRequest &request, std::chrono::duration<R, P> wait_time);
 
 protected:
     /**
@@ -118,7 +115,7 @@ protected:
      *
      * @param timeout Max time to allow for a socket to be available.
      */
-    virtual void poll(const std::chrono::microseconds &timeout) noexcept = 0;
+    virtual void poll(const std::chrono::microseconds &timeout) = 0;
 
     /**
      * Add new sockets to and remove closed sockets from the socket system.
@@ -126,9 +123,8 @@ protected:
      * @param closed_sockets Newly added sockets.
      * @param closed_sockets Newly closed sockets.
      */
-    void handle_new_and_closed_sockets(
-        const SocketList &new_sockets,
-        const SocketList &closed_sockets) noexcept;
+    void
+    handle_new_and_closed_sockets(const SocketList &new_sockets, const SocketList &closed_sockets);
 
     /**
      * Trigger the connected and closed client callbacks.
@@ -136,9 +132,7 @@ protected:
      * @param connected_clients Newly connected clients.
      * @param closed_clients Newly closed clients.
      */
-    void trigger_callbacks(
-        const SocketList &connected_clients,
-        const SocketList &closed_clients) noexcept;
+    void trigger_callbacks(const SocketList &connected_clients, const SocketList &closed_clients);
 
     std::mutex m_async_sockets_mutex;
     SocketList m_async_sockets;
@@ -173,7 +167,7 @@ protected:
      * Call back into the socket manager to check if any asynchronous sockets are available for IO.
      * The task re-arms itself.
      */
-    void run() noexcept override;
+    void run() override;
 
 private:
     std::weak_ptr<SocketManager> m_weak_socket_manager;
@@ -183,7 +177,7 @@ private:
 template <typename R, typename P>
 bool SocketManager::wait_for_completed_receive(
     AsyncRequest &request,
-    std::chrono::duration<R, P> wait_time) noexcept
+    std::chrono::duration<R, P> wait_time)
 {
     return m_completed_receives.pop(request, wait_time);
 }
@@ -192,7 +186,7 @@ bool SocketManager::wait_for_completed_receive(
 template <typename R, typename P>
 bool SocketManager::wait_for_completed_send(
     AsyncRequest &request,
-    std::chrono::duration<R, P> wait_time) noexcept
+    std::chrono::duration<R, P> wait_time)
 {
     return m_completed_sends.pop(request, wait_time);
 }

--- a/fly/socket/win/socket_impl.cpp
+++ b/fly/socket/win/socket_impl.cpp
@@ -11,7 +11,7 @@ namespace fly {
 
 namespace {
 
-    struct sockaddr_in create_socket_address(address_type address, port_type port) noexcept
+    struct sockaddr_in create_socket_address(address_type address, port_type port)
     {
         struct sockaddr_in socket_address;
         memset(&socket_address, 0, sizeof(socket_address));
@@ -48,7 +48,7 @@ SocketImpl::~SocketImpl()
 }
 
 //==================================================================================================
-bool SocketImpl::hostname_to_address(const std::string &hostname, address_type &address) noexcept
+bool SocketImpl::hostname_to_address(const std::string &hostname, address_type &address)
 {
     struct hostent *ip_address = ::gethostbyname(hostname.c_str());
 
@@ -70,19 +70,19 @@ bool SocketImpl::hostname_to_address(const std::string &hostname, address_type &
 }
 
 //==================================================================================================
-address_type SocketImpl::in_addr_any() noexcept
+address_type SocketImpl::in_addr_any()
 {
     return INADDR_ANY;
 }
 
 //==================================================================================================
-socket_type SocketImpl::invalid_socket() noexcept
+socket_type SocketImpl::invalid_socket()
 {
     return INVALID_SOCKET;
 }
 
 //==================================================================================================
-void SocketImpl::close() noexcept
+void SocketImpl::close()
 {
     if (is_valid())
     {
@@ -92,7 +92,7 @@ void SocketImpl::close() noexcept
 }
 
 //==================================================================================================
-bool SocketImpl::is_error_free() noexcept
+bool SocketImpl::is_error_free()
 {
     int opt = 0;
     int len = sizeof(opt);
@@ -108,7 +108,7 @@ bool SocketImpl::is_error_free() noexcept
 }
 
 //==================================================================================================
-bool SocketImpl::set_async() noexcept
+bool SocketImpl::set_async()
 {
     unsigned long non_zero = 1;
 
@@ -123,7 +123,7 @@ bool SocketImpl::set_async() noexcept
 }
 
 //==================================================================================================
-bool SocketImpl::bind(address_type address, port_type port, BindOption option) const noexcept
+bool SocketImpl::bind(address_type address, port_type port, BindOption option) const
 {
     static const char s_bind_for_reuse_option = 1;
     static const int s_bind_for_reuse_option_length =
@@ -164,7 +164,7 @@ bool SocketImpl::bind(address_type address, port_type port, BindOption option) c
 }
 
 //==================================================================================================
-bool SocketImpl::listen() noexcept
+bool SocketImpl::listen()
 {
     if (::listen(m_socket_handle, 100) == SOCKET_ERROR)
     {
@@ -177,7 +177,7 @@ bool SocketImpl::listen() noexcept
 }
 
 //==================================================================================================
-bool SocketImpl::connect(address_type address, port_type port) noexcept
+bool SocketImpl::connect(address_type address, port_type port)
 {
     struct sockaddr_in socket_address = create_socket_address(address, port);
     auto *p_socket_address = reinterpret_cast<sockaddr *>(&socket_address);
@@ -202,7 +202,7 @@ bool SocketImpl::connect(address_type address, port_type port) noexcept
 }
 
 //==================================================================================================
-std::shared_ptr<Socket> SocketImpl::accept() const noexcept
+std::shared_ptr<Socket> SocketImpl::accept() const
 {
     auto ret = std::make_shared<SocketImpl>(m_protocol, m_config);
 
@@ -231,7 +231,7 @@ std::shared_ptr<Socket> SocketImpl::accept() const noexcept
 }
 
 //==================================================================================================
-std::size_t SocketImpl::send(const std::string &message, bool &would_block) const noexcept
+std::size_t SocketImpl::send(const std::string &message, bool &would_block) const
 {
     std::string to_send = message + std::string(1, m_socket_eom);
 
@@ -284,7 +284,7 @@ std::size_t SocketImpl::send_to(
     const std::string &message,
     address_type address,
     port_type port,
-    bool &would_block) const noexcept
+    bool &would_block) const
 {
     std::string to_send = message + std::string(1, m_socket_eom);
 
@@ -337,7 +337,7 @@ std::size_t SocketImpl::send_to(
 }
 
 //==================================================================================================
-std::string SocketImpl::recv(bool &would_block, bool &is_complete) const noexcept
+std::string SocketImpl::recv(bool &would_block, bool &is_complete) const
 {
     std::string ret;
 
@@ -381,7 +381,7 @@ std::string SocketImpl::recv(bool &would_block, bool &is_complete) const noexcep
 }
 
 //==================================================================================================
-std::string SocketImpl::recv_from(bool &would_block, bool &is_complete) const noexcept
+std::string SocketImpl::recv_from(bool &would_block, bool &is_complete) const
 {
     std::string ret;
 

--- a/fly/socket/win/socket_impl.hpp
+++ b/fly/socket/win/socket_impl.hpp
@@ -22,36 +22,36 @@ public:
     SocketImpl(Protocol protocol, const std::shared_ptr<SocketConfig> &config) noexcept;
     ~SocketImpl() override;
 
-    static bool hostname_to_address(const std::string &hostname, address_type &address) noexcept;
+    static bool hostname_to_address(const std::string &hostname, address_type &address);
 
-    static address_type in_addr_any() noexcept;
+    static address_type in_addr_any();
 
-    static socket_type invalid_socket() noexcept;
+    static socket_type invalid_socket();
 
-    void close() noexcept override;
+    void close() override;
 
-    bool is_error_free() noexcept override;
+    bool is_error_free() override;
 
-    bool set_async() noexcept override;
+    bool set_async() override;
 
-    bool bind(address_type address, port_type port, BindOption option) const noexcept override;
+    bool bind(address_type address, port_type port, BindOption option) const override;
 
-    bool listen() noexcept override;
+    bool listen() override;
 
-    bool connect(address_type address, port_type port) noexcept override;
+    bool connect(address_type address, port_type port) override;
 
-    std::shared_ptr<Socket> accept() const noexcept override;
+    std::shared_ptr<Socket> accept() const override;
 
 protected:
-    size_t send(const std::string &message, bool &would_block) const noexcept override;
+    size_t send(const std::string &message, bool &would_block) const override;
 
     size_t
     send_to(const std::string &message, address_type address, port_type port, bool &would_block)
-        const noexcept override;
+        const override;
 
-    std::string recv(bool &would_block, bool &is_complete) const noexcept override;
+    std::string recv(bool &would_block, bool &is_complete) const override;
 
-    std::string recv_from(bool &would_block, bool &is_complete) const noexcept override;
+    std::string recv_from(bool &would_block, bool &is_complete) const override;
 };
 
 } // namespace fly

--- a/fly/socket/win/socket_manager_impl.cpp
+++ b/fly/socket/win/socket_manager_impl.cpp
@@ -38,7 +38,7 @@ SocketManagerImpl::~SocketManagerImpl()
 }
 
 //==================================================================================================
-void SocketManagerImpl::poll(const std::chrono::microseconds &timeout) noexcept
+void SocketManagerImpl::poll(const std::chrono::microseconds &timeout)
 {
     fd_set read_fd, write_fd;
     struct timeval tv = {0, static_cast<long>(timeout.count())};
@@ -61,7 +61,7 @@ void SocketManagerImpl::poll(const std::chrono::microseconds &timeout) noexcept
 }
 
 //==================================================================================================
-bool SocketManagerImpl::set_read_and_write_masks(fd_set *read_fd, fd_set *write_fd) noexcept
+bool SocketManagerImpl::set_read_and_write_masks(fd_set *read_fd, fd_set *write_fd)
 {
     bool any_masks_set = false;
 
@@ -85,7 +85,7 @@ bool SocketManagerImpl::set_read_and_write_masks(fd_set *read_fd, fd_set *write_
 }
 
 //==================================================================================================
-void SocketManagerImpl::handle_socket_io(fd_set *read_fd, fd_set *write_fd) noexcept
+void SocketManagerImpl::handle_socket_io(fd_set *read_fd, fd_set *write_fd)
 {
     SocketList new_clients, connected_clients, closed_clients;
 

--- a/fly/socket/win/socket_manager_impl.hpp
+++ b/fly/socket/win/socket_manager_impl.hpp
@@ -27,11 +27,11 @@ public:
     ~SocketManagerImpl() override;
 
 protected:
-    void poll(const std::chrono::microseconds &timeout) noexcept override;
+    void poll(const std::chrono::microseconds &timeout) override;
 
 private:
-    bool set_read_and_write_masks(fd_set *read_fd, fd_set *write_fd) noexcept;
-    void handle_socket_io(fd_set *read_fd, fd_set *write_fd) noexcept;
+    bool set_read_and_write_masks(fd_set *read_fd, fd_set *write_fd);
+    void handle_socket_io(fd_set *read_fd, fd_set *write_fd);
 
     static std::atomic_int s_socket_manager_count;
 };

--- a/fly/system/nix/system_impl.cpp
+++ b/fly/system/nix/system_impl.cpp
@@ -10,7 +10,7 @@
 namespace fly {
 
 //==================================================================================================
-void SystemImpl::print_backtrace() noexcept
+void SystemImpl::print_backtrace()
 {
     void *trace[10];
     int trace_size = ::backtrace(trace, 10);
@@ -18,7 +18,7 @@ void SystemImpl::print_backtrace() noexcept
 }
 
 //==================================================================================================
-std::string SystemImpl::local_time(const char *fmt) noexcept
+std::string SystemImpl::local_time(const char *fmt)
 {
     auto sys = std::chrono::system_clock::now();
     time_t now = std::chrono::system_clock::to_time_t(sys);
@@ -40,13 +40,13 @@ std::string SystemImpl::local_time(const char *fmt) noexcept
 }
 
 //==================================================================================================
-int SystemImpl::get_error_code() noexcept
+int SystemImpl::get_error_code()
 {
     return errno;
 }
 
 //==================================================================================================
-std::vector<int> SystemImpl::get_signals() noexcept
+std::vector<int> SystemImpl::get_signals()
 {
     return {SIGINT, SIGTERM, SIGSYS, SIGBUS, SIGILL, SIGFPE, SIGABRT, SIGSEGV};
 }

--- a/fly/system/nix/system_impl.hpp
+++ b/fly/system/nix/system_impl.hpp
@@ -14,10 +14,10 @@ namespace fly {
 class SystemImpl
 {
 public:
-    static void print_backtrace() noexcept;
-    static std::string local_time(const char *fmt) noexcept;
-    static int get_error_code() noexcept;
-    static std::vector<int> get_signals() noexcept;
+    static void print_backtrace();
+    static std::string local_time(const char *fmt);
+    static int get_error_code();
+    static std::vector<int> get_signals();
 };
 
 } // namespace fly

--- a/fly/system/nix/system_monitor_impl.cpp
+++ b/fly/system/nix/system_monitor_impl.cpp
@@ -38,7 +38,7 @@ SystemMonitorImpl::SystemMonitorImpl(
 }
 
 //==================================================================================================
-void SystemMonitorImpl::update_system_cpu_count() noexcept
+void SystemMonitorImpl::update_system_cpu_count()
 {
     std::ifstream stream(s_proc_stat_file, std::ios::in);
     std::string contents, line;
@@ -69,7 +69,7 @@ void SystemMonitorImpl::update_system_cpu_count() noexcept
 }
 
 //==================================================================================================
-void SystemMonitorImpl::update_system_cpu_usage() noexcept
+void SystemMonitorImpl::update_system_cpu_usage()
 {
     std::ifstream stream(s_proc_stat_file, std::ios::in);
     std::string line;
@@ -112,7 +112,7 @@ void SystemMonitorImpl::update_system_cpu_usage() noexcept
 }
 
 //==================================================================================================
-void SystemMonitorImpl::update_process_cpu_usage() noexcept
+void SystemMonitorImpl::update_process_cpu_usage()
 {
     struct tms sample;
     clock_t now = ::times(&sample);
@@ -140,7 +140,7 @@ void SystemMonitorImpl::update_process_cpu_usage() noexcept
 }
 
 //==================================================================================================
-void SystemMonitorImpl::update_system_memory_usage() noexcept
+void SystemMonitorImpl::update_system_memory_usage()
 {
     struct sysinfo info;
 
@@ -159,7 +159,7 @@ void SystemMonitorImpl::update_system_memory_usage() noexcept
 }
 
 //==================================================================================================
-void SystemMonitorImpl::update_process_memory_usage() noexcept
+void SystemMonitorImpl::update_process_memory_usage()
 {
     std::ifstream stream(s_self_status_file, std::ios::in);
     std::string contents, line;

--- a/fly/system/nix/system_monitor_impl.hpp
+++ b/fly/system/nix/system_monitor_impl.hpp
@@ -28,12 +28,12 @@ public:
         const std::shared_ptr<SystemConfig> &config) noexcept;
 
 protected:
-    void update_system_cpu_count() noexcept override;
-    void update_system_cpu_usage() noexcept override;
-    void update_process_cpu_usage() noexcept override;
+    void update_system_cpu_count() override;
+    void update_system_cpu_usage() override;
+    void update_process_cpu_usage() override;
 
-    void update_system_memory_usage() noexcept override;
-    void update_process_memory_usage() noexcept override;
+    void update_system_memory_usage() override;
+    void update_process_memory_usage() override;
 
 private:
     std::uint64_t m_prev_system_user_time;

--- a/fly/system/system.cpp
+++ b/fly/system/system.cpp
@@ -12,37 +12,37 @@
 namespace fly {
 
 //==================================================================================================
-void System::print_backtrace() noexcept
+void System::print_backtrace()
 {
     SystemImpl::print_backtrace();
 }
 
 //==================================================================================================
-std::string System::local_time() noexcept
+std::string System::local_time()
 {
     return SystemImpl::local_time("%m-%d-%Y %H:%M:%S");
 }
 
 //==================================================================================================
-int System::get_error_code() noexcept
+int System::get_error_code()
 {
     return SystemImpl::get_error_code();
 }
 
 //==================================================================================================
-std::string System::get_error_string() noexcept
+std::string System::get_error_string()
 {
     return get_error_string(get_error_code());
 }
 
 //==================================================================================================
-std::string System::get_error_string(int code) noexcept
+std::string System::get_error_string(int code)
 {
     return fly::String::format("(%d) %s", code, std::system_category().message(code));
 }
 
 //==================================================================================================
-void System::set_signal_handler(SignalHandler handler) noexcept
+void System::set_signal_handler(SignalHandler handler)
 {
     static std::vector<int> s_signals = SystemImpl::get_signals();
 

--- a/fly/system/system.hpp
+++ b/fly/system/system.hpp
@@ -19,22 +19,22 @@ public:
     /**
      * Print the backtrace to stderr.
      */
-    static void print_backtrace() noexcept;
+    static void print_backtrace();
 
     /**
      * @return The local time formatted as a string.
      */
-    static std::string local_time() noexcept;
+    static std::string local_time();
 
     /**
      * @return The last system error code.
      */
-    static int get_error_code() noexcept;
+    static int get_error_code();
 
     /**
      * @return The last system error code as a string.
      */
-    static std::string get_error_string() noexcept;
+    static std::string get_error_string();
 
     /**
      * Convert a system error code to a string.
@@ -43,14 +43,14 @@ public:
      *
      * @return The given system error code as a string.
      */
-    static std::string get_error_string(int code) noexcept;
+    static std::string get_error_string(int code);
 
     /**
      * Set a signal handler for all terminal signals.
      *
      * @param handler The signal handler function to set.
      */
-    static void set_signal_handler(SignalHandler handler) noexcept;
+    static void set_signal_handler(SignalHandler handler);
 };
 
 } // namespace fly

--- a/fly/system/system_config.cpp
+++ b/fly/system/system_config.cpp
@@ -9,7 +9,7 @@ SystemConfig::SystemConfig() noexcept : m_default_poll_interval(1000_i64)
 {
 }
 //==================================================================================================
-std::chrono::milliseconds SystemConfig::poll_interval() const noexcept
+std::chrono::milliseconds SystemConfig::poll_interval() const
 {
     return std::chrono::milliseconds(
         get_value<std::chrono::milliseconds::rep>("poll_interval", m_default_poll_interval));

--- a/fly/system/system_config.hpp
+++ b/fly/system/system_config.hpp
@@ -25,7 +25,7 @@ public:
     /**
      * @return Delay between system monitor poll intervals.
      */
-    virtual std::chrono::milliseconds poll_interval() const noexcept;
+    virtual std::chrono::milliseconds poll_interval() const;
 
 protected:
     std::chrono::milliseconds::rep m_default_poll_interval;

--- a/fly/system/system_monitor.cpp
+++ b/fly/system/system_monitor.cpp
@@ -24,7 +24,7 @@ SystemMonitor::SystemMonitor(
 }
 
 //==================================================================================================
-bool SystemMonitor::start() noexcept
+bool SystemMonitor::start()
 {
     update_system_cpu_count();
 
@@ -42,49 +42,49 @@ bool SystemMonitor::start() noexcept
 }
 
 //==================================================================================================
-std::uint32_t SystemMonitor::get_system_cpu_count() const noexcept
+std::uint32_t SystemMonitor::get_system_cpu_count() const
 {
     return m_system_cpu_count.load();
 }
 
 //==================================================================================================
-double SystemMonitor::get_system_cpu_usage() const noexcept
+double SystemMonitor::get_system_cpu_usage() const
 {
     return m_system_cpu_usage.load();
 }
 
 //==================================================================================================
-double SystemMonitor::get_process_cpu_usage() const noexcept
+double SystemMonitor::get_process_cpu_usage() const
 {
     return m_process_cpu_usage.load();
 }
 
 //==================================================================================================
-std::uint64_t SystemMonitor::get_total_system_memory() const noexcept
+std::uint64_t SystemMonitor::get_total_system_memory() const
 {
     return m_total_system_memory.load();
 }
 
 //==================================================================================================
-std::uint64_t SystemMonitor::get_system_memory_usage() const noexcept
+std::uint64_t SystemMonitor::get_system_memory_usage() const
 {
     return m_system_memory_usage.load();
 }
 
 //==================================================================================================
-std::uint64_t SystemMonitor::get_process_memory_usage() const noexcept
+std::uint64_t SystemMonitor::get_process_memory_usage() const
 {
     return m_process_memory_usage.load();
 }
 
 //==================================================================================================
-bool SystemMonitor::is_valid() const noexcept
+bool SystemMonitor::is_valid() const
 {
     return get_system_cpu_count() > 0;
 }
 
 //==================================================================================================
-void SystemMonitor::poll() noexcept
+void SystemMonitor::poll()
 {
     update_system_cpu_count();
     update_system_cpu_usage();
@@ -102,7 +102,7 @@ SystemMonitorTask::SystemMonitorTask(std::weak_ptr<SystemMonitor> weak_system_mo
 }
 
 //==================================================================================================
-void SystemMonitorTask::run() noexcept
+void SystemMonitorTask::run()
 {
     std::shared_ptr<SystemMonitor> system_monitor = m_weak_system_monitor.lock();
 

--- a/fly/system/system_monitor.hpp
+++ b/fly/system/system_monitor.hpp
@@ -45,75 +45,75 @@ public:
      *
      * @return True if the path monitor is in a valid state.
      */
-    bool start() noexcept;
+    bool start();
 
     /**
      * Get the system's CPU count.
      *
      * @return System CPU count.
      */
-    std::uint32_t get_system_cpu_count() const noexcept;
+    std::uint32_t get_system_cpu_count() const;
 
     /**
      * Get the system's CPU usage percentage (0-100%) over the last second.
      *
      * @return Current system CPU usage.
      */
-    double get_system_cpu_usage() const noexcept;
+    double get_system_cpu_usage() const;
 
     /**
      * Get the process's CPU usage percentage (0-100%) over the last second.
      *
      * @return Current process CPU usage.
      */
-    double get_process_cpu_usage() const noexcept;
+    double get_process_cpu_usage() const;
 
     /**
      * Get the system's total physical memory available in bytes.
      *
      * @return Total system memory.
      */
-    std::uint64_t get_total_system_memory() const noexcept;
+    std::uint64_t get_total_system_memory() const;
 
     /**
      * Get the system's physical memory usage in bytes.
      *
      * @return Current system memory usage.
      */
-    std::uint64_t get_system_memory_usage() const noexcept;
+    std::uint64_t get_system_memory_usage() const;
 
     /**
      * Get the process's physical memory usage in bytes.
      *
      * @return Current process memory usage.
      */
-    std::uint64_t get_process_memory_usage() const noexcept;
+    std::uint64_t get_process_memory_usage() const;
 
 protected:
     /**
      * Update the system's current CPU count.
      */
-    virtual void update_system_cpu_count() noexcept = 0;
+    virtual void update_system_cpu_count() = 0;
 
     /**
      * Update the system's current CPU usage.
      */
-    virtual void update_system_cpu_usage() noexcept = 0;
+    virtual void update_system_cpu_usage() = 0;
 
     /**
      * Update the process's current CPU usage.
      */
-    virtual void update_process_cpu_usage() noexcept = 0;
+    virtual void update_process_cpu_usage() = 0;
 
     /**
      * Update the system's current memory usage.
      */
-    virtual void update_system_memory_usage() noexcept = 0;
+    virtual void update_system_memory_usage() = 0;
 
     /**
      * Update the process's current memory usage.
      */
-    virtual void update_process_memory_usage() noexcept = 0;
+    virtual void update_process_memory_usage() = 0;
 
     std::atomic<std::uint32_t> m_system_cpu_count;
     std::atomic<double> m_system_cpu_usage;
@@ -129,12 +129,12 @@ private:
      *
      * @return True if the CPU count is valid.
      */
-    bool is_valid() const noexcept;
+    bool is_valid() const;
 
     /**
      * Update the system-level resources.
      */
-    void poll() noexcept;
+    void poll();
 
     std::shared_ptr<SequencedTaskRunner> m_task_runner;
     std::shared_ptr<Task> m_task;
@@ -158,7 +158,7 @@ protected:
      * Call back into the system monitor to update system-level resources. If the system monitor
      * implementation is still valid, the task re-arms itself.
      */
-    void run() noexcept override;
+    void run() override;
 
 private:
     std::weak_ptr<SystemMonitor> m_weak_system_monitor;

--- a/fly/system/win/system_impl.cpp
+++ b/fly/system/win/system_impl.cpp
@@ -9,7 +9,7 @@
 namespace fly {
 
 //==================================================================================================
-void SystemImpl::print_backtrace() noexcept
+void SystemImpl::print_backtrace()
 {
     void *trace[10];
     const USHORT trace_size = ::CaptureStackBackTrace(0, 10, trace, nullptr);
@@ -21,7 +21,7 @@ void SystemImpl::print_backtrace() noexcept
 }
 
 //==================================================================================================
-std::string SystemImpl::local_time(const char *fmt) noexcept
+std::string SystemImpl::local_time(const char *fmt)
 {
     auto sys = std::chrono::system_clock::now();
     time_t now = std::chrono::system_clock::to_time_t(sys);
@@ -43,13 +43,13 @@ std::string SystemImpl::local_time(const char *fmt) noexcept
 }
 
 //==================================================================================================
-int SystemImpl::get_error_code() noexcept
+int SystemImpl::get_error_code()
 {
     return ::GetLastError();
 }
 
 //==================================================================================================
-std::vector<int> SystemImpl::get_signals() noexcept
+std::vector<int> SystemImpl::get_signals()
 {
     return {SIGINT, SIGTERM, SIGILL, SIGFPE, SIGABRT, SIGSEGV};
 }

--- a/fly/system/win/system_impl.hpp
+++ b/fly/system/win/system_impl.hpp
@@ -14,10 +14,10 @@ namespace fly {
 class SystemImpl
 {
 public:
-    static void print_backtrace() noexcept;
-    static std::string local_time(const char *fmt) noexcept;
-    static int get_error_code() noexcept;
-    static std::vector<int> get_signals() noexcept;
+    static void print_backtrace();
+    static std::string local_time(const char *fmt);
+    static int get_error_code();
+    static std::vector<int> get_signals();
 };
 
 } // namespace fly

--- a/fly/system/win/system_monitor_impl.cpp
+++ b/fly/system/win/system_monitor_impl.cpp
@@ -61,7 +61,7 @@ SystemMonitorImpl::~SystemMonitorImpl()
 }
 
 //==================================================================================================
-void SystemMonitorImpl::update_system_cpu_count() noexcept
+void SystemMonitorImpl::update_system_cpu_count()
 {
     SYSTEM_INFO info;
     ::GetSystemInfo(&info);
@@ -77,7 +77,7 @@ void SystemMonitorImpl::update_system_cpu_count() noexcept
 }
 
 //==================================================================================================
-void SystemMonitorImpl::update_system_cpu_usage() noexcept
+void SystemMonitorImpl::update_system_cpu_usage()
 {
     PDH_FMT_COUNTERVALUE value;
 
@@ -99,7 +99,7 @@ void SystemMonitorImpl::update_system_cpu_usage() noexcept
 }
 
 //==================================================================================================
-void SystemMonitorImpl::update_process_cpu_usage() noexcept
+void SystemMonitorImpl::update_process_cpu_usage()
 {
     ULARGE_INTEGER now, system, user;
     FILETIME fnow, fsystem, fuser;
@@ -130,7 +130,7 @@ void SystemMonitorImpl::update_process_cpu_usage() noexcept
 }
 
 //==================================================================================================
-void SystemMonitorImpl::update_system_memory_usage() noexcept
+void SystemMonitorImpl::update_system_memory_usage()
 {
     MEMORYSTATUSEX info;
     info.dwLength = sizeof(MEMORYSTATUSEX);
@@ -147,7 +147,7 @@ void SystemMonitorImpl::update_system_memory_usage() noexcept
 }
 
 //==================================================================================================
-void SystemMonitorImpl::update_process_memory_usage() noexcept
+void SystemMonitorImpl::update_process_memory_usage()
 {
     PROCESS_MEMORY_COUNTERS pmc;
 

--- a/fly/system/win/system_monitor_impl.hpp
+++ b/fly/system/win/system_monitor_impl.hpp
@@ -33,12 +33,12 @@ public:
     ~SystemMonitorImpl() override;
 
 protected:
-    void update_system_cpu_count() noexcept override;
-    void update_system_cpu_usage() noexcept override;
-    void update_process_cpu_usage() noexcept override;
+    void update_system_cpu_count() override;
+    void update_system_cpu_usage() override;
+    void update_process_cpu_usage() override;
 
-    void update_system_memory_usage() noexcept override;
-    void update_process_memory_usage() noexcept override;
+    void update_system_memory_usage() override;
+    void update_process_memory_usage() override;
 
 private:
     HANDLE m_process;

--- a/fly/task/task.hpp
+++ b/fly/task/task.hpp
@@ -25,7 +25,7 @@ protected:
      * Classes which inherit from this class should implement this method to perform the work
      * required by the task.
      */
-    virtual void run() noexcept = 0;
+    virtual void run() = 0;
 };
 
 } // namespace fly

--- a/fly/task/task_manager.cpp
+++ b/fly/task/task_manager.cpp
@@ -22,7 +22,7 @@ TaskManager::TaskManager(std::uint32_t num_workers) noexcept :
 }
 
 //==================================================================================================
-bool TaskManager::start() noexcept
+bool TaskManager::start()
 {
     bool expected = false;
 
@@ -47,7 +47,7 @@ bool TaskManager::start() noexcept
 }
 
 //==================================================================================================
-bool TaskManager::stop() noexcept
+bool TaskManager::stop()
 {
     bool expected = true;
 
@@ -72,7 +72,7 @@ bool TaskManager::stop() noexcept
 //==================================================================================================
 void TaskManager::post_task(
     std::weak_ptr<Task> weak_task,
-    std::weak_ptr<TaskRunner> weak_task_runner) noexcept
+    std::weak_ptr<TaskRunner> weak_task_runner)
 {
     const auto now = std::chrono::steady_clock::now();
     TaskHolder task {weak_task, weak_task_runner, now};
@@ -84,7 +84,7 @@ void TaskManager::post_task(
 void TaskManager::post_task_with_delay(
     std::weak_ptr<Task> weak_task,
     std::weak_ptr<TaskRunner> weak_task_runner,
-    std::chrono::milliseconds delay) noexcept
+    std::chrono::milliseconds delay)
 {
     const auto schedule = std::chrono::steady_clock::now() + delay;
     TaskHolder task {weak_task, weak_task_runner, schedule};
@@ -94,7 +94,7 @@ void TaskManager::post_task_with_delay(
 }
 
 //==================================================================================================
-void TaskManager::worker_thread() noexcept
+void TaskManager::worker_thread()
 {
     TaskHolder task_holder;
 
@@ -119,7 +119,7 @@ void TaskManager::worker_thread() noexcept
 }
 
 //==================================================================================================
-void TaskManager::timer_thread() noexcept
+void TaskManager::timer_thread()
 {
     while (m_keep_running.load())
     {

--- a/fly/task/task_manager.hpp
+++ b/fly/task/task_manager.hpp
@@ -43,14 +43,14 @@ public:
      *
      * @return True if the threads were created in this invocation.
      */
-    bool start() noexcept;
+    bool start();
 
     /**
      * Destroy the worker threads and timer thread, blocking until the threads exit.
      *
      * @return True if the threads were destroyed in this invocation.
      */
-    bool stop() noexcept;
+    bool stop();
 
     /**
      * Create a task runner, holding a weak reference to this task manager.
@@ -60,7 +60,7 @@ public:
      * @return The created task runner.
      */
     template <typename TaskRunnerType>
-    std::shared_ptr<TaskRunnerType> create_task_runner() noexcept;
+    std::shared_ptr<TaskRunnerType> create_task_runner();
 
 private:
     /**
@@ -80,8 +80,7 @@ private:
      * @param weak_task The task to be executed.
      * @param weak_task_runner The task runner posting the task.
      */
-    void
-    post_task(std::weak_ptr<Task> weak_task, std::weak_ptr<TaskRunner> weak_task_runner) noexcept;
+    void post_task(std::weak_ptr<Task> weak_task, std::weak_ptr<TaskRunner> weak_task_runner);
 
     /**
      * Schedule a task to be posted for execution after some delay.
@@ -93,17 +92,17 @@ private:
     void post_task_with_delay(
         std::weak_ptr<Task> weak_task,
         std::weak_ptr<TaskRunner> weak_task_runner,
-        std::chrono::milliseconds delay) noexcept;
+        std::chrono::milliseconds delay);
 
     /**
      * Worker thread for executing tasks.
      */
-    void worker_thread() noexcept;
+    void worker_thread();
 
     /**
      * Timer thread for holding delayed tasks until their scheduled time.
      */
-    void timer_thread() noexcept;
+    void timer_thread();
 
     ConcurrentQueue<TaskHolder> m_tasks;
 
@@ -119,7 +118,7 @@ private:
 
 //==================================================================================================
 template <typename TaskRunnerType>
-std::shared_ptr<TaskRunnerType> TaskManager::create_task_runner() noexcept
+std::shared_ptr<TaskRunnerType> TaskManager::create_task_runner()
 {
     static_assert(std::is_base_of_v<TaskRunner, TaskRunnerType>);
 

--- a/fly/task/task_runner.cpp
+++ b/fly/task/task_runner.cpp
@@ -15,7 +15,7 @@ TaskRunner::TaskRunner(std::weak_ptr<TaskManager> weak_task_manager) noexcept :
 //==================================================================================================
 bool TaskRunner::post_task_with_delay(
     std::weak_ptr<Task> weak_task,
-    std::chrono::milliseconds delay) noexcept
+    std::chrono::milliseconds delay)
 {
     std::shared_ptr<TaskManager> task_manager = m_weak_task_manager.lock();
 
@@ -31,7 +31,7 @@ bool TaskRunner::post_task_with_delay(
 }
 
 //==================================================================================================
-bool TaskRunner::post_task_to_task_manager(std::weak_ptr<Task> weak_task) noexcept
+bool TaskRunner::post_task_to_task_manager(std::weak_ptr<Task> weak_task)
 {
     std::shared_ptr<TaskManager> task_manager = m_weak_task_manager.lock();
 
@@ -53,13 +53,13 @@ ParallelTaskRunner::ParallelTaskRunner(std::weak_ptr<TaskManager> weak_task_mana
 }
 
 //==================================================================================================
-bool ParallelTaskRunner::post_task(std::weak_ptr<Task> weak_task) noexcept
+bool ParallelTaskRunner::post_task(std::weak_ptr<Task> weak_task)
 {
     return post_task_to_task_manager(weak_task);
 }
 
 //==================================================================================================
-void ParallelTaskRunner::task_complete(const std::shared_ptr<Task> &) noexcept
+void ParallelTaskRunner::task_complete(const std::shared_ptr<Task> &)
 {
 }
 
@@ -71,21 +71,21 @@ SequencedTaskRunner::SequencedTaskRunner(std::weak_ptr<TaskManager> weak_task_ma
 }
 
 //==================================================================================================
-bool SequencedTaskRunner::post_task(std::weak_ptr<Task> weak_task) noexcept
+bool SequencedTaskRunner::post_task(std::weak_ptr<Task> weak_task)
 {
     m_pending_tasks.push(std::move(weak_task));
     return maybe_post_task();
 }
 
 //==================================================================================================
-void SequencedTaskRunner::task_complete(const std::shared_ptr<Task> &) noexcept
+void SequencedTaskRunner::task_complete(const std::shared_ptr<Task> &)
 {
     m_has_running_task.store(false);
     maybe_post_task();
 }
 
 //==================================================================================================
-bool SequencedTaskRunner::maybe_post_task() noexcept
+bool SequencedTaskRunner::maybe_post_task()
 {
     static std::chrono::seconds s_wait(0);
     bool expected = false;

--- a/fly/task/task_runner.hpp
+++ b/fly/task/task_runner.hpp
@@ -40,7 +40,7 @@ public:
      *
      * @return True if the task was posted for execution.
      */
-    virtual bool post_task(std::weak_ptr<Task> weak_task) noexcept = 0;
+    virtual bool post_task(std::weak_ptr<Task> weak_task) = 0;
 
     /**
      * Schedule a task to be posted after a delay. The task is given to the task manager immediately
@@ -56,8 +56,7 @@ public:
      *
      * @return True if the task was posted for delayed execution.
      */
-    bool
-    post_task_with_delay(std::weak_ptr<Task> weak_task, std::chrono::milliseconds delay) noexcept;
+    bool post_task_with_delay(std::weak_ptr<Task> weak_task, std::chrono::milliseconds delay);
 
 protected:
     /**
@@ -73,7 +72,7 @@ protected:
      *
      * @param task The (possibly null) task that was executed or skipped.
      */
-    virtual void task_complete(const std::shared_ptr<Task> &task) noexcept = 0;
+    virtual void task_complete(const std::shared_ptr<Task> &task) = 0;
 
     /**
      * Forward a task to the task manager to be executed as soon as a worker thread is available.
@@ -82,7 +81,7 @@ protected:
      *
      * @return True if the task was posted for execution.
      */
-    bool post_task_to_task_manager(std::weak_ptr<Task> task) noexcept;
+    bool post_task_to_task_manager(std::weak_ptr<Task> task);
 
 private:
     std::weak_ptr<TaskManager> m_weak_task_manager;
@@ -100,7 +99,7 @@ class ParallelTaskRunner : public TaskRunner
     friend class TaskManager;
 
 public:
-    bool post_task(std::weak_ptr<Task>) noexcept override;
+    bool post_task(std::weak_ptr<Task>) override;
 
 protected:
     explicit ParallelTaskRunner(std::weak_ptr<TaskManager>) noexcept;
@@ -110,7 +109,7 @@ protected:
      *
      * @param task The (possibly null) task that was executed or skipped.
      */
-    void task_complete(const std::shared_ptr<Task> &task) noexcept override;
+    void task_complete(const std::shared_ptr<Task> &task) override;
 };
 
 /**
@@ -130,7 +129,7 @@ class SequencedTaskRunner : public TaskRunner
     friend class TaskManager;
 
 public:
-    bool post_task(std::weak_ptr<Task>) noexcept override;
+    bool post_task(std::weak_ptr<Task>) override;
 
 protected:
     explicit SequencedTaskRunner(std::weak_ptr<TaskManager>) noexcept;
@@ -140,7 +139,7 @@ protected:
      *
      * @param task The (possibly null) task that was executed or skipped.
      */
-    void task_complete(const std::shared_ptr<Task> &task) noexcept override;
+    void task_complete(const std::shared_ptr<Task> &task) override;
 
 private:
     /**
@@ -148,7 +147,7 @@ private:
      *
      * @return True if the task was posted for execution or added to the pending queue.
      */
-    bool maybe_post_task() noexcept;
+    bool maybe_post_task();
 
     ConcurrentQueue<std::weak_ptr<Task>> m_pending_tasks;
     std::atomic_bool m_has_running_task;

--- a/fly/types/bit_stream/bit_stream_reader.cpp
+++ b/fly/types/bit_stream/bit_stream_reader.cpp
@@ -30,25 +30,25 @@ BitStreamReader::BitStreamReader(std::istream &stream) noexcept :
 }
 
 //==================================================================================================
-bool BitStreamReader::read_word(word_type &word) noexcept
+bool BitStreamReader::read_word(word_type &word)
 {
     return read_bits(word, detail::s_bits_per_word) == detail::s_bits_per_word;
 }
 
 //==================================================================================================
-bool BitStreamReader::read_byte(byte_type &byte) noexcept
+bool BitStreamReader::read_byte(byte_type &byte)
 {
     return read_bits(byte, detail::s_bits_per_byte) == detail::s_bits_per_byte;
 }
 
 //==================================================================================================
-void BitStreamReader::discard_bits(byte_type size) noexcept
+void BitStreamReader::discard_bits(byte_type size)
 {
     m_position -= size;
 }
 
 //==================================================================================================
-bool BitStreamReader::fully_consumed() const noexcept
+bool BitStreamReader::fully_consumed() const
 {
     if (m_stream_buffer->sgetc() == EOF)
     {
@@ -59,13 +59,13 @@ bool BitStreamReader::fully_consumed() const noexcept
 }
 
 //==================================================================================================
-byte_type BitStreamReader::header() const noexcept
+byte_type BitStreamReader::header() const
 {
     return m_header;
 }
 
 //==================================================================================================
-void BitStreamReader::refill_buffer() noexcept
+void BitStreamReader::refill_buffer()
 {
     const byte_type bits_to_fill = detail::s_most_significant_bit_position - m_position;
     buffer_type buffer = 0;

--- a/fly/types/bit_stream/bit_stream_reader.hpp
+++ b/fly/types/bit_stream/bit_stream_reader.hpp
@@ -44,7 +44,7 @@ public:
      * @return True if the word was successfully read and filling the byte buffer was successful (if
      *         needed).
      */
-    bool read_word(word_type &word) noexcept;
+    bool read_word(word_type &word);
 
     /**
      * Read a full byte from the byte buffer.
@@ -57,7 +57,7 @@ public:
      * @return True if the byte was successfully read and filling the byte buffer was successful (if
      *         needed).
      */
-    bool read_byte(byte_type &byte) noexcept;
+    bool read_byte(byte_type &byte);
 
     /**
      * Read a number of bits from the byte buffer. There is no guarantee that the requested number
@@ -77,7 +77,7 @@ public:
      * @return The number of bits successfully read.
      */
     template <typename DataType>
-    byte_type read_bits(DataType &bits, byte_type size) noexcept;
+    byte_type read_bits(DataType &bits, byte_type size);
 
     /**
      * Read a number of bits from the byte buffer without discarding those bits. There is no
@@ -95,7 +95,7 @@ public:
      * @return The number of bits successfully peeked.
      */
     template <typename DataType>
-    byte_type peek_bits(DataType &bits, byte_type size) noexcept;
+    byte_type peek_bits(DataType &bits, byte_type size);
 
     /**
      * Discard a number of bits from the byte buffer. Should only be used after a successful call to
@@ -103,25 +103,25 @@ public:
      *
      * @param size The number of bits to discard.
      */
-    void discard_bits(byte_type size) noexcept;
+    void discard_bits(byte_type size);
 
     /**
      * Check if the stream has reached end-of-file and the byte buffer has been fully consumed.
      *
      * @return True if the stream has been fully consumed.
      */
-    bool fully_consumed() const noexcept;
+    bool fully_consumed() const;
 
     /**
      * @return The header byte decoded from the stream.
      */
-    byte_type header() const noexcept;
+    byte_type header() const;
 
 private:
     /**
      * Read from the stream to fill the byte buffer.
      */
-    void refill_buffer() noexcept;
+    void refill_buffer();
 
     /**
      * Read from the stream to fill a byte buffer.
@@ -134,7 +134,7 @@ private:
      * @return The number of bytes actually read.
      */
     template <typename DataType>
-    byte_type fill(DataType &buffer, byte_type bytes) noexcept;
+    byte_type fill(DataType &buffer, byte_type bytes);
 
     std::istream &m_stream;
 
@@ -144,7 +144,7 @@ private:
 
 //==================================================================================================
 template <typename DataType>
-byte_type BitStreamReader::read_bits(DataType &bits, byte_type size) noexcept
+byte_type BitStreamReader::read_bits(DataType &bits, byte_type size)
 {
     static_assert(
         detail::BitStreamTraits::is_unsigned_integer_v<DataType>,
@@ -177,7 +177,7 @@ byte_type BitStreamReader::read_bits(DataType &bits, byte_type size) noexcept
 
 //==================================================================================================
 template <typename DataType>
-byte_type BitStreamReader::peek_bits(DataType &bits, byte_type size) noexcept
+byte_type BitStreamReader::peek_bits(DataType &bits, byte_type size)
 {
     static_assert(
         detail::BitStreamTraits::is_unsigned_integer_v<DataType>,
@@ -232,7 +232,7 @@ byte_type BitStreamReader::peek_bits(DataType &bits, byte_type size) noexcept
 
 //==================================================================================================
 template <typename DataType>
-byte_type BitStreamReader::fill(DataType &buffer, byte_type bytes) noexcept
+byte_type BitStreamReader::fill(DataType &buffer, byte_type bytes)
 {
     static_assert(
         detail::BitStreamTraits::is_unsigned_integer_v<DataType>,

--- a/fly/types/bit_stream/bit_stream_writer.cpp
+++ b/fly/types/bit_stream/bit_stream_writer.cpp
@@ -14,19 +14,19 @@ BitStreamWriter::BitStreamWriter(std::ostream &stream) noexcept :
 }
 
 //==================================================================================================
-void BitStreamWriter::write_word(word_type word) noexcept
+void BitStreamWriter::write_word(word_type word)
 {
     write_bits(word, detail::s_bits_per_word);
 }
 
 //==================================================================================================
-void BitStreamWriter::write_byte(byte_type byte) noexcept
+void BitStreamWriter::write_byte(byte_type byte)
 {
     write_bits(byte, detail::s_bits_per_byte);
 }
 
 //==================================================================================================
-bool BitStreamWriter::finish() noexcept
+bool BitStreamWriter::finish()
 {
     const byte_type bits_in_buffer = detail::s_most_significant_bit_position - m_position;
 
@@ -46,7 +46,7 @@ bool BitStreamWriter::finish() noexcept
 }
 
 //==================================================================================================
-void BitStreamWriter::flush_header(byte_type remainder) noexcept
+void BitStreamWriter::flush_header(byte_type remainder)
 {
     m_stream_buffer->pubseekpos(0);
 
@@ -56,7 +56,7 @@ void BitStreamWriter::flush_header(byte_type remainder) noexcept
 }
 
 //==================================================================================================
-void BitStreamWriter::flush_buffer() noexcept
+void BitStreamWriter::flush_buffer()
 {
     flush(m_buffer, detail::s_buffer_type_size);
 

--- a/fly/types/bit_stream/bit_stream_writer.hpp
+++ b/fly/types/bit_stream/bit_stream_writer.hpp
@@ -36,7 +36,7 @@ public:
      *
      * @param word The word to write.
      */
-    void write_word(word_type word) noexcept;
+    void write_word(word_type word);
 
     /**
      * Write a full byte to the byte buffer.
@@ -45,7 +45,7 @@ public:
      *
      * @param byte The byte to write.
      */
-    void write_byte(byte_type byte) noexcept;
+    void write_byte(byte_type byte);
 
     /**
      * Write a number of bits to the byte buffer. The least-significant bits in the provided data
@@ -59,14 +59,14 @@ public:
      * @param size The number of bits to write.
      */
     template <typename DataType>
-    void write_bits(DataType bits, byte_type size) noexcept;
+    void write_bits(DataType bits, byte_type size);
 
     /**
      * If needed, zero-fill the byte buffer, flush it to the stream, and update the header byte.
      *
      * @return True if the stream remains in a good state.
      */
-    bool finish() noexcept;
+    bool finish();
 
 private:
     /**
@@ -74,12 +74,12 @@ private:
      *
      * @param remainder The number of zero-filled bits in the byte buffer.
      */
-    void flush_header(byte_type remainder) noexcept;
+    void flush_header(byte_type remainder);
 
     /**
      * Flush the byte buffer onto the stream.
      */
-    void flush_buffer() noexcept;
+    void flush_buffer();
 
     /**
      * Flush a byte buffer to the stream.
@@ -90,14 +90,14 @@ private:
      * @param bytes The number of bytes to flush.
      */
     template <typename DataType>
-    void flush(const DataType &buffer, byte_type bytes) noexcept;
+    void flush(const DataType &buffer, byte_type bytes);
 
     std::ostream &m_stream;
 };
 
 //==================================================================================================
 template <typename DataType>
-void BitStreamWriter::write_bits(DataType bits, byte_type size) noexcept
+void BitStreamWriter::write_bits(DataType bits, byte_type size)
 {
     static_assert(
         detail::BitStreamTraits::is_unsigned_integer_v<DataType>,
@@ -127,7 +127,7 @@ void BitStreamWriter::write_bits(DataType bits, byte_type size) noexcept
 
 //==================================================================================================
 template <typename DataType>
-void BitStreamWriter::flush(const DataType &buffer, byte_type bytes) noexcept
+void BitStreamWriter::flush(const DataType &buffer, byte_type bytes)
 {
     static_assert(
         detail::BitStreamTraits::is_unsigned_integer_v<DataType>,

--- a/fly/types/concurrency/concurrent_queue.hpp
+++ b/fly/types/concurrency/concurrent_queue.hpp
@@ -16,20 +16,20 @@ template <typename T>
 class ConcurrentQueue : public detail::ConcurrentContainer<T, std::queue<T>>
 {
 protected:
-    void push_internal(T &&) noexcept override;
-    void pop_internal(T &) noexcept override;
+    void push_internal(T &&) override;
+    void pop_internal(T &) override;
 };
 
 //==================================================================================================
 template <typename T>
-void ConcurrentQueue<T>::push_internal(T &&item) noexcept
+void ConcurrentQueue<T>::push_internal(T &&item)
 {
     this->m_container.push(std::move(item));
 }
 
 //==================================================================================================
 template <typename T>
-void ConcurrentQueue<T>::pop_internal(T &item) noexcept
+void ConcurrentQueue<T>::pop_internal(T &item)
 {
     item = std::move(this->m_container.front());
     this->m_container.pop();

--- a/fly/types/concurrency/concurrent_stack.hpp
+++ b/fly/types/concurrency/concurrent_stack.hpp
@@ -16,20 +16,20 @@ template <typename T>
 class ConcurrentStack : public detail::ConcurrentContainer<T, std::stack<T>>
 {
 protected:
-    void push_internal(T &&) noexcept override;
-    void pop_internal(T &) noexcept override;
+    void push_internal(T &&) override;
+    void pop_internal(T &) override;
 };
 
 //==================================================================================================
 template <typename T>
-void ConcurrentStack<T>::push_internal(T &&item) noexcept
+void ConcurrentStack<T>::push_internal(T &&item)
 {
     this->m_container.push(std::move(item));
 }
 
 //==================================================================================================
 template <typename T>
-void ConcurrentStack<T>::pop_internal(T &item) noexcept
+void ConcurrentStack<T>::pop_internal(T &item)
 {
     item = std::move(this->m_container.top());
     this->m_container.pop();

--- a/fly/types/concurrency/detail/concurrent_container.hpp
+++ b/fly/types/concurrency/detail/concurrent_container.hpp
@@ -28,7 +28,7 @@ public:
      *
      * @param item Item to push onto the container.
      */
-    void push(T &&item) noexcept;
+    void push(T &&item);
 
     /**
      * Pop an item from the container. If the container is empty, wait indefinitely for item to be
@@ -36,7 +36,7 @@ public:
      *
      * @param item Location to store the popped item.
      */
-    void pop(T &item) noexcept;
+    void pop(T &item);
 
     /**
      * Pop an item from the container. If the container is empty, wait (at most) for the specified
@@ -48,17 +48,17 @@ public:
      * @return True if an object was popped in the given duration.
      */
     template <typename R, typename P>
-    bool pop(T &item, std::chrono::duration<R, P> duration) noexcept;
+    bool pop(T &item, std::chrono::duration<R, P> duration);
 
     /**
      * @return True if the container is empty.
      */
-    bool empty() const noexcept;
+    bool empty() const;
 
     /**
      * @return The number of items in the container.
      */
-    size_type size() const noexcept;
+    size_type size() const;
 
 protected:
     /**
@@ -66,14 +66,14 @@ protected:
      *
      * @param item Item to push onto the container.
      */
-    virtual void push_internal(T &&item) noexcept = 0;
+    virtual void push_internal(T &&item) = 0;
 
     /**
      * Implementation-specific method to pop an item from the container.
      *
      * @param item Location to store the popped item.
      */
-    virtual void pop_internal(T &item) noexcept = 0;
+    virtual void pop_internal(T &item) = 0;
 
     mutable std::mutex m_container_mutex;
     Container m_container;
@@ -84,7 +84,7 @@ private:
 
 //==================================================================================================
 template <typename T, typename Container>
-void ConcurrentContainer<T, Container>::push(T &&item) noexcept
+void ConcurrentContainer<T, Container>::push(T &&item)
 {
     {
         std::unique_lock<std::mutex> lock(m_container_mutex);
@@ -96,7 +96,7 @@ void ConcurrentContainer<T, Container>::push(T &&item) noexcept
 
 //==================================================================================================
 template <typename T, typename Container>
-void ConcurrentContainer<T, Container>::pop(T &item) noexcept
+void ConcurrentContainer<T, Container>::pop(T &item)
 {
     std::unique_lock<std::mutex> lock(m_container_mutex);
 
@@ -111,7 +111,7 @@ void ConcurrentContainer<T, Container>::pop(T &item) noexcept
 //==================================================================================================
 template <typename T, typename Container>
 template <typename R, typename P>
-bool ConcurrentContainer<T, Container>::pop(T &item, std::chrono::duration<R, P> wait_time) noexcept
+bool ConcurrentContainer<T, Container>::pop(T &item, std::chrono::duration<R, P> wait_time)
 {
     std::unique_lock<std::mutex> lock(m_container_mutex);
 
@@ -128,7 +128,7 @@ bool ConcurrentContainer<T, Container>::pop(T &item, std::chrono::duration<R, P>
 
 //==================================================================================================
 template <typename T, typename Container>
-bool ConcurrentContainer<T, Container>::empty() const noexcept
+bool ConcurrentContainer<T, Container>::empty() const
 {
     std::unique_lock<std::mutex> lock(m_container_mutex);
     return m_container.empty();
@@ -136,7 +136,7 @@ bool ConcurrentContainer<T, Container>::empty() const noexcept
 
 //==================================================================================================
 template <typename T, typename Container>
-auto ConcurrentContainer<T, Container>::size() const noexcept -> size_type
+auto ConcurrentContainer<T, Container>::size() const -> size_type
 {
     std::unique_lock<std::mutex> lock(m_container_mutex);
     return m_container.size();

--- a/fly/types/json/detail/json_iterator.hpp
+++ b/fly/types/json/detail/json_iterator.hpp
@@ -151,7 +151,7 @@ public:
      *
      * @throws NullJsonException If the iterator is empty or past-the-end.
      */
-    reference operator*() const noexcept(false);
+    reference operator*() const;
 
     /**
      * Retrieve a pointer to the Json instance pointed to by this iterator.
@@ -160,7 +160,7 @@ public:
      *
      * @throws NullJsonException If the iterator is empty or past-the-end.
      */
-    pointer operator->() const noexcept(false);
+    pointer operator->() const;
 
     /**
      * Retrieve a reference to the Json instance at some offset earlier or later than the instance
@@ -176,7 +176,7 @@ public:
      * @throws OutOfRangeJsonException If the iterator at the offset escapes the Json instance's
      *         valid range.
      */
-    reference operator[](difference_type offset) const noexcept(false);
+    reference operator[](difference_type offset) const;
 
     /**
      * Equality comparison operator.
@@ -188,7 +188,7 @@ public:
      * @throws BadJsonComparisonException If the two iterators are not for the same Json instance.
      * @throws NullJsonException If either iterator is empty.
      */
-    bool operator==(const JsonIterator &iterator) const noexcept(false);
+    bool operator==(const JsonIterator &iterator) const;
 
     /**
      * Unequality comparison operator.
@@ -200,7 +200,7 @@ public:
      * @throws BadJsonComparisonException If the two iterators are not for the same Json instance.
      * @throws NullJsonException If either iterator is empty.
      */
-    bool operator!=(const JsonIterator &iterator) const noexcept(false);
+    bool operator!=(const JsonIterator &iterator) const;
 
     /**
      * Less-than comparison operator. Invalid for Json object types.
@@ -213,7 +213,7 @@ public:
      * @throws BadJsonComparisonException If the two iterators are not for the same Json instance.
      * @throws NullJsonException If either iterator is empty.
      */
-    bool operator<(const JsonIterator &iterator) const noexcept(false);
+    bool operator<(const JsonIterator &iterator) const;
 
     /**
      * Less-than-or-equal-to comparison operator. Invalid for Json object types.
@@ -227,7 +227,7 @@ public:
      * @throws BadJsonComparisonException If the two iterators are not for the same Json instance.
      * @throws NullJsonException If either iterator is empty.
      */
-    bool operator<=(const JsonIterator &iterator) const noexcept(false);
+    bool operator<=(const JsonIterator &iterator) const;
 
     /**
      * Greater-than comparison operator. Invalid for Json object types.
@@ -240,7 +240,7 @@ public:
      * @throws BadJsonComparisonException If the two iterators are not for the same Json instance.
      * @throws NullJsonException If either iterator is empty.
      */
-    bool operator>(const JsonIterator &iterator) const noexcept(false);
+    bool operator>(const JsonIterator &iterator) const;
 
     /**
      * Greater-than-or-equal-to comparison operator. Invalid for Json object types.
@@ -254,7 +254,7 @@ public:
      * @throws BadJsonComparisonException If the two iterators are not for the same Json instance.
      * @throws NullJsonException If either iterator is empty.
      */
-    bool operator>=(const JsonIterator &iterator) const noexcept(false);
+    bool operator>=(const JsonIterator &iterator) const;
 
     /**
      * Pre-increment operator. Sets the instance pointed to by this iterator to the next instance in
@@ -265,7 +265,7 @@ public:
      * @throws NullJsonException If the iterator is empty.
      * @throws OutOfRangeJsonException If the next iterator escapes the Json instance's valid range.
      */
-    JsonIterator operator++(int) noexcept(false);
+    JsonIterator operator++(int);
 
     /**
      * Post-increment operator. Sets the instance pointed to by this iterator to the next instance
@@ -276,7 +276,7 @@ public:
      * @throws NullJsonException If the iterator is empty.
      * @throws OutOfRangeJsonException If the next iterator escapes the Json instance's valid range.
      */
-    JsonIterator &operator++() noexcept(false);
+    JsonIterator &operator++();
 
     /**
      * Pre-decrement operator. Sets the instance pointed to by this iterator to the previous
@@ -288,7 +288,7 @@ public:
      * @throws OutOfRangeJsonException If the previous iterator escapes the Json instance's valid
      *         range.
      */
-    JsonIterator operator--(int) noexcept(false);
+    JsonIterator operator--(int);
 
     /**
      * Post-decrement operator. Sets the instance pointed to by this iterator to the previous
@@ -300,7 +300,7 @@ public:
      * @throws OutOfRangeJsonException If the previous iterator escapes the Json instance's valid
      *         range.
      */
-    JsonIterator &operator--() noexcept(false);
+    JsonIterator &operator--();
 
     /**
      * Addition operator. Sets the Json instance pointed to by this iterator to some offset earlier
@@ -315,7 +315,7 @@ public:
      * @throws OutOfRangeJsonException If the iterator at the offset escapes the Json instance's
      *         valid range.
      */
-    JsonIterator &operator+=(difference_type offset) noexcept(false);
+    JsonIterator &operator+=(difference_type offset);
 
     /**
      * Subtraction operator. Sets the Json instance pointed to by this iterator to some offset
@@ -330,7 +330,7 @@ public:
      * @throws OutOfRangeJsonException If the iterator at the offset escapes the Json instance's
      *         valid range.
      */
-    JsonIterator &operator-=(difference_type offset) noexcept(false);
+    JsonIterator &operator-=(difference_type offset);
 
     /**
      * Addition operator. Retrieve an iterator pointed at the Json instance some offset earlier or
@@ -345,7 +345,7 @@ public:
      * @throws OutOfRangeJsonException If the iterator at the offset escapes the Json instance's
      *         valid range.
      */
-    JsonIterator operator+(difference_type offset) const noexcept(false);
+    JsonIterator operator+(difference_type offset) const;
 
     /**
      * Addition operator. Retrieve an iterator pointed at the Json instance some offset earlier or
@@ -361,9 +361,8 @@ public:
      *         valid range.
      */
     template <typename J>
-    friend JsonIterator<J> operator+(
-        typename JsonIterator<J>::difference_type offset,
-        const JsonIterator<J> &iterator) noexcept(false);
+    friend JsonIterator<J>
+    operator+(typename JsonIterator<J>::difference_type offset, const JsonIterator<J> &iterator);
 
     /**
      * Subtraction operator. Retrieve an iterator pointed at the Json instance some offset earlier
@@ -378,7 +377,7 @@ public:
      * @throws OutOfRangeJsonException If the iterator at the offset escapes the Json instance's
      *         valid range.
      */
-    JsonIterator operator-(difference_type offset) const noexcept(false);
+    JsonIterator operator-(difference_type offset) const;
 
     /**
      * Difference operator. Compute the distance between this iterator and another. Invalid for Json
@@ -391,7 +390,7 @@ public:
      * @throws JsonIteratorException If the Json instance is an object.
      * @throws NullJsonException If either iterator is empty.
      */
-    difference_type operator-(const JsonIterator &iterator) const noexcept(false);
+    difference_type operator-(const JsonIterator &iterator) const;
 
     /**
      * Retrieve a reference to the key of the Json instance pointed to by this iterator. Only valid
@@ -402,7 +401,7 @@ public:
      * @throws JsonIteratorException If the Json instance is not an object.
      * @throws NullJsonException If the iterator is empty or past-the-end.
      */
-    const typename JsonTraits::object_type::key_type &key() const noexcept(false);
+    const typename JsonTraits::object_type::key_type &key() const;
 
     /**
      * Retrieve a reference to the Json instance pointed to by this iterator.
@@ -411,7 +410,7 @@ public:
      *
      * @throws NullJsonException If the iterator is empty or past-the-end.
      */
-    reference value() const noexcept(false);
+    reference value() const;
 
 private:
     friend std::
@@ -434,7 +433,7 @@ private:
      *
      * @throws JsonIteratorException If the iterator is empty.
      */
-    void validate_iterator() const noexcept(false);
+    void validate_iterator() const;
 
     /**
      * Verify that this and another iterator are not empty and are for the same Json instance.
@@ -444,7 +443,7 @@ private:
      * @throws JsonIteratorException If either iterator is empty, or if the two iterators are not
      *         for the same Json instance.
      */
-    void validate_iterator(const JsonIterator &iterator) const noexcept(false);
+    void validate_iterator(const JsonIterator &iterator) const;
 
     /**
      * Verify that the iterator at some offset earlier or later than this iterator does not escape
@@ -459,7 +458,7 @@ private:
      *         the Json instance's valid range.
      */
     template <typename T>
-    void validate_offset(const T &it, difference_type offset) const noexcept(false);
+    void validate_offset(const T &it, difference_type offset) const;
 
     /**
      * Verify that the provided iterator may be dereferenced.
@@ -471,7 +470,7 @@ private:
      * @throws JsonIteratorException If the iterator is empty or past-the-end.
      */
     template <typename T>
-    void validate_dereference(const T &it) const noexcept(false);
+    void validate_dereference(const T &it) const;
 
     pointer m_json;
     iterator_type m_iterator;
@@ -541,11 +540,11 @@ JsonIterator<JsonType>::operator=(const NonConstJsonIterator &iterator) noexcept
 
 //==================================================================================================
 template <typename JsonType>
-auto JsonIterator<JsonType>::operator*() const noexcept(false) -> reference
+auto JsonIterator<JsonType>::operator*() const -> reference
 {
     validate_iterator();
 
-    auto visitor = [this](const auto &it) noexcept(false) -> reference {
+    auto visitor = [this](const auto &it) -> reference {
         this->validate_dereference(it);
 
         if constexpr (is_object_iterator<decltype(it)>)
@@ -563,11 +562,11 @@ auto JsonIterator<JsonType>::operator*() const noexcept(false) -> reference
 
 //==================================================================================================
 template <typename JsonType>
-auto JsonIterator<JsonType>::operator->() const noexcept(false) -> pointer
+auto JsonIterator<JsonType>::operator->() const -> pointer
 {
     validate_iterator();
 
-    auto visitor = [this](const auto &it) noexcept(false) -> pointer {
+    auto visitor = [this](const auto &it) -> pointer {
         this->validate_dereference(it);
 
         if constexpr (is_object_iterator<decltype(it)>)
@@ -585,11 +584,11 @@ auto JsonIterator<JsonType>::operator->() const noexcept(false) -> pointer
 
 //==================================================================================================
 template <typename JsonType>
-auto JsonIterator<JsonType>::operator[](difference_type offset) const noexcept(false) -> reference
+auto JsonIterator<JsonType>::operator[](difference_type offset) const -> reference
 {
     validate_iterator();
 
-    auto visitor = [&](const auto &it) noexcept(false) -> reference {
+    auto visitor = [&](const auto &it) -> reference {
         if constexpr (is_array_iterator<decltype(it)>)
         {
             validate_offset(it, offset);
@@ -610,7 +609,7 @@ auto JsonIterator<JsonType>::operator[](difference_type offset) const noexcept(f
 
 //==================================================================================================
 template <typename JsonType>
-bool JsonIterator<JsonType>::operator==(const JsonIterator &iterator) const noexcept(false)
+bool JsonIterator<JsonType>::operator==(const JsonIterator &iterator) const
 {
     validate_iterator(iterator);
     return m_iterator == iterator.m_iterator;
@@ -618,22 +617,18 @@ bool JsonIterator<JsonType>::operator==(const JsonIterator &iterator) const noex
 
 //==================================================================================================
 template <typename JsonType>
-bool JsonIterator<JsonType>::operator!=(const JsonIterator &iterator) const noexcept(false)
+bool JsonIterator<JsonType>::operator!=(const JsonIterator &iterator) const
 {
     return !(*this == iterator);
 }
 
 //==================================================================================================
 template <typename JsonType>
-bool JsonIterator<JsonType>::operator<(const JsonIterator &iterator) const noexcept(false)
+bool JsonIterator<JsonType>::operator<(const JsonIterator &iterator) const
 {
     validate_iterator(iterator);
 
-    // Formatter badly handles hanging indent in lambdas
-    // clang-format off
-    auto visitor = [this](const auto &it1, const auto &it2)
-       noexcept(is_array_iterator<decltype(it1), decltype(it2)>) -> bool
-    {
+    auto visitor = [this](const auto &it1, const auto &it2) -> bool {
         if constexpr (is_array_iterator<decltype(it1), decltype(it2)>)
         {
             return it1 < it2;
@@ -643,35 +638,34 @@ bool JsonIterator<JsonType>::operator<(const JsonIterator &iterator) const noexc
             throw JsonIteratorException(*m_json, "JSON type invalid for comparison operator");
         }
     };
-    // clang-format on
 
     return std::visit(visitor, m_iterator, iterator.m_iterator);
 }
 
 //==================================================================================================
 template <typename JsonType>
-bool JsonIterator<JsonType>::operator<=(const JsonIterator &iterator) const noexcept(false)
+bool JsonIterator<JsonType>::operator<=(const JsonIterator &iterator) const
 {
     return !(iterator < *this);
 }
 
 //==================================================================================================
 template <typename JsonType>
-bool JsonIterator<JsonType>::operator>(const JsonIterator &iterator) const noexcept(false)
+bool JsonIterator<JsonType>::operator>(const JsonIterator &iterator) const
 {
     return !(*this <= iterator);
 }
 
 //==================================================================================================
 template <typename JsonType>
-bool JsonIterator<JsonType>::operator>=(const JsonIterator &iterator) const noexcept(false)
+bool JsonIterator<JsonType>::operator>=(const JsonIterator &iterator) const
 {
     return !(*this < iterator);
 }
 
 //==================================================================================================
 template <typename JsonType>
-auto JsonIterator<JsonType>::operator++(int) noexcept(false) -> JsonIterator
+auto JsonIterator<JsonType>::operator++(int) -> JsonIterator
 {
     auto result = *this;
     ++(*this);
@@ -681,11 +675,11 @@ auto JsonIterator<JsonType>::operator++(int) noexcept(false) -> JsonIterator
 
 //==================================================================================================
 template <typename JsonType>
-auto JsonIterator<JsonType>::operator++() noexcept(false) -> JsonIterator &
+auto JsonIterator<JsonType>::operator++() -> JsonIterator &
 {
     validate_iterator();
 
-    auto visitor = [this](auto &it) noexcept(false) -> JsonIterator & {
+    auto visitor = [this](auto &it) -> JsonIterator & {
         validate_offset(it, 1);
         std::advance(it, 1);
 
@@ -697,7 +691,7 @@ auto JsonIterator<JsonType>::operator++() noexcept(false) -> JsonIterator &
 
 //==================================================================================================
 template <typename JsonType>
-auto JsonIterator<JsonType>::operator--(int) noexcept(false) -> JsonIterator
+auto JsonIterator<JsonType>::operator--(int) -> JsonIterator
 {
     auto result = *this;
     --(*this);
@@ -707,11 +701,11 @@ auto JsonIterator<JsonType>::operator--(int) noexcept(false) -> JsonIterator
 
 //==================================================================================================
 template <typename JsonType>
-auto JsonIterator<JsonType>::operator--() noexcept(false) -> JsonIterator &
+auto JsonIterator<JsonType>::operator--() -> JsonIterator &
 {
     validate_iterator();
 
-    auto visitor = [this](auto &it) noexcept(false) -> JsonIterator & {
+    auto visitor = [this](auto &it) -> JsonIterator & {
         validate_offset(it, -1);
         std::advance(it, -1);
 
@@ -723,11 +717,11 @@ auto JsonIterator<JsonType>::operator--() noexcept(false) -> JsonIterator &
 
 //==================================================================================================
 template <typename JsonType>
-auto JsonIterator<JsonType>::operator+=(difference_type offset) noexcept(false) -> JsonIterator &
+auto JsonIterator<JsonType>::operator+=(difference_type offset) -> JsonIterator &
 {
     validate_iterator();
 
-    auto visitor = [this, &offset](auto &it) noexcept(false) {
+    auto visitor = [this, &offset](auto &it) {
         if constexpr (is_array_iterator<decltype(it)>)
         {
             validate_offset(it, offset);
@@ -745,14 +739,14 @@ auto JsonIterator<JsonType>::operator+=(difference_type offset) noexcept(false) 
 
 //==================================================================================================
 template <typename JsonType>
-auto JsonIterator<JsonType>::operator-=(difference_type offset) noexcept(false) -> JsonIterator &
+auto JsonIterator<JsonType>::operator-=(difference_type offset) -> JsonIterator &
 {
     return *this += -offset;
 }
 
 //==================================================================================================
 template <typename JsonType>
-auto JsonIterator<JsonType>::operator+(difference_type offset) const noexcept(false) -> JsonIterator
+auto JsonIterator<JsonType>::operator+(difference_type offset) const -> JsonIterator
 {
     auto result = *this;
     result += offset;
@@ -764,7 +758,7 @@ auto JsonIterator<JsonType>::operator+(difference_type offset) const noexcept(fa
 template <typename JsonType>
 JsonIterator<JsonType> operator+(
     typename JsonIterator<JsonType>::difference_type offset,
-    const JsonIterator<JsonType> &iterator) noexcept(false)
+    const JsonIterator<JsonType> &iterator)
 {
     auto result = iterator;
     result += offset;
@@ -774,7 +768,7 @@ JsonIterator<JsonType> operator+(
 
 //==================================================================================================
 template <typename JsonType>
-auto JsonIterator<JsonType>::operator-(difference_type offset) const noexcept(false) -> JsonIterator
+auto JsonIterator<JsonType>::operator-(difference_type offset) const -> JsonIterator
 {
     auto result = *this;
     result -= offset;
@@ -784,17 +778,12 @@ auto JsonIterator<JsonType>::operator-(difference_type offset) const noexcept(fa
 
 //==================================================================================================
 template <typename JsonType>
-auto JsonIterator<JsonType>::operator-(const JsonIterator &iterator) const noexcept(false)
-    -> difference_type
+auto JsonIterator<JsonType>::operator-(const JsonIterator &iterator) const -> difference_type
 {
     validate_iterator();
     iterator.validate_iterator();
 
-    // Formatter badly handles hanging indent in lambdas
-    // clang-format off
-    auto visitor = [this](const auto &it1, const auto &it2) noexcept(
-       is_array_iterator<decltype(it1), decltype(it2)>) -> difference_type
-    {
+    auto visitor = [this](const auto &it1, const auto &it2) -> difference_type {
         if constexpr (is_array_iterator<decltype(it1), decltype(it2)>)
         {
             return std::distance(it2, it1);
@@ -804,7 +793,6 @@ auto JsonIterator<JsonType>::operator-(const JsonIterator &iterator) const noexc
             throw JsonIteratorException(*m_json, "JSON type invalid for iterator difference");
         }
     };
-    // clang-format on
 
     return std::visit(visitor, m_iterator, iterator.m_iterator);
 }
@@ -812,15 +800,11 @@ auto JsonIterator<JsonType>::operator-(const JsonIterator &iterator) const noexc
 //==================================================================================================
 template <typename JsonType>
 const typename JsonTraits::object_type::key_type &JsonIterator<JsonType>::key() const
-    noexcept(false)
+
 {
     validate_iterator();
 
-    // Formatter badly handles hanging indent in lambdas
-    // clang-format off
-    auto visitor = [this](const auto &it) noexcept(false)
-        -> const typename JsonTraits::object_type::key_type &
-    {
+    auto visitor = [this](const auto &it) -> const typename JsonTraits::object_type::key_type & {
         if constexpr (is_object_iterator<decltype(it)>)
         {
             validate_dereference(it);
@@ -831,21 +815,20 @@ const typename JsonTraits::object_type::key_type &JsonIterator<JsonType>::key() 
             throw JsonIteratorException(*m_json, "JSON type is not keyed");
         }
     };
-    // clang-format on
 
     return std::visit(visitor, m_iterator);
 }
 
 //==================================================================================================
 template <typename JsonType>
-auto JsonIterator<JsonType>::value() const noexcept(false) -> reference
+auto JsonIterator<JsonType>::value() const -> reference
 {
     return *(*this);
 }
 
 //==================================================================================================
 template <typename JsonType>
-void JsonIterator<JsonType>::validate_iterator() const noexcept(false)
+void JsonIterator<JsonType>::validate_iterator() const
 {
     if (m_json == nullptr)
     {
@@ -855,7 +838,7 @@ void JsonIterator<JsonType>::validate_iterator() const noexcept(false)
 
 //==================================================================================================
 template <typename JsonType>
-void JsonIterator<JsonType>::validate_iterator(const JsonIterator &iterator) const noexcept(false)
+void JsonIterator<JsonType>::validate_iterator(const JsonIterator &iterator) const
 {
     validate_iterator();
     iterator.validate_iterator();
@@ -870,7 +853,7 @@ void JsonIterator<JsonType>::validate_iterator(const JsonIterator &iterator) con
 template <typename JsonType>
 template <typename T>
 void JsonIterator<JsonType>::validate_offset(const T &it, difference_type offset) const
-    noexcept(false)
+
 {
     difference_type distance = 0;
 
@@ -894,7 +877,7 @@ void JsonIterator<JsonType>::validate_offset(const T &it, difference_type offset
 //==================================================================================================
 template <typename JsonType>
 template <typename T>
-void JsonIterator<JsonType>::validate_dereference(const T &it) const noexcept(false)
+void JsonIterator<JsonType>::validate_dereference(const T &it) const
 {
     const JsonIterator end = m_json->end();
 

--- a/fly/types/json/json.cpp
+++ b/fly/types/json/json.cpp
@@ -109,25 +109,25 @@ Json::reference Json::operator=(Json json) noexcept
 }
 
 //==================================================================================================
-bool Json::is_null() const noexcept
+bool Json::is_null() const
 {
     return std::holds_alternative<JsonTraits::null_type>(m_value);
 }
 
 //==================================================================================================
-bool Json::is_string() const noexcept
+bool Json::is_string() const
 {
     return std::holds_alternative<JsonTraits::string_type>(m_value);
 }
 
 //==================================================================================================
-bool Json::is_object() const noexcept
+bool Json::is_object() const
 {
     return std::holds_alternative<JsonTraits::object_type>(m_value);
 }
 
 //==================================================================================================
-bool Json::is_object_like() const noexcept
+bool Json::is_object_like() const
 {
     const auto *value = std::get_if<JsonTraits::array_type>(&m_value);
 
@@ -135,31 +135,31 @@ bool Json::is_object_like() const noexcept
 }
 
 //==================================================================================================
-bool Json::is_array() const noexcept
+bool Json::is_array() const
 {
     return std::holds_alternative<JsonTraits::array_type>(m_value);
 }
 
 //==================================================================================================
-bool Json::is_boolean() const noexcept
+bool Json::is_boolean() const
 {
     return std::holds_alternative<JsonTraits::boolean_type>(m_value);
 }
 
 //==================================================================================================
-bool Json::is_signed_integer() const noexcept
+bool Json::is_signed_integer() const
 {
     return std::holds_alternative<JsonTraits::signed_type>(m_value);
 }
 
 //==================================================================================================
-bool Json::is_unsigned_integer() const noexcept
+bool Json::is_unsigned_integer() const
 {
     return std::holds_alternative<JsonTraits::unsigned_type>(m_value);
 }
 
 //==================================================================================================
-bool Json::is_float() const noexcept
+bool Json::is_float() const
 {
     return std::holds_alternative<JsonTraits::float_type>(m_value);
 }
@@ -194,8 +194,7 @@ Json::operator JsonTraits::string_type() const noexcept
 }
 
 //==================================================================================================
-Json::reference
-Json::operator[](const typename JsonTraits::object_type::key_type &key) noexcept(false)
+Json::reference Json::operator[](const typename JsonTraits::object_type::key_type &key)
 {
     if (is_null())
     {
@@ -215,13 +214,13 @@ Json::operator[](const typename JsonTraits::object_type::key_type &key) noexcept
 
 //==================================================================================================
 Json::const_reference Json::operator[](const typename JsonTraits::object_type::key_type &key) const
-    noexcept(false)
+
 {
     return at(key);
 }
 
 //==================================================================================================
-Json::reference Json::operator[](size_type index) noexcept(false)
+Json::reference Json::operator[](size_type index)
 {
     if (is_null())
     {
@@ -244,13 +243,13 @@ Json::reference Json::operator[](size_type index) noexcept(false)
 }
 
 //==================================================================================================
-Json::const_reference Json::operator[](size_type index) const noexcept(false)
+Json::const_reference Json::operator[](size_type index) const
 {
     return at(index);
 }
 
 //==================================================================================================
-Json::reference Json::at(const typename JsonTraits::object_type::key_type &key) noexcept(false)
+Json::reference Json::at(const typename JsonTraits::object_type::key_type &key)
 {
     if (is_object())
     {
@@ -272,7 +271,7 @@ Json::reference Json::at(const typename JsonTraits::object_type::key_type &key) 
 
 //==================================================================================================
 Json::const_reference Json::at(const typename JsonTraits::object_type::key_type &key) const
-    noexcept(false)
+
 {
     if (is_object())
     {
@@ -293,7 +292,7 @@ Json::const_reference Json::at(const typename JsonTraits::object_type::key_type 
 }
 
 //==================================================================================================
-Json::reference Json::at(size_type index) noexcept(false)
+Json::reference Json::at(size_type index)
 {
     if (is_array())
     {
@@ -311,7 +310,7 @@ Json::reference Json::at(size_type index) noexcept(false)
 }
 
 //==================================================================================================
-Json::const_reference Json::at(size_type index) const noexcept(false)
+Json::const_reference Json::at(size_type index) const
 {
     if (is_array())
     {
@@ -329,9 +328,9 @@ Json::const_reference Json::at(size_type index) const noexcept(false)
 }
 
 //==================================================================================================
-bool Json::empty() const noexcept
+bool Json::empty() const
 {
-    auto visitor = [](const auto &value) noexcept -> bool {
+    auto visitor = [](const auto &value) -> bool {
         using T = std::decay_t<decltype(value)>;
 
         if constexpr (std::is_same_v<T, JsonTraits::null_type>)
@@ -354,9 +353,9 @@ bool Json::empty() const noexcept
 }
 
 //==================================================================================================
-Json::size_type Json::size() const noexcept
+Json::size_type Json::size() const
 {
-    auto visitor = [](const auto &value) noexcept -> size_type {
+    auto visitor = [](const auto &value) -> size_type {
         using T = std::decay_t<decltype(value)>;
 
         if constexpr (std::is_same_v<T, JsonTraits::null_type>)
@@ -379,9 +378,9 @@ Json::size_type Json::size() const noexcept
 }
 
 //==================================================================================================
-void Json::clear() noexcept
+void Json::clear()
 {
-    auto visitor = [](auto &value) noexcept {
+    auto visitor = [](auto &value) {
         using T = std::decay_t<decltype(value)>;
 
         if constexpr (
@@ -407,49 +406,49 @@ void Json::clear() noexcept
 }
 
 //==================================================================================================
-void Json::swap(reference json) noexcept
+void Json::swap(reference json)
 {
     std::swap(m_value, json.m_value);
 }
 
 //==================================================================================================
-Json::iterator Json::begin() noexcept(false)
+Json::iterator Json::begin()
 {
     return iterator(this, iterator::Position::Begin);
 }
 
 //==================================================================================================
-Json::const_iterator Json::begin() const noexcept(false)
+Json::const_iterator Json::begin() const
 {
     return cbegin();
 }
 
 //==================================================================================================
-Json::const_iterator Json::cbegin() const noexcept(false)
+Json::const_iterator Json::cbegin() const
 {
     return const_iterator(this, const_iterator::Position::Begin);
 }
 
 //==================================================================================================
-Json::iterator Json::end() noexcept(false)
+Json::iterator Json::end()
 {
     return iterator(this, iterator::Position::End);
 }
 
 //==================================================================================================
-Json::const_iterator Json::end() const noexcept(false)
+Json::const_iterator Json::end() const
 {
     return cend();
 }
 
 //==================================================================================================
-Json::const_iterator Json::cend() const noexcept(false)
+Json::const_iterator Json::cend() const
 {
     return const_iterator(this, const_iterator::Position::End);
 }
 
 //==================================================================================================
-void Json::swap(JsonTraits::string_type &other) noexcept(false)
+void Json::swap(JsonTraits::string_type &other)
 {
     if (is_string())
     {
@@ -463,9 +462,9 @@ void Json::swap(JsonTraits::string_type &other) noexcept(false)
 }
 
 //==================================================================================================
-bool operator==(Json::const_reference json1, Json::const_reference json2) noexcept
+bool operator==(Json::const_reference json1, Json::const_reference json2)
 {
-    auto visitor = [](const auto &value1, const auto &value2) noexcept -> bool {
+    auto visitor = [](const auto &value1, const auto &value2) -> bool {
         using F = JsonTraits::float_type;
         using T = std::decay_t<decltype(value1)>;
         using U = std::decay_t<decltype(value2)>;
@@ -497,13 +496,13 @@ bool operator==(Json::const_reference json1, Json::const_reference json2) noexce
 }
 
 //==================================================================================================
-bool operator!=(Json::const_reference json1, Json::const_reference json2) noexcept
+bool operator!=(Json::const_reference json1, Json::const_reference json2)
 {
     return !(json1 == json2);
 }
 
 //==================================================================================================
-std::ostream &operator<<(std::ostream &stream, Json::const_reference json) noexcept
+std::ostream &operator<<(std::ostream &stream, Json::const_reference json)
 {
     auto serialize_string = [&stream](const JsonTraits::string_type &value) {
         const auto end = value.cend();
@@ -576,7 +575,7 @@ std::ostream &operator<<(std::ostream &stream, Json::const_reference json) noexc
 }
 
 //==================================================================================================
-JsonTraits::string_type Json::validate_string(const JsonTraits::string_type &str) noexcept(false)
+JsonTraits::string_type Json::validate_string(const JsonTraits::string_type &str)
 {
     stream_type stream;
 
@@ -601,7 +600,7 @@ JsonTraits::string_type Json::validate_string(const JsonTraits::string_type &str
 void Json::read_escaped_character(
     stream_type &stream,
     JsonTraits::string_type::const_iterator &it,
-    const JsonTraits::string_type::const_iterator &end) noexcept(false)
+    const JsonTraits::string_type::const_iterator &end)
 {
     if (++it == end)
     {
@@ -662,7 +661,7 @@ void Json::read_escaped_character(
 void Json::write_escaped_charater(
     std::ostream &stream,
     JsonTraits::string_type::const_iterator &it,
-    const JsonTraits::string_type::const_iterator &end) noexcept
+    const JsonTraits::string_type::const_iterator &end)
 {
     switch (*it)
     {
@@ -706,7 +705,7 @@ void Json::write_escaped_charater(
 void Json::validate_character(
     stream_type &stream,
     JsonTraits::string_type::const_iterator &it,
-    const JsonTraits::string_type::const_iterator &end) noexcept(false)
+    const JsonTraits::string_type::const_iterator &end)
 {
     const std::uint8_t ch = static_cast<std::uint8_t>(*it);
     auto start = it;

--- a/fly/types/json/json.hpp
+++ b/fly/types/json/json.hpp
@@ -233,17 +233,17 @@ public:
     /**
      * @return True if the Json instance is null.
      */
-    bool is_null() const noexcept;
+    bool is_null() const;
 
     /**
      * @return True if the Json instance is a string.
      */
-    bool is_string() const noexcept;
+    bool is_string() const;
 
     /**
      * @return True if the Json instance is an object.
      */
-    bool is_object() const noexcept;
+    bool is_object() const;
 
     /**
      * Determine if the Json instance is object-like. This is mostly useful for constructing a Json
@@ -252,32 +252,32 @@ public:
      *
      * @return True if the Json instance is object-like.
      */
-    bool is_object_like() const noexcept;
+    bool is_object_like() const;
 
     /**
      * @return True if the Json instance is an array.
      */
-    bool is_array() const noexcept;
+    bool is_array() const;
 
     /**
      * @return True if the Json instance is a boolean.
      */
-    bool is_boolean() const noexcept;
+    bool is_boolean() const;
 
     /**
      * @return True if the Json instance is a signed integer.
      */
-    bool is_signed_integer() const noexcept;
+    bool is_signed_integer() const;
 
     /**
      * @return True if the Json instance is an unsigned integer.
      */
-    bool is_unsigned_integer() const noexcept;
+    bool is_unsigned_integer() const;
 
     /**
      * @return True if the Json instance is a float.
      */
-    bool is_float() const noexcept;
+    bool is_float() const;
 
     /**
      * Null conversion operator. Converts the Json instance to a null type.
@@ -394,7 +394,7 @@ public:
      * @throws JsonException If the Json instance is neither an object nor null, or the key value is
      *         invalid.
      */
-    reference operator[](const typename JsonTraits::object_type::key_type &key) noexcept(false);
+    reference operator[](const typename JsonTraits::object_type::key_type &key);
 
     /**
      * Object read-only access operator.
@@ -408,8 +408,7 @@ public:
      * @throws JsonException If the Json instance is not an object, or the key value does not exist,
      *         or the key value is invalid.
      */
-    const_reference operator[](const typename JsonTraits::object_type::key_type &key) const
-        noexcept(false);
+    const_reference operator[](const typename JsonTraits::object_type::key_type &key) const;
 
     /**
      * Array access operator.
@@ -425,7 +424,7 @@ public:
      *
      * @throws JsonException If the Json instance is neither an array nor null.
      */
-    reference operator[](size_type index) noexcept(false);
+    reference operator[](size_type index);
 
     /**
      * Array read-only access operator.
@@ -438,7 +437,7 @@ public:
      *
      * @throws JsonException If the Json instance is not an array or the index does not exist.
      */
-    const_reference operator[](size_type index) const noexcept(false);
+    const_reference operator[](size_type index) const;
 
     /**
      * Object read-only accessor.
@@ -452,7 +451,7 @@ public:
      * @throws JsonException If the Json instance is not an object, or the key value does not exist,
      *         or the key value is invalid.
      */
-    reference at(const typename JsonTraits::object_type::key_type &key) noexcept(false);
+    reference at(const typename JsonTraits::object_type::key_type &key);
 
     /**
      * Object read-only accessor.
@@ -466,7 +465,7 @@ public:
      * @throws JsonException If the Json instance is not an object, or the key value does not exist,
      *         or the key value is invalid.
      */
-    const_reference at(const typename JsonTraits::object_type::key_type &key) const noexcept(false);
+    const_reference at(const typename JsonTraits::object_type::key_type &key) const;
 
     /**
      * Array read-only accessor.
@@ -479,7 +478,7 @@ public:
      *
      * @throws JsonException If the Json instance is not an array or the index does not exist.
      */
-    reference at(size_type index) noexcept(false);
+    reference at(size_type index);
 
     /**
      * Array read-only accessor.
@@ -492,7 +491,7 @@ public:
      *
      * @throws JsonException If the Json instance is not an array or the index does not exist.
      */
-    const_reference at(size_type index) const noexcept(false);
+    const_reference at(size_type index) const;
 
     /**
      * Check if the Json instance contains zero elements.
@@ -506,7 +505,7 @@ public:
      *
      * @return True if the instance is empty.
      */
-    bool empty() const noexcept;
+    bool empty() const;
 
     /**
      * Get the number of elements in the Json instance.
@@ -522,7 +521,7 @@ public:
      *
      * @return The size of the Json instance.
      */
-    size_type size() const noexcept;
+    size_type size() const;
 
     /**
      * Clear the contents of the Json instance.
@@ -533,14 +532,14 @@ public:
      *
      * If the Json instance is numeric, sets to zero.
      */
-    void clear() noexcept;
+    void clear();
 
     /**
      * Exchange the contents of the Json instance with another instance.
      *
      * @param json The Json instance to swap with.
      */
-    void swap(reference json) noexcept;
+    void swap(reference json);
 
     /**
      * Exchange the contents of the Json instance with another string. Only valid if the Json
@@ -550,7 +549,7 @@ public:
      *
      * @throws JsonException If the Json instance is not a string.
      */
-    void swap(JsonTraits::string_type &other) noexcept(false);
+    void swap(JsonTraits::string_type &other);
 
     /**
      * Exchange the contents of the Json instance with another object. Only valid if the Json
@@ -561,7 +560,7 @@ public:
      * @throws JsonException If the Json instance is not an object.
      */
     template <typename T, enable_if_all<JsonTraits::is_object<T>> = 0>
-    void swap(T &other) noexcept(false);
+    void swap(T &other);
 
     /**
      * Exchange the contents of the Json instance with another array. Only valid if the Json
@@ -572,7 +571,7 @@ public:
      * @throws JsonException If the Json instance is not an array.
      */
     template <typename T, enable_if_all<JsonTraits::is_array<T>> = 0>
-    void swap(T &other) noexcept(false);
+    void swap(T &other);
 
     /**
      * Retrieve an iterator to the beginning of the Json instance.
@@ -581,7 +580,7 @@ public:
      *
      * @throws JsonException If the Json instance is not an object or array.
      */
-    iterator begin() noexcept(false);
+    iterator begin();
 
     /**
      * Retrieve a constant iterator to the beginning of the Json instance.
@@ -590,7 +589,7 @@ public:
      *
      * @throws JsonException If the Json instance is not an object or array.
      */
-    const_iterator begin() const noexcept(false);
+    const_iterator begin() const;
 
     /**
      * Retrieve a constant iterator to the beginning of the Json instance.
@@ -599,7 +598,7 @@ public:
      *
      * @throws JsonException If the Json instance is not an object or array.
      */
-    const_iterator cbegin() const noexcept(false);
+    const_iterator cbegin() const;
 
     /**
      * Retrieve an iterator to the end of the Json instance.
@@ -608,7 +607,7 @@ public:
      *
      * @throws JsonException If the Json instance is not an object or array.
      */
-    iterator end() noexcept(false);
+    iterator end();
 
     /**
      * Retrieve a constant iterator to the end of the Json instance.
@@ -617,7 +616,7 @@ public:
      *
      * @throws JsonException If the Json instance is not an object or array.
      */
-    const_iterator end() const noexcept(false);
+    const_iterator end() const;
 
     /**
      * Retrieve a constant iterator to the end of the Json instance.
@@ -626,7 +625,7 @@ public:
      *
      * @throws JsonException If the Json instance is not an object or array.
      */
-    const_iterator cend() const noexcept(false);
+    const_iterator cend() const;
 
     /**
      * Equality operator. Compares two Json instances for equality. They are equal if one of the
@@ -642,7 +641,7 @@ public:
      *
      * @return True if the two Json instances are equal.
      */
-    friend bool operator==(const_reference json1, const_reference json2) noexcept;
+    friend bool operator==(const_reference json1, const_reference json2);
 
     /**
      * Unequality operator. Compares two Json instances for unequality. They are unequal if none of
@@ -650,7 +649,7 @@ public:
      *
      * @return True if the two Json instances are unequal.
      */
-    friend bool operator!=(const_reference json1, const_reference json2) noexcept;
+    friend bool operator!=(const_reference json1, const_reference json2);
 
     /**
      * Stream operator. Stream the Json instance into an output stream.
@@ -660,7 +659,7 @@ public:
      *
      * @return A reference to the output stream.
      */
-    friend std::ostream &operator<<(std::ostream &stream, const_reference json) noexcept;
+    friend std::ostream &operator<<(std::ostream &stream, const_reference json);
 
 private:
     friend iterator;
@@ -676,8 +675,7 @@ private:
      *
      * @throws JsonException If the string value is not valid.
      */
-    static JsonTraits::string_type
-    validate_string(const JsonTraits::string_type &str) noexcept(false);
+    static JsonTraits::string_type validate_string(const JsonTraits::string_type &str);
 
     /**
      * After reading a reverse solidus character, read the escaped character that follows. Replace
@@ -693,7 +691,7 @@ private:
     static void read_escaped_character(
         stream_type &stream,
         JsonTraits::string_type::const_iterator &it,
-        const JsonTraits::string_type::const_iterator &end) noexcept(false);
+        const JsonTraits::string_type::const_iterator &end);
 
     /**
      * Write a character to a stream, handling any value that should be escaped. For those
@@ -706,7 +704,7 @@ private:
     static void write_escaped_charater(
         std::ostream &stream,
         JsonTraits::string_type::const_iterator &it,
-        const JsonTraits::string_type::const_iterator &end) noexcept;
+        const JsonTraits::string_type::const_iterator &end);
 
     /**
      * Validate a non-escaped character is JSON and Unicode compliant. If so, write the character
@@ -721,7 +719,7 @@ private:
     static void validate_character(
         stream_type &stream,
         JsonTraits::string_type::const_iterator &it,
-        const JsonTraits::string_type::const_iterator &end) noexcept(false);
+        const JsonTraits::string_type::const_iterator &end);
 
     json_type m_value;
 };
@@ -899,7 +897,7 @@ Json::operator T() const noexcept(false)
 
 //==================================================================================================
 template <typename T, enable_if_all<JsonTraits::is_object<T>>>
-void Json::swap(T &other) noexcept(false)
+void Json::swap(T &other)
 {
     if (is_object())
     {
@@ -916,7 +914,7 @@ void Json::swap(T &other) noexcept(false)
 
 //==================================================================================================
 template <typename T, enable_if_all<JsonTraits::is_array<T>>>
-void Json::swap(T &other) noexcept(false)
+void Json::swap(T &other)
 {
     if (is_array())
     {

--- a/fly/types/numeric/endian.hpp
+++ b/fly/types/numeric/endian.hpp
@@ -52,7 +52,7 @@ enum class Endian : std::uint16_t
  * @return The swapped value.
  */
 template <Endian Endianness, typename T>
-inline T endian_swap(T value) noexcept
+inline T endian_swap(T value)
 {
     static_assert(
         detail::EndianTraits::is_supported_integer_v<T>,

--- a/fly/types/string/detail/string_converter.hpp
+++ b/fly/types/string/detail/string_converter.hpp
@@ -29,7 +29,7 @@ struct BasicStringConverter;
 template <typename StringType, typename T>
 struct BasicStringConverter
 {
-    static T convert(const StringType &value) noexcept(false)
+    static T convert(const StringType &value)
     {
         static constexpr long long s_min = std::numeric_limits<T>::min();
         static constexpr long long s_max = std::numeric_limits<T>::max();
@@ -56,7 +56,7 @@ struct BasicStringConverter<StringType, std::int64_t>
 {
     using value_type = std::int64_t;
 
-    static value_type convert(const StringType &value) noexcept(false)
+    static value_type convert(const StringType &value)
     {
         std::size_t index = 0;
         value_type result = std::stoll(value, &index);
@@ -76,7 +76,7 @@ struct BasicStringConverter<StringType, std::uint64_t>
 {
     using value_type = std::uint64_t;
 
-    static value_type convert(const StringType &value) noexcept(false)
+    static value_type convert(const StringType &value)
     {
         std::size_t index = 0;
         value_type result = std::stoull(value, &index);
@@ -96,7 +96,7 @@ struct BasicStringConverter<StringType, float>
 {
     using value_type = float;
 
-    static value_type convert(const StringType &value) noexcept(false)
+    static value_type convert(const StringType &value)
     {
         std::size_t index = 0;
         value_type result = std::stof(value, &index);
@@ -116,7 +116,7 @@ struct BasicStringConverter<StringType, double>
 {
     using value_type = double;
 
-    static value_type convert(const StringType &value) noexcept(false)
+    static value_type convert(const StringType &value)
     {
         std::size_t index = 0;
         value_type result = std::stod(value, &index);
@@ -136,7 +136,7 @@ struct BasicStringConverter<StringType, long double>
 {
     using value_type = long double;
 
-    static value_type convert(const StringType &value) noexcept(false)
+    static value_type convert(const StringType &value)
     {
         std::size_t index = 0;
         value_type result = std::stold(value, &index);

--- a/fly/types/string/detail/string_formatter.hpp
+++ b/fly/types/string/detail/string_formatter.hpp
@@ -43,7 +43,7 @@ public:
      * @return A string that has been formatted with the given arguments.
      */
     template <typename... Args>
-    static streamed_type format(const char_type *fmt, const Args &... args) noexcept;
+    static streamed_type format(const char_type *fmt, const Args &... args);
 
     /**
      * Format a string with variadic template arguments, inserting the formatted string into a
@@ -68,8 +68,7 @@ public:
      * @return The same stream object.
      */
     template <typename... Args>
-    static ostream_type &
-    format(ostream_type &ostream, const char_type *fmt, const Args &... args) noexcept;
+    static ostream_type &format(ostream_type &ostream, const char_type *fmt, const Args &... args);
 
     /**
      * Stream the given value into the given stream. If the value is a string-like type, the string
@@ -81,7 +80,7 @@ public:
      * @param value The value to stream.
      */
     template <typename T>
-    static void stream(ostream_type &ostream, const T &value) noexcept;
+    static void stream(ostream_type &ostream, const T &value);
 
 private:
     /**
@@ -92,19 +91,19 @@ private:
         ostream_type &ostream,
         const char_type *fmt,
         const T &value,
-        const Args &... args) noexcept;
+        const Args &... args);
 
     /**
      * Terminator for the variadic template formatter. Stream the rest of the string into the given
      * ostream.
      */
-    static void format_internal(ostream_type &ostream, const char_type *fmt) noexcept;
+    static void format_internal(ostream_type &ostream, const char_type *fmt);
 };
 
 //==================================================================================================
 template <typename StringType>
 template <typename... Args>
-auto BasicStringFormatter<StringType>::format(const char_type *fmt, const Args &... args) noexcept
+auto BasicStringFormatter<StringType>::format(const char_type *fmt, const Args &... args)
     -> streamed_type
 {
     typename traits::ostringstream_type ostream;
@@ -120,7 +119,7 @@ template <typename... Args>
 auto BasicStringFormatter<StringType>::format(
     ostream_type &ostream,
     const char_type *fmt,
-    const Args &... args) noexcept -> ostream_type &
+    const Args &... args) -> ostream_type &
 {
     if (fmt != nullptr)
     {
@@ -137,7 +136,7 @@ void BasicStringFormatter<StringType>::format_internal(
     ostream_type &ostream,
     const char_type *fmt,
     const T &value,
-    const Args &... args) noexcept
+    const Args &... args)
 {
     const std::ios_base::fmtflags flags(ostream.flags());
 
@@ -213,9 +212,7 @@ void BasicStringFormatter<StringType>::format_internal(
 
 //==================================================================================================
 template <typename StringType>
-void BasicStringFormatter<StringType>::format_internal(
-    ostream_type &ostream,
-    const char_type *fmt) noexcept
+void BasicStringFormatter<StringType>::format_internal(ostream_type &ostream, const char_type *fmt)
 {
     for (; *fmt != '\0'; ++fmt)
     {
@@ -233,7 +230,7 @@ void BasicStringFormatter<StringType>::format_internal(
 //==================================================================================================
 template <typename StringType>
 template <typename T>
-void BasicStringFormatter<StringType>::stream(ostream_type &ostream, const T &value) noexcept
+void BasicStringFormatter<StringType>::stream(ostream_type &ostream, const T &value)
 {
     if constexpr (
         std::is_same_v<char_type, std::decay_t<T>> || traits::template is_string_like_v<T>)

--- a/fly/types/string/detail/string_streamer.hpp
+++ b/fly/types/string/detail/string_streamer.hpp
@@ -47,17 +47,17 @@ struct BasicStringStreamer<std::string>
     using istringstream_type = std::istringstream;
     using ostringstream_type = std::ostringstream;
 
-    static void stream(ostream_type &ostream, const std::string &value) noexcept
+    static void stream(ostream_type &ostream, const std::string &value)
     {
         ostream << value;
     }
 
-    static void stream(ostream_type &ostream, const char *value) noexcept
+    static void stream(ostream_type &ostream, const char *value)
     {
         ostream << value;
     }
 
-    static void stream(ostream_type &ostream, const char value) noexcept
+    static void stream(ostream_type &ostream, const char value)
     {
         ostream << value;
     }
@@ -80,17 +80,17 @@ struct BasicStringStreamer<std::wstring>
     using istringstream_type = std::wistringstream;
     using ostringstream_type = std::wostringstream;
 
-    static void stream(ostream_type &ostream, const std::wstring &value) noexcept
+    static void stream(ostream_type &ostream, const std::wstring &value)
     {
         ostream << value;
     }
 
-    static void stream(ostream_type &ostream, const wchar_t *value) noexcept
+    static void stream(ostream_type &ostream, const wchar_t *value)
     {
         ostream << value;
     }
 
-    static void stream(ostream_type &ostream, const wchar_t value) noexcept
+    static void stream(ostream_type &ostream, const wchar_t value)
     {
         ostream << value;
     }
@@ -113,7 +113,7 @@ struct BasicStringStreamer<std::u16string>
     using istringstream_type = std::istringstream;
     using ostringstream_type = std::ostringstream;
 
-    static void stream(ostream_type &ostream, const std::u16string &value) noexcept
+    static void stream(ostream_type &ostream, const std::u16string &value)
     {
         for (const auto &ch : value)
         {
@@ -121,7 +121,7 @@ struct BasicStringStreamer<std::u16string>
         }
     }
 
-    static void stream(ostream_type &ostream, const char16_t *value) noexcept
+    static void stream(ostream_type &ostream, const char16_t *value)
     {
         const std::size_t size = std::char_traits<char16_t>::length(value);
 
@@ -131,7 +131,7 @@ struct BasicStringStreamer<std::u16string>
         }
     }
 
-    static void stream(ostream_type &ostream, const char16_t value) noexcept
+    static void stream(ostream_type &ostream, const char16_t value)
     {
         if (value <= 127)
         {
@@ -163,7 +163,7 @@ struct BasicStringStreamer<std::u32string>
     using istringstream_type = std::istringstream;
     using ostringstream_type = std::ostringstream;
 
-    static void stream(ostream_type &ostream, const std::u32string &value) noexcept
+    static void stream(ostream_type &ostream, const std::u32string &value)
     {
         for (const auto &ch : value)
         {
@@ -171,7 +171,7 @@ struct BasicStringStreamer<std::u32string>
         }
     }
 
-    static void stream(ostream_type &ostream, const char32_t *value) noexcept
+    static void stream(ostream_type &ostream, const char32_t *value)
     {
         const std::size_t size = std::char_traits<char32_t>::length(value);
 
@@ -181,7 +181,7 @@ struct BasicStringStreamer<std::u32string>
         }
     }
 
-    static void stream(ostream_type &ostream, const char32_t value) noexcept
+    static void stream(ostream_type &ostream, const char32_t value)
     {
         if (value <= 127)
         {

--- a/fly/types/string/detail/string_unicode.hpp
+++ b/fly/types/string/detail/string_unicode.hpp
@@ -48,7 +48,7 @@ public:
      */
     static codepoint_type decode_character(
         typename StringType::const_iterator &it,
-        const typename StringType::const_iterator &end) noexcept(false);
+        const typename StringType::const_iterator &end);
 
     /**
      * Escape a single unicode codepoint, starting at the character pointed to by the provided
@@ -81,7 +81,7 @@ public:
     template <char UnicodePrefix>
     static StringType escape_character(
         typename StringType::const_iterator &it,
-        const typename StringType::const_iterator &end) noexcept(false);
+        const typename StringType::const_iterator &end);
 
     /**
      * Unescape a single unicode codepoint, starting at the character pointed to by provided
@@ -103,7 +103,7 @@ public:
      */
     static StringType unescape_character(
         typename StringType::const_iterator &it,
-        const typename StringType::const_iterator &end) noexcept(false);
+        const typename StringType::const_iterator &end);
 
 private:
     using EncodedByteProvider = std::function<codepoint_type()>;
@@ -118,7 +118,7 @@ private:
      * @return The escaped unicode codepoint.
      */
     template <char UnicodePrefix>
-    static StringType escape_codepoint(codepoint_type codepoint) noexcept;
+    static StringType escape_codepoint(codepoint_type codepoint);
 
     /**
      * Unescape a sequence of characters to form a single unicode codepoint.
@@ -135,7 +135,7 @@ private:
     template <char UnicodePrefix>
     static codepoint_type unescape_codepoint(
         typename StringType::const_iterator &it,
-        const typename StringType::const_iterator &end) noexcept(false);
+        const typename StringType::const_iterator &end);
 
     /**
      * Decode a UTF-8 encoded unicode codepoint.
@@ -147,7 +147,7 @@ private:
      * @throws UnicodeException If the unicode codepoint could not be decoded.
      */
     template <typename CharType = char_type, std::enable_if_t<(sizeof(CharType) == 1), bool> = 0>
-    static codepoint_type decode_codepoint(EncodedByteProvider next_encoded_byte) noexcept(false);
+    static codepoint_type decode_codepoint(EncodedByteProvider next_encoded_byte);
 
     /**
      * Decode a UTF-16 encoded unicode codepoint.
@@ -159,7 +159,7 @@ private:
      * @throws UnicodeException If the unicode codepoint could not be decoded.
      */
     template <typename CharType = char_type, std::enable_if_t<(sizeof(CharType) == 2), bool> = 0>
-    static codepoint_type decode_codepoint(EncodedByteProvider next_encoded_byte) noexcept(false);
+    static codepoint_type decode_codepoint(EncodedByteProvider next_encoded_byte);
 
     /**
      * Decode a UTF-32 encoded unicode codepoint.
@@ -169,7 +169,7 @@ private:
      * @return The decoded unicode codepoint.
      */
     template <typename CharType = char_type, std::enable_if_t<(sizeof(CharType) == 4), bool> = 0>
-    static codepoint_type decode_codepoint(EncodedByteProvider next_encoded_byte) noexcept(false);
+    static codepoint_type decode_codepoint(EncodedByteProvider next_encoded_byte);
 
     /**
      * Encode a unicode codepoint as UTF-8.
@@ -179,7 +179,7 @@ private:
      * @return The encoded unicode codepoint.
      */
     template <typename CharType = char_type, std::enable_if_t<(sizeof(CharType) == 1), bool> = 0>
-    static StringType encode_codepoint(codepoint_type codepoint) noexcept;
+    static StringType encode_codepoint(codepoint_type codepoint);
 
     /**
      * Encode a unicode codepoint as UTF-16.
@@ -189,7 +189,7 @@ private:
      * @return The encoded unicode codepoint.
      */
     template <typename CharType = char_type, std::enable_if_t<(sizeof(CharType) == 2), bool> = 0>
-    static StringType encode_codepoint(codepoint_type codepoint) noexcept;
+    static StringType encode_codepoint(codepoint_type codepoint);
 
     /**
      * Encode a unicode codepoint as UTF-32.
@@ -199,7 +199,7 @@ private:
      * @return The encoded unicode codepoint.
      */
     template <typename CharType = char_type, std::enable_if_t<(sizeof(CharType) == 4), bool> = 0>
-    static StringType encode_codepoint(codepoint_type codepoint) noexcept;
+    static StringType encode_codepoint(codepoint_type codepoint);
 
     /**
      * Create a unicode codepoint from either one complete codepoint or two surrogate halves. The
@@ -214,7 +214,7 @@ private:
      *
      * @throws UnicodeException If the unicode codepoint could not be created.
      */
-    static codepoint_type create_codepoint(EncodedByteProvider next_encoded_byte) noexcept(false);
+    static codepoint_type create_codepoint(EncodedByteProvider next_encoded_byte);
 
     /**
      * Structure to hold static data required for decoding UTF-8 encoded unicode codepoints.
@@ -271,9 +271,9 @@ private:
 template <typename StringType>
 auto BasicStringUnicode<StringType>::decode_character(
     typename StringType::const_iterator &it,
-    const typename StringType::const_iterator &end) noexcept(false) -> codepoint_type
+    const typename StringType::const_iterator &end) -> codepoint_type
 {
-    auto next_encoded_byte = [&it, &end]() noexcept(false) -> codepoint_type {
+    auto next_encoded_byte = [&it, &end]() -> codepoint_type {
         if (it == end)
         {
             throw UnicodeException("Expected another encoded byte");
@@ -304,7 +304,7 @@ template <typename StringType>
 template <char UnicodePrefix>
 StringType BasicStringUnicode<StringType>::escape_character(
     typename StringType::const_iterator &it,
-    const typename StringType::const_iterator &end) noexcept(false)
+    const typename StringType::const_iterator &end)
 {
     static_assert((UnicodePrefix == 'u') || (UnicodePrefix == 'U'));
 
@@ -316,7 +316,7 @@ StringType BasicStringUnicode<StringType>::escape_character(
 template <typename StringType>
 StringType BasicStringUnicode<StringType>::unescape_character(
     typename StringType::const_iterator &it,
-    const typename StringType::const_iterator &end) noexcept(false)
+    const typename StringType::const_iterator &end)
 {
     auto escaped_with = [&it, &end](const char_type ch) -> bool {
         if ((it == end) || ((it + 1) == end))
@@ -331,7 +331,7 @@ StringType BasicStringUnicode<StringType>::unescape_character(
 
     if (escaped_with(ch_u))
     {
-        auto next_codepoint = [&it, &end]() noexcept(false) -> codepoint_type {
+        auto next_codepoint = [&it, &end]() -> codepoint_type {
             return unescape_codepoint<ch_u>(it, end);
         };
 
@@ -355,7 +355,7 @@ StringType BasicStringUnicode<StringType>::unescape_character(
 //==================================================================================================
 template <typename StringType>
 template <char UnicodePrefix>
-StringType BasicStringUnicode<StringType>::escape_codepoint(codepoint_type codepoint) noexcept
+StringType BasicStringUnicode<StringType>::escape_codepoint(codepoint_type codepoint)
 {
     StringType result;
 
@@ -410,7 +410,7 @@ template <typename StringType>
 template <char UnicodePrefix>
 auto BasicStringUnicode<StringType>::unescape_codepoint(
     typename StringType::const_iterator &it,
-    const typename StringType::const_iterator &end) noexcept(false) -> codepoint_type
+    const typename StringType::const_iterator &end) -> codepoint_type
 {
     static_assert((UnicodePrefix == 'u') || (UnicodePrefix == 'U'));
 
@@ -465,8 +465,8 @@ auto BasicStringUnicode<StringType>::unescape_codepoint(
 //==================================================================================================
 template <typename StringType>
 template <typename CharType, std::enable_if_t<(sizeof(CharType) == 1), bool>>
-auto BasicStringUnicode<StringType>::decode_codepoint(
-    EncodedByteProvider next_encoded_byte) noexcept(false) -> codepoint_type
+auto BasicStringUnicode<StringType>::decode_codepoint(EncodedByteProvider next_encoded_byte)
+    -> codepoint_type
 {
     const codepoint_type leading_byte = next_encoded_byte() & 0xff;
 
@@ -534,8 +534,8 @@ auto BasicStringUnicode<StringType>::decode_codepoint(
 //==================================================================================================
 template <typename StringType>
 template <typename CharType, std::enable_if_t<(sizeof(CharType) == 2), bool>>
-auto BasicStringUnicode<StringType>::decode_codepoint(
-    EncodedByteProvider next_encoded_byte) noexcept(false) -> codepoint_type
+auto BasicStringUnicode<StringType>::decode_codepoint(EncodedByteProvider next_encoded_byte)
+    -> codepoint_type
 {
     return create_codepoint(std::move(next_encoded_byte));
 }
@@ -543,8 +543,8 @@ auto BasicStringUnicode<StringType>::decode_codepoint(
 //==================================================================================================
 template <typename StringType>
 template <typename CharType, std::enable_if_t<(sizeof(CharType) == 4), bool>>
-auto BasicStringUnicode<StringType>::decode_codepoint(
-    EncodedByteProvider next_encoded_byte) noexcept(false) -> codepoint_type
+auto BasicStringUnicode<StringType>::decode_codepoint(EncodedByteProvider next_encoded_byte)
+    -> codepoint_type
 {
     return next_encoded_byte();
 }
@@ -552,7 +552,7 @@ auto BasicStringUnicode<StringType>::decode_codepoint(
 //==================================================================================================
 template <typename StringType>
 template <typename CharType, std::enable_if_t<(sizeof(CharType) == 1), bool>>
-StringType BasicStringUnicode<StringType>::encode_codepoint(codepoint_type codepoint) noexcept
+StringType BasicStringUnicode<StringType>::encode_codepoint(codepoint_type codepoint)
 {
     StringType result;
 
@@ -585,7 +585,7 @@ StringType BasicStringUnicode<StringType>::encode_codepoint(codepoint_type codep
 //==================================================================================================
 template <typename StringType>
 template <typename CharType, std::enable_if_t<(sizeof(CharType) == 2), bool>>
-StringType BasicStringUnicode<StringType>::encode_codepoint(codepoint_type codepoint) noexcept
+StringType BasicStringUnicode<StringType>::encode_codepoint(codepoint_type codepoint)
 {
     StringType result;
 
@@ -606,15 +606,15 @@ StringType BasicStringUnicode<StringType>::encode_codepoint(codepoint_type codep
 //==================================================================================================
 template <typename StringType>
 template <typename CharType, std::enable_if_t<(sizeof(CharType) == 4), bool>>
-StringType BasicStringUnicode<StringType>::encode_codepoint(codepoint_type codepoint) noexcept
+StringType BasicStringUnicode<StringType>::encode_codepoint(codepoint_type codepoint)
 {
     return StringType(1, static_cast<char_type>(codepoint));
 }
 
 //==================================================================================================
 template <typename StringType>
-auto BasicStringUnicode<StringType>::create_codepoint(
-    EncodedByteProvider next_encoded_byte) noexcept(false) -> codepoint_type
+auto BasicStringUnicode<StringType>::create_codepoint(EncodedByteProvider next_encoded_byte)
+    -> codepoint_type
 {
     auto is_high_surrogate = [](codepoint_type c) -> bool {
         return (c >= high_surrogate_min) && (c <= high_surrogate_max);

--- a/fly/types/string/string.hpp
+++ b/fly/types/string/string.hpp
@@ -59,7 +59,7 @@ public:
      *
      * @return A vector containing the split strings.
      */
-    static std::vector<StringType> split(const StringType &input, char_type delimiter) noexcept;
+    static std::vector<StringType> split(const StringType &input, char_type delimiter);
 
     /**
      * Split a string into a vector of strings, up to a maximum size. If the max size is reached,
@@ -72,14 +72,14 @@ public:
      * @return A vector containing the split strings.
      */
     static std::vector<StringType>
-    split(const StringType &input, char_type delimiter, std::uint32_t count) noexcept;
+    split(const StringType &input, char_type delimiter, std::uint32_t count);
 
     /**
      * Remove leading and trailing whitespace from a string.
      *
      * @param target The string to trim.
      */
-    static void trim(StringType &target) noexcept;
+    static void trim(StringType &target);
 
     /**
      * Replace all instances of a substring in a string with a character.
@@ -88,8 +88,7 @@ public:
      * @param search The string to search for and replace.
      * @param replace The replacement character.
      */
-    static void
-    replace_all(StringType &target, const StringType &search, const char_type &replace) noexcept;
+    static void replace_all(StringType &target, const StringType &search, const char_type &replace);
 
     /**
      * Replace all instances of a substring in a string with another string.
@@ -99,7 +98,7 @@ public:
      * @param replace The replacement string.
      */
     static void
-    replace_all(StringType &target, const StringType &search, const StringType &replace) noexcept;
+    replace_all(StringType &target, const StringType &search, const StringType &replace);
 
     /**
      * Remove all instances of a substring in a string.
@@ -107,7 +106,7 @@ public:
      * @param target The string container which will be modified.
      * @param search The string to search for and remove.
      */
-    static void remove_all(StringType &target, const StringType &search) noexcept;
+    static void remove_all(StringType &target, const StringType &search);
 
     /**
      * Check if a string begins with a character.
@@ -117,7 +116,7 @@ public:
      *
      * @return True if the string begins with the search character.
      */
-    static bool starts_with(const StringType &source, const char_type &search) noexcept;
+    static bool starts_with(const StringType &source, const char_type &search);
 
     /**
      * Check if a string begins with another string.
@@ -127,7 +126,7 @@ public:
      *
      * @return True if the string begins with the search string.
      */
-    static bool starts_with(const StringType &source, const StringType &search) noexcept;
+    static bool starts_with(const StringType &source, const StringType &search);
 
     /**
      * Check if a string ends with a character.
@@ -137,7 +136,7 @@ public:
      *
      * @return True if the string ends with the search character.
      */
-    static bool ends_with(const StringType &source, const char_type &search) noexcept;
+    static bool ends_with(const StringType &source, const char_type &search);
 
     /**
      * Check if a string ends with another string.
@@ -147,7 +146,7 @@ public:
      *
      * @return True if the string ends with the search string.
      */
-    static bool ends_with(const StringType &source, const StringType &search) noexcept;
+    static bool ends_with(const StringType &source, const StringType &search);
 
     /**
      * Check if a string matches another string with wildcard expansion.
@@ -157,7 +156,7 @@ public:
      *
      * @return True if the wildcard string matches the source string.
      */
-    static bool wildcard_match(const StringType &source, const StringType &search) noexcept;
+    static bool wildcard_match(const StringType &source, const StringType &search);
 
     /**
      * Decode a single unicode codepoint, starting at the character pointed to by the provided
@@ -173,7 +172,7 @@ public:
      */
     static codepoint_type decode_unicode_character(
         typename StringType::const_iterator &it,
-        const typename StringType::const_iterator &end) noexcept(false);
+        const typename StringType::const_iterator &end);
 
     /**
      * Escape all unicode codepoints in a string.
@@ -201,7 +200,7 @@ public:
      * @throws UnicodeException If any unicode codepoint could not be escaped.
      */
     template <char UnicodePrefix = 'U'>
-    static StringType escape_unicode_string(const StringType &source) noexcept(false);
+    static StringType escape_unicode_string(const StringType &source);
 
     /**
      * Escape a single unicode codepoint, starting at the character pointed to by the provided
@@ -234,7 +233,7 @@ public:
     template <char UnicodePrefix = 'U'>
     static StringType escape_unicode_character(
         typename StringType::const_iterator &it,
-        const typename StringType::const_iterator &end) noexcept(false);
+        const typename StringType::const_iterator &end);
 
     /**
      * Unescape all unicode codepoints in a string.
@@ -251,7 +250,7 @@ public:
      *
      * @throws UnicodeException If any escaped sequence is not a valid unicode character.
      */
-    static StringType unescape_unicode_string(const StringType &source) noexcept(false);
+    static StringType unescape_unicode_string(const StringType &source);
 
     /**
      * Unescape a single unicode codepoint, starting at the character pointed to by provided
@@ -273,7 +272,7 @@ public:
      */
     static StringType unescape_unicode_character(
         typename StringType::const_iterator &it,
-        const typename StringType::const_iterator &end) noexcept(false);
+        const typename StringType::const_iterator &end);
 
     /**
      * Generate a random string of the given size.
@@ -282,7 +281,7 @@ public:
      *
      * @return The generated string.
      */
-    static StringType generate_random_string(size_type size) noexcept;
+    static StringType generate_random_string(size_type size);
 
     /**
      * Format a string with variadic template arguments, returning the formatted string.
@@ -305,7 +304,7 @@ public:
      * @return A string that has been formatted with the given arguments.
      */
     template <typename... Args>
-    static streamed_type format(const char_type *fmt, const Args &... args) noexcept;
+    static streamed_type format(const char_type *fmt, const Args &... args);
 
     /**
      * Format a string with variadic template arguments, inserting the formatted string into a
@@ -330,8 +329,7 @@ public:
      * @return The same stream object.
      */
     template <typename... Args>
-    static ostream_type &
-    format(ostream_type &ostream, const char_type *fmt, const Args &... args) noexcept;
+    static ostream_type &format(ostream_type &ostream, const char_type *fmt, const Args &... args);
 
     /**
      * Concatenate a list of objects with the given separator.
@@ -344,7 +342,7 @@ public:
      * @return The resulting join of the given arguments.
      */
     template <typename... Args>
-    static streamed_type join(const char_type &separator, const Args &... args) noexcept;
+    static streamed_type join(const char_type &separator, const Args &... args);
 
     /**
      * Convert a string to a plain-old-data type, e.g. int or bool.
@@ -359,7 +357,7 @@ public:
      * @throws std::out_of_range Converted value is out of range of result type.
      */
     template <typename T>
-    static T convert(const StringType &value) noexcept(std::is_same_v<StringType, std::decay_t<T>>);
+    static T convert(const StringType &value);
 
 private:
     /**
@@ -370,14 +368,13 @@ private:
         ostream_type &ostream,
         const char_type &separator,
         const T &value,
-        const Args &... args) noexcept;
+        const Args &... args);
 
     /**
      * Terminator for the variadic template joiner. Join the last argument into the given ostream.
      */
     template <typename T>
-    static void
-    join_internal(ostream_type &ostream, const char_type &separator, const T &value) noexcept;
+    static void join_internal(ostream_type &ostream, const char_type &separator, const T &value);
 
     /**
      * A list of alpha-numeric characters in the range [0-9A-Za-z].
@@ -394,18 +391,15 @@ private:
 
 //==================================================================================================
 template <typename StringType>
-std::vector<StringType>
-BasicString<StringType>::split(const StringType &input, char_type delimiter) noexcept
+std::vector<StringType> BasicString<StringType>::split(const StringType &input, char_type delimiter)
 {
     return split(input, delimiter, 0);
 }
 
 //==================================================================================================
 template <typename StringType>
-std::vector<StringType> BasicString<StringType>::split(
-    const StringType &input,
-    char_type delimiter,
-    std::uint32_t count) noexcept
+std::vector<StringType>
+BasicString<StringType>::split(const StringType &input, char_type delimiter, std::uint32_t count)
 {
     std::vector<StringType> elements;
     std::uint32_t num_items = 0;
@@ -446,7 +440,7 @@ std::vector<StringType> BasicString<StringType>::split(
 
 //==================================================================================================
 template <typename StringType>
-void BasicString<StringType>::trim(StringType &target) noexcept
+void BasicString<StringType>::trim(StringType &target)
 {
     auto is_non_space = [](int ch) { return !std::isspace(ch); };
 
@@ -462,7 +456,7 @@ template <typename StringType>
 void BasicString<StringType>::replace_all(
     StringType &target,
     const StringType &search,
-    const char_type &replace) noexcept
+    const char_type &replace)
 {
     size_type index = target.find(search);
 
@@ -478,7 +472,7 @@ template <typename StringType>
 void BasicString<StringType>::replace_all(
     StringType &target,
     const StringType &search,
-    const StringType &replace) noexcept
+    const StringType &replace)
 {
     size_type index = target.find(search);
 
@@ -491,16 +485,14 @@ void BasicString<StringType>::replace_all(
 
 //==================================================================================================
 template <typename StringType>
-void BasicString<StringType>::remove_all(StringType &target, const StringType &search) noexcept
+void BasicString<StringType>::remove_all(StringType &target, const StringType &search)
 {
     replace_all(target, search, StringType());
 }
 
 //==================================================================================================
 template <typename StringType>
-bool BasicString<StringType>::starts_with(
-    const StringType &source,
-    const char_type &search) noexcept
+bool BasicString<StringType>::starts_with(const StringType &source, const char_type &search)
 {
     bool result = false;
 
@@ -514,9 +506,7 @@ bool BasicString<StringType>::starts_with(
 
 //==================================================================================================
 template <typename StringType>
-bool BasicString<StringType>::starts_with(
-    const StringType &source,
-    const StringType &search) noexcept
+bool BasicString<StringType>::starts_with(const StringType &source, const StringType &search)
 {
     bool result = false;
 
@@ -533,7 +523,7 @@ bool BasicString<StringType>::starts_with(
 
 //==================================================================================================
 template <typename StringType>
-bool BasicString<StringType>::ends_with(const StringType &source, const char_type &search) noexcept
+bool BasicString<StringType>::ends_with(const StringType &source, const char_type &search)
 {
     bool result = false;
 
@@ -549,7 +539,7 @@ bool BasicString<StringType>::ends_with(const StringType &source, const char_typ
 
 //==================================================================================================
 template <typename StringType>
-bool BasicString<StringType>::ends_with(const StringType &source, const StringType &search) noexcept
+bool BasicString<StringType>::ends_with(const StringType &source, const StringType &search)
 {
     bool result = false;
 
@@ -566,9 +556,7 @@ bool BasicString<StringType>::ends_with(const StringType &source, const StringTy
 
 //==================================================================================================
 template <typename StringType>
-bool BasicString<StringType>::wildcard_match(
-    const StringType &source,
-    const StringType &search) noexcept
+bool BasicString<StringType>::wildcard_match(const StringType &source, const StringType &search)
 {
     static constexpr char_type s_wildcard = '*';
     bool result = !search.empty();
@@ -605,7 +593,7 @@ bool BasicString<StringType>::wildcard_match(
 template <typename StringType>
 auto BasicString<StringType>::decode_unicode_character(
     typename StringType::const_iterator &it,
-    const typename StringType::const_iterator &end) noexcept(false) -> codepoint_type
+    const typename StringType::const_iterator &end) -> codepoint_type
 {
     return detail::BasicStringUnicode<StringType>::decode_character(it, end);
 }
@@ -613,7 +601,7 @@ auto BasicString<StringType>::decode_unicode_character(
 //==================================================================================================
 template <typename StringType>
 template <char UnicodePrefix>
-StringType BasicString<StringType>::escape_unicode_string(const StringType &source) noexcept(false)
+StringType BasicString<StringType>::escape_unicode_string(const StringType &source)
 {
     StringType result;
     result.reserve(source.size());
@@ -633,7 +621,7 @@ template <typename StringType>
 template <char UnicodePrefix>
 StringType BasicString<StringType>::escape_unicode_character(
     typename StringType::const_iterator &it,
-    const typename StringType::const_iterator &end) noexcept(false)
+    const typename StringType::const_iterator &end)
 {
     return detail::BasicStringUnicode<StringType>::template escape_character<UnicodePrefix>(
         it,
@@ -642,8 +630,7 @@ StringType BasicString<StringType>::escape_unicode_character(
 
 //==================================================================================================
 template <typename StringType>
-StringType
-BasicString<StringType>::unescape_unicode_string(const StringType &source) noexcept(false)
+StringType BasicString<StringType>::unescape_unicode_string(const StringType &source)
 {
     StringType result;
     result.reserve(source.size());
@@ -679,14 +666,14 @@ BasicString<StringType>::unescape_unicode_string(const StringType &source) noexc
 template <typename StringType>
 StringType BasicString<StringType>::unescape_unicode_character(
     typename StringType::const_iterator &it,
-    const typename StringType::const_iterator &end) noexcept(false)
+    const typename StringType::const_iterator &end)
 {
     return detail::BasicStringUnicode<StringType>::unescape_character(it, end);
 }
 
 //==================================================================================================
 template <typename StringType>
-StringType BasicString<StringType>::generate_random_string(size_type size) noexcept
+StringType BasicString<StringType>::generate_random_string(size_type size)
 {
     using short_distribution = std::uniform_int_distribution<short>;
 
@@ -713,8 +700,7 @@ StringType BasicString<StringType>::generate_random_string(size_type size) noexc
 //==================================================================================================
 template <typename StringType>
 template <typename... Args>
-auto BasicString<StringType>::format(const char_type *fmt, const Args &... args) noexcept
-    -> streamed_type
+auto BasicString<StringType>::format(const char_type *fmt, const Args &... args) -> streamed_type
 {
     return detail::BasicStringFormatter<StringType>::format(fmt, args...);
 }
@@ -725,7 +711,7 @@ template <typename... Args>
 auto BasicString<StringType>::format(
     ostream_type &ostream,
     const char_type *fmt,
-    const Args &... args) noexcept -> ostream_type &
+    const Args &... args) -> ostream_type &
 {
     return detail::BasicStringFormatter<StringType>::format(ostream, fmt, args...);
 }
@@ -733,7 +719,7 @@ auto BasicString<StringType>::format(
 //==================================================================================================
 template <typename StringType>
 template <typename... Args>
-auto BasicString<StringType>::join(const char_type &separator, const Args &... args) noexcept
+auto BasicString<StringType>::join(const char_type &separator, const Args &... args)
     -> streamed_type
 {
     typename traits::ostringstream_type ostream;
@@ -749,7 +735,7 @@ void BasicString<StringType>::join_internal(
     ostream_type &ostream,
     const char_type &separator,
     const T &value,
-    const Args &... args) noexcept
+    const Args &... args)
 {
     detail::BasicStringFormatter<StringType>::stream(ostream, value);
     detail::BasicStringFormatter<StringType>::stream(ostream, separator);
@@ -763,7 +749,7 @@ template <typename T>
 void BasicString<StringType>::join_internal(
     ostream_type &ostream,
     const char_type &,
-    const T &value) noexcept
+    const T &value)
 {
     detail::BasicStringFormatter<StringType>::stream(ostream, value);
 }
@@ -771,8 +757,7 @@ void BasicString<StringType>::join_internal(
 //==================================================================================================
 template <typename StringType>
 template <typename T>
-T BasicString<StringType>::convert(const StringType &value) noexcept(
-    std::is_same_v<StringType, std::decay_t<T>>)
+T BasicString<StringType>::convert(const StringType &value)
 {
     if constexpr (std::is_same_v<StringType, std::decay_t<T>>)
     {

--- a/test/coders/base64_coder.cpp
+++ b/test/coders/base64_coder.cpp
@@ -129,7 +129,7 @@ public:
     /**
      * Create the directory to contain test output files.
      */
-    void SetUp() noexcept override
+    void SetUp() override
     {
         ASSERT_TRUE(std::filesystem::create_directories(m_path));
     }
@@ -137,7 +137,7 @@ public:
     /**
      * Delete the created directory.
      */
-    void TearDown() noexcept override
+    void TearDown() override
     {
         std::filesystem::remove_all(m_path);
     }

--- a/test/coders/huffman_coder.cpp
+++ b/test/coders/huffman_coder.cpp
@@ -483,7 +483,7 @@ public:
     /**
      * Create the directory to contain test output files.
      */
-    void SetUp() noexcept override
+    void SetUp() override
     {
         ASSERT_TRUE(std::filesystem::create_directories(m_path));
     }
@@ -491,7 +491,7 @@ public:
     /**
      * Delete the created directory.
      */
-    void TearDown() noexcept override
+    void TearDown() override
     {
         std::filesystem::remove_all(m_path);
     }

--- a/test/config/config_manager.cpp
+++ b/test/config/config_manager.cpp
@@ -53,7 +53,7 @@ public:
     /**
      * Create the file directory and start the task and config managers.
      */
-    void SetUp() noexcept override
+    void SetUp() override
     {
         ASSERT_TRUE(std::filesystem::create_directories(m_path));
         ASSERT_TRUE(m_task_manager->start());
@@ -65,7 +65,7 @@ public:
     /**
      * Delete the created directory and stop the task manager.
      */
-    void TearDown() noexcept override
+    void TearDown() override
     {
         ASSERT_TRUE(m_task_manager->stop());
         std::filesystem::remove_all(m_path);

--- a/test/config/test_config.hpp
+++ b/test/config/test_config.hpp
@@ -15,12 +15,12 @@ public:
     static constexpr const char *identifier = "config";
 
     template <typename T>
-    T get_value(const std::string &name, T def) const noexcept
+    T get_value(const std::string &name, T def) const
     {
         return fly::Config::get_value(name, def);
     }
 
-    void update(const fly::Json &values) noexcept
+    void update(const fly::Json &values)
     {
         fly::Config::update(values);
     }

--- a/test/logger/logger.cpp
+++ b/test/logger/logger.cpp
@@ -50,7 +50,7 @@ public:
     /**
      * Create the file directory and start the task manager and logger.
      */
-    void SetUp() noexcept override
+    void SetUp() override
     {
         ASSERT_TRUE(std::filesystem::create_directories(m_path));
 
@@ -63,7 +63,7 @@ public:
     /**
      * Delete the created directory and stop the task manager.
      */
-    void TearDown() noexcept override
+    void TearDown() override
     {
         ASSERT_TRUE(m_task_manager->stop());
 
@@ -133,7 +133,7 @@ protected:
      *
      * @return uintmax_t Size of the log point.
      */
-    std::uintmax_t log_size(const std::string &message) noexcept
+    std::uintmax_t log_size(const std::string &message)
     {
         fly::Log log;
 

--- a/test/mock/mock_system.cpp
+++ b/test/mock/mock_system.cpp
@@ -42,14 +42,14 @@ MockSystem::~MockSystem()
 }
 
 //==================================================================================================
-bool MockSystem::mock_enabled(MockCall mock) noexcept
+bool MockSystem::mock_enabled(MockCall mock)
 {
     bool fail;
     return mock_enabled(mock, fail);
 }
 
 //==================================================================================================
-bool MockSystem::mock_enabled(MockCall mock, bool &fail) noexcept
+bool MockSystem::mock_enabled(MockCall mock, bool &fail)
 {
     std::lock_guard<std::mutex> lock(s_mock_system_mutex);
 

--- a/test/mock/mock_system.hpp
+++ b/test/mock/mock_system.hpp
@@ -57,7 +57,7 @@ public:
      *
      * @return True if the mocked system call is enabled.
      */
-    static bool mock_enabled(MockCall mock) noexcept;
+    static bool mock_enabled(MockCall mock);
 
     /**
      * Check if a mocked system call is enabled.
@@ -67,7 +67,7 @@ public:
      *
      * @return True if the mocked system call is enabled.
      */
-    static bool mock_enabled(MockCall mock, bool &fail) noexcept;
+    static bool mock_enabled(MockCall mock, bool &fail);
 
 private:
     static std::mutex s_mock_system_mutex;

--- a/test/parser/json_parser.cpp
+++ b/test/parser/json_parser.cpp
@@ -15,26 +15,24 @@
 class JsonParserTest : public ::testing::Test
 {
 protected:
-    void validate_fail(const std::string &test) noexcept
+    void validate_fail(const std::string &test)
     {
         validate_fail_raw(fly::String::format("{ \"a\" : %s }", test));
     }
 
-    void validate_fail_raw(const std::string &test) noexcept
+    void validate_fail_raw(const std::string &test)
     {
         SCOPED_TRACE(test);
         EXPECT_THROW(m_parser.parse_string(test), fly::ParserException);
     }
 
-    void validate_pass(const std::string &test, const fly::Json &expected) noexcept
+    void validate_pass(const std::string &test, const fly::Json &expected)
     {
         validate_pass_raw(fly::String::format("{ \"a\" : %s }", test), "a", expected);
     }
 
-    void validate_pass_raw(
-        const std::string &test,
-        const std::string &key,
-        const fly::Json &expected) noexcept
+    void
+    validate_pass_raw(const std::string &test, const std::string &key, const fly::Json &expected)
     {
         fly::Json actual, repeat;
 

--- a/test/parser/parser.cpp
+++ b/test/parser/parser.cpp
@@ -15,7 +15,7 @@ namespace {
 class EofParser : public fly::Parser
 {
 public:
-    void compare_parsed(std::vector<int> chars) const noexcept
+    void compare_parsed(std::vector<int> chars) const
     {
         EXPECT_EQ(m_chars, chars);
     }

--- a/test/path/path_monitor.cpp
+++ b/test/path/path_monitor.cpp
@@ -71,7 +71,7 @@ public:
     /**
      * Create and start the task manager and path monitor.
      */
-    void SetUp() noexcept override
+    void SetUp() override
     {
         ASSERT_TRUE(std::filesystem::create_directories(m_path0));
         ASSERT_TRUE(std::filesystem::create_directories(m_path1));
@@ -92,7 +92,7 @@ public:
     /**
      * Stop the task manager and delete the created directory.
      */
-    void TearDown() noexcept override
+    void TearDown() override
     {
         ASSERT_TRUE(m_task_manager->stop());
 
@@ -109,7 +109,7 @@ protected:
      * @param path Path to the changed file.
      * @param event The type of event that occurred.
      */
-    void handle_event(const std::filesystem::path &path, fly::PathMonitor::PathEvent event) noexcept
+    void handle_event(const std::filesystem::path &path, fly::PathMonitor::PathEvent event)
     {
         switch (event)
         {

--- a/test/socket/socket.cpp
+++ b/test/socket/socket.cpp
@@ -46,12 +46,12 @@ public:
     {
     }
 
-    virtual void server_thread(bool) noexcept
+    virtual void server_thread(bool)
     {
         ASSERT_TRUE(false);
     };
 
-    virtual void client_thread(bool) noexcept
+    virtual void client_thread(bool)
     {
         ASSERT_TRUE(false);
     };
@@ -60,7 +60,7 @@ protected:
     /**
      * Start the task and socket managers.
      */
-    void SetUp() noexcept override
+    void SetUp() override
     {
         ASSERT_TRUE(fly::Socket::hostname_to_address(m_host, m_address));
 
@@ -72,7 +72,7 @@ protected:
     /**
      * Stop the task manager.
      */
-    void TearDown() noexcept override
+    void TearDown() override
     {
         ASSERT_TRUE(m_task_manager->stop());
     }
@@ -286,7 +286,7 @@ TEST_F(SocketTest, Connect_Async_MockGetsockoptFail)
         listen_socket->bind(fly::Socket::in_addr_any(), m_port, fly::BindOption::AllowReuse));
     ASSERT_TRUE(listen_socket->listen());
 
-    auto callback([&](std::shared_ptr<fly::Socket>) noexcept { m_event_queue.push(1); });
+    auto callback([&](std::shared_ptr<fly::Socket>) { m_event_queue.push(1); });
     m_client_socket_manager->set_client_callbacks(nullptr, callback);
 
     int item = 0;
@@ -346,7 +346,7 @@ TEST_F(SocketTest, Send_Async_MockSendFail)
         listen_socket->bind(fly::Socket::in_addr_any(), m_port, fly::BindOption::AllowReuse));
     ASSERT_TRUE(listen_socket->listen());
 
-    auto callback([&](std::shared_ptr<fly::Socket>) noexcept { m_event_queue.push(1); });
+    auto callback([&](std::shared_ptr<fly::Socket>) { m_event_queue.push(1); });
     m_client_socket_manager->set_client_callbacks(callback, callback);
 
     int item = 0;
@@ -381,7 +381,7 @@ TEST_F(SocketTest, Send_Async_MockSendBlock)
         listen_socket->bind(fly::Socket::in_addr_any(), m_port, fly::BindOption::AllowReuse));
     ASSERT_TRUE(listen_socket->listen());
 
-    auto callback([&](std::shared_ptr<fly::Socket>) noexcept { m_event_queue.push(1); });
+    auto callback([&](std::shared_ptr<fly::Socket>) { m_event_queue.push(1); });
     m_client_socket_manager->set_client_callbacks(callback, callback);
 
     int item = 0;
@@ -450,7 +450,7 @@ TEST_F(SocketTest, Send_Async_MockSendtoFail)
     ASSERT_TRUE(
         listen_socket->bind(fly::Socket::in_addr_any(), m_port, fly::BindOption::AllowReuse));
 
-    auto callback([&](std::shared_ptr<fly::Socket>) noexcept { m_event_queue.push(1); });
+    auto callback([&](std::shared_ptr<fly::Socket>) { m_event_queue.push(1); });
     m_client_socket_manager->set_client_callbacks(nullptr, callback);
 
     int item = 0;
@@ -534,11 +534,11 @@ TEST_F(SocketTest, Recv_Async_MockRecvFail)
 
     std::shared_ptr<fly::Socket> server_socket;
 
-    auto connect_callback([&](std::shared_ptr<fly::Socket> socket) noexcept {
+    auto connect_callback([&](std::shared_ptr<fly::Socket> socket) {
         server_socket = socket;
         m_event_queue.push(1);
     });
-    auto disconnect_callback([&](std::shared_ptr<fly::Socket>) noexcept { m_event_queue.push(1); });
+    auto disconnect_callback([&](std::shared_ptr<fly::Socket>) { m_event_queue.push(1); });
     m_server_socket_manager->set_client_callbacks(connect_callback, disconnect_callback);
 
     int item = 0;
@@ -580,7 +580,7 @@ TEST_F(SocketTest, Recv_Async_MockRecvfromFail)
     ASSERT_TRUE(
         listen_socket->bind(fly::Socket::in_addr_any(), m_port, fly::BindOption::AllowReuse));
 
-    auto callback([&](std::shared_ptr<fly::Socket>) noexcept { m_event_queue.push(1); });
+    auto callback([&](std::shared_ptr<fly::Socket>) { m_event_queue.push(1); });
     m_server_socket_manager->set_client_callbacks(nullptr, callback);
 
     int item = 0;
@@ -602,7 +602,7 @@ public:
     /**
      * Thread to run server functions to accept a client socket and receive data.
      */
-    void server_thread(bool async) noexcept override
+    void server_thread(bool async) override
     {
         auto listen_socket = create_socket(m_server_socket_manager, fly::Protocol::TCP, async);
 
@@ -644,7 +644,7 @@ public:
     /**
      * Thread to run client functions to connect to the server socket and send data.
      */
-    void client_thread(bool async) noexcept override
+    void client_thread(bool async) override
     {
         auto send_socket = create_socket(m_client_socket_manager, fly::Protocol::TCP, async);
 
@@ -658,7 +658,7 @@ public:
         std::chrono::seconds wait_time(10);
         ASSERT_TRUE(m_event_queue.pop(item, wait_time));
 
-        auto callback([&](std::shared_ptr<fly::Socket>) noexcept { m_event_queue.push(1); });
+        auto callback([&](std::shared_ptr<fly::Socket>) { m_event_queue.push(1); });
         m_client_socket_manager->set_client_callbacks(callback, nullptr);
 
         if (async)
@@ -763,7 +763,7 @@ public:
     /**
      * Thread to run server functions to accept a client socket and receive data.
      */
-    void server_thread(bool async) noexcept override
+    void server_thread(bool async) override
     {
         auto server_socket = create_socket(m_server_socket_manager, fly::Protocol::UDP, async);
 
@@ -795,7 +795,7 @@ public:
     /**
      * Thread to run client functions to connect to the server socket and send data.
      */
-    void client_thread(bool async) noexcept override
+    void client_thread(bool async) override
     {
         static unsigned int s_call_count = 0;
 

--- a/test/system/system_monitor.cpp
+++ b/test/system/system_monitor.cpp
@@ -52,7 +52,7 @@ public:
     /**
      * Start the task manager and system monitor.
      */
-    void SetUp() noexcept override
+    void SetUp() override
     {
         ASSERT_TRUE(m_task_manager->start());
         ASSERT_TRUE(m_monitor->start());
@@ -62,7 +62,7 @@ public:
     /**
      * Stop the task manager.
      */
-    void TearDown() noexcept override
+    void TearDown() override
     {
         ASSERT_TRUE(m_task_manager->stop());
     }
@@ -70,7 +70,7 @@ public:
     /**
      * Thread to spin infinitely until signaled to stop.
      */
-    void spin_thread() noexcept
+    void spin_thread()
     {
         while (m_keep_running.load())
         {

--- a/test/task/task.cpp
+++ b/test/task/task.cpp
@@ -20,13 +20,13 @@ public:
     {
     }
 
-    int get_count() const noexcept
+    int get_count() const
     {
         return m_count.load();
     }
 
 protected:
-    void run() noexcept override
+    void run() override
     {
         ++m_count;
     }
@@ -46,7 +46,7 @@ public:
     }
 
 protected:
-    void run() noexcept override
+    void run() override
     {
         m_ordering->push(std::move(m_marker));
     }
@@ -69,7 +69,7 @@ public:
     /**
      * Start the task manager.
      */
-    void SetUp() noexcept override
+    void SetUp() override
     {
         ASSERT_TRUE(m_task_manager->start());
     }
@@ -77,7 +77,7 @@ public:
     /**
      * Stop the task manager.
      */
-    void TearDown() noexcept override
+    void TearDown() override
     {
         ASSERT_TRUE(m_task_manager->stop());
     }

--- a/test/traits/traits.cpp
+++ b/test/traits/traits.cpp
@@ -27,7 +27,7 @@ public:
     {
     }
 
-    bool foo() const noexcept
+    bool foo() const
     {
         return true;
     }
@@ -41,7 +41,7 @@ public:
     {
     }
 
-    std::string operator()() const noexcept
+    std::string operator()() const
     {
         return "BarClass";
     }
@@ -57,27 +57,27 @@ std::ostream &operator<<(std::ostream &stream, const BarClass &bar)
 
 //==================================================================================================
 template <typename T, fly::enable_if_all<FooTraits::is_declared<T>> = 0>
-bool call_foo(const T &arg) noexcept
+bool call_foo(const T &arg)
 {
     return arg.foo();
 }
 
 template <typename T, fly::enable_if_not_all<FooTraits::is_declared<T>> = 0>
-bool call_foo(const T &) noexcept
+bool call_foo(const T &)
 {
     return false;
 }
 
 //==================================================================================================
 template <typename T, fly::enable_if_all<OstreamTraits::is_declared<T>> = 0>
-bool is_streamable(std::ostream &stream, const T &arg) noexcept
+bool is_streamable(std::ostream &stream, const T &arg)
 {
     stream << arg;
     return true;
 }
 
 template <typename T, fly::enable_if_not_all<OstreamTraits::is_declared<T>> = 0>
-bool is_streamable(std::ostream &, const T &) noexcept
+bool is_streamable(std::ostream &, const T &)
 {
     return false;
 }
@@ -298,9 +298,9 @@ TEST(TraitsTest, Visitation)
         1,
         std::visit(
             fly::visitation {
-                [](int) noexcept -> int { return 1; },
-                [](bool) noexcept -> int { return 2; },
-                [](std::string) noexcept -> int { return 3; },
+                [](int) -> int { return 1; },
+                [](bool) -> int { return 2; },
+                [](std::string) -> int { return 3; },
             },
             TestVariant {int()}));
 
@@ -308,9 +308,9 @@ TEST(TraitsTest, Visitation)
         2,
         std::visit(
             fly::visitation {
-                [](int) noexcept -> int { return 1; },
-                [](bool) noexcept -> int { return 2; },
-                [](std::string) noexcept -> int { return 3; },
+                [](int) -> int { return 1; },
+                [](bool) -> int { return 2; },
+                [](std::string) -> int { return 3; },
             },
             TestVariant {bool()}));
 
@@ -318,9 +318,9 @@ TEST(TraitsTest, Visitation)
         3,
         std::visit(
             fly::visitation {
-                [](int) noexcept -> int { return 1; },
-                [](bool) noexcept -> int { return 2; },
-                [](std::string) noexcept -> int { return 3; },
+                [](int) -> int { return 1; },
+                [](bool) -> int { return 2; },
+                [](std::string) -> int { return 3; },
             },
             TestVariant {std::string()}));
 
@@ -328,8 +328,8 @@ TEST(TraitsTest, Visitation)
         1,
         std::visit(
             fly::visitation {
-                [](int) noexcept -> int { return 1; },
-                [](auto) noexcept -> int { return 2; },
+                [](int) -> int { return 1; },
+                [](auto) -> int { return 2; },
             },
             TestVariant {int()}));
 
@@ -337,8 +337,8 @@ TEST(TraitsTest, Visitation)
         2,
         std::visit(
             fly::visitation {
-                [](int) noexcept -> int { return 1; },
-                [](auto) noexcept -> int { return 2; },
+                [](int) -> int { return 1; },
+                [](auto) -> int { return 2; },
             },
             TestVariant {std::string()}));
 }

--- a/test/types/bit_stream.cpp
+++ b/test/types/bit_stream.cpp
@@ -21,7 +21,7 @@ constexpr const std::ios::openmode s_output_mode =
 class BitStreamTest : public ::testing::Test
 {
 public:
-    BitStreamTest() : m_input_stream(s_input_mode), m_output_stream(s_output_mode)
+    BitStreamTest() noexcept : m_input_stream(s_input_mode), m_output_stream(s_output_mode)
     {
     }
 

--- a/test/types/concurrent_container.cpp
+++ b/test/types/concurrent_container.cpp
@@ -16,7 +16,7 @@ public:
     using Object = unsigned int;
     using ObjectQueue = fly::ConcurrentQueue<Object>;
 
-    unsigned int writer_thread(ObjectQueue &object_queue) noexcept
+    unsigned int writer_thread(ObjectQueue &object_queue)
     {
         unsigned int writes = 100;
 
@@ -29,8 +29,7 @@ public:
         return writes;
     }
 
-    unsigned int
-    reader_thread(ObjectQueue &object_queue, std::atomic_bool &finished_writes) noexcept
+    unsigned int reader_thread(ObjectQueue &object_queue, std::atomic_bool &finished_writes)
     {
         unsigned int reads = 0;
 
@@ -47,7 +46,7 @@ public:
         return reads;
     }
 
-    Object infinite_wait_reader_thread(ObjectQueue &object_queue) noexcept
+    Object infinite_wait_reader_thread(ObjectQueue &object_queue)
     {
         Object object;
         object_queue.pop(object);
@@ -56,7 +55,7 @@ public:
     }
 
 protected:
-    void run_multi_threaded_test(unsigned int writers, unsigned int readers) noexcept
+    void run_multi_threaded_test(unsigned int writers, unsigned int readers)
     {
         ObjectQueue object_queue;
 
@@ -101,10 +100,8 @@ protected:
         ASSERT_EQ(writes, reads);
     }
 
-    void do_queue_push(
-        ObjectQueue &object_queue,
-        Object object,
-        ObjectQueue::size_type expected_size) noexcept
+    void
+    do_queue_push(ObjectQueue &object_queue, Object object, ObjectQueue::size_type expected_size)
     {
         object_queue.push(std::move(object));
 
@@ -115,7 +112,7 @@ protected:
     void do_queue_pop(
         ObjectQueue &object_queue,
         const Object &expected_object,
-        ObjectQueue::size_type expected_size) noexcept
+        ObjectQueue::size_type expected_size)
     {
         Object object;
 

--- a/test/types/json_traits.cpp
+++ b/test/types/json_traits.cpp
@@ -20,56 +20,56 @@ namespace {
 
 //==================================================================================================
 template <typename T>
-bool is_string(const T &) noexcept
+bool is_string(const T &)
 {
     return fly::JsonTraits::is_string_v<T>;
 }
 
 //==================================================================================================
 template <typename T>
-bool is_bool(const T &) noexcept
+bool is_bool(const T &)
 {
     return fly::JsonTraits::is_boolean_v<T>;
 }
 
 //==================================================================================================
 template <typename T>
-bool is_signed_integer(const T &) noexcept
+bool is_signed_integer(const T &)
 {
     return fly::JsonTraits::is_signed_integer_v<T>;
 }
 
 //==================================================================================================
 template <typename T>
-bool is_unsigned_integer(const T &) noexcept
+bool is_unsigned_integer(const T &)
 {
     return fly::JsonTraits::is_unsigned_integer_v<T>;
 }
 
 //==================================================================================================
 template <typename T>
-bool is_floating_point(const T &) noexcept
+bool is_floating_point(const T &)
 {
     return fly::JsonTraits::is_floating_point_v<T>;
 }
 
 //==================================================================================================
 template <typename T>
-bool is_object(const T &) noexcept
+bool is_object(const T &)
 {
     return fly::JsonTraits::is_object_v<T>;
 }
 
 //==================================================================================================
 template <typename T>
-bool is_array(const T &) noexcept
+bool is_array(const T &)
 {
     return fly::JsonTraits::is_array_v<T>;
 }
 
 //==================================================================================================
 template <typename T>
-bool is_iterable(const T &) noexcept
+bool is_iterable(const T &)
 {
     return fly::JsonTraits::is_iterable_v<T>;
 }

--- a/test/types/string.cpp
+++ b/test/types/string.cpp
@@ -15,7 +15,7 @@ namespace {
 
 //==================================================================================================
 template <typename StringType, typename T>
-StringType minstr() noexcept
+StringType minstr()
 {
     static constexpr std::intmax_t s_min = std::numeric_limits<T>::min();
 
@@ -31,7 +31,7 @@ StringType minstr() noexcept
 
 //==================================================================================================
 template <typename StringType, typename T>
-StringType maxstr() noexcept
+StringType maxstr()
 {
     static constexpr std::uintmax_t s_max = std::numeric_limits<T>::max();
 

--- a/test/types/string_test.hpp
+++ b/test/types/string_test.hpp
@@ -42,12 +42,12 @@ public:
     {
     }
 
-    StringType str() const noexcept
+    StringType str() const
     {
         return m_str;
     };
 
-    int num() const noexcept
+    int num() const
     {
         return m_num;
     };

--- a/test/types/string_traits.cpp
+++ b/test/types/string_traits.cpp
@@ -19,7 +19,7 @@ template <
         fly::detail::BasicStringTraits<std::wstring>::is_string_like<T>,
         fly::detail::BasicStringTraits<std::u16string>::is_string_like<T>,
         fly::detail::BasicStringTraits<std::u32string>::is_string_like<T>> = 0>
-constexpr bool is_string_like(const T &) noexcept
+constexpr bool is_string_like(const T &)
 {
     return true;
 }
@@ -32,7 +32,7 @@ template <
         fly::detail::BasicStringTraits<std::wstring>::is_string_like<T>,
         fly::detail::BasicStringTraits<std::u16string>::is_string_like<T>,
         fly::detail::BasicStringTraits<std::u32string>::is_string_like<T>> = 0>
-constexpr bool is_string_like(const T &) noexcept
+constexpr bool is_string_like(const T &)
 {
     return false;
 }
@@ -41,7 +41,7 @@ constexpr bool is_string_like(const T &) noexcept
 template <
     typename StringType,
     fly::enable_if_all<typename fly::detail::BasicStringTraits<StringType>::has_stoi_family> = 0>
-constexpr int call_stoi(const StringType &str) noexcept
+constexpr int call_stoi(const StringType &str)
 {
     return std::stoi(str);
 }
@@ -51,7 +51,7 @@ template <
     typename StringType,
     fly::enable_if_not_all<typename fly::detail::BasicStringTraits<StringType>::has_stoi_family> =
         0>
-constexpr int call_stoi(const StringType &) noexcept
+constexpr int call_stoi(const StringType &)
 {
     return -1;
 }

--- a/test/util/capture_stream.cpp
+++ b/test/util/capture_stream.cpp
@@ -63,13 +63,13 @@ CaptureStream::~CaptureStream()
 }
 
 //==================================================================================================
-std::string CaptureStream::operator()() noexcept
+std::string CaptureStream::operator()()
 {
     return restore(true);
 }
 
 //==================================================================================================
-std::string CaptureStream::restore(bool read) noexcept
+std::string CaptureStream::restore(bool read)
 {
     std::string contents;
 

--- a/test/util/capture_stream.hpp
+++ b/test/util/capture_stream.hpp
@@ -39,7 +39,7 @@ public:
      *
      * @return The contents of the redirected stream.
      */
-    std::string operator()() noexcept;
+    std::string operator()();
 
 private:
     /**
@@ -50,7 +50,7 @@ private:
      *
      * @return The contents of the redirected stream.
      */
-    std::string restore(bool read) noexcept;
+    std::string restore(bool read);
 
     std::filesystem::path m_path;
 

--- a/test/util/path_util.cpp
+++ b/test/util/path_util.cpp
@@ -12,13 +12,13 @@
 namespace fly {
 
 //==================================================================================================
-std::filesystem::path PathUtil::generate_temp_directory() noexcept
+std::filesystem::path PathUtil::generate_temp_directory()
 {
     return std::filesystem::temp_directory_path() / fly::String::generate_random_string(10);
 }
 
 //==================================================================================================
-bool PathUtil::write_file(const std::filesystem::path &path, const std::string &contents) noexcept
+bool PathUtil::write_file(const std::filesystem::path &path, const std::string &contents)
 {
     std::ofstream stream(path, std::ios::out);
 
@@ -31,7 +31,7 @@ bool PathUtil::write_file(const std::filesystem::path &path, const std::string &
 }
 
 //==================================================================================================
-std::string PathUtil::read_file(const std::filesystem::path &path) noexcept
+std::string PathUtil::read_file(const std::filesystem::path &path)
 {
     std::ifstream stream(path, std::ios::in);
     std::stringstream sstream;
@@ -45,9 +45,7 @@ std::string PathUtil::read_file(const std::filesystem::path &path) noexcept
 }
 
 //==================================================================================================
-bool PathUtil::compare_files(
-    const std::filesystem::path &path1,
-    const std::filesystem::path &path2) noexcept
+bool PathUtil::compare_files(const std::filesystem::path &path1, const std::filesystem::path &path2)
 {
     if (std::filesystem::file_size(path1) != std::filesystem::file_size(path2))
     {

--- a/test/util/path_util.hpp
+++ b/test/util/path_util.hpp
@@ -19,7 +19,7 @@ public:
      *
      * @return The random directory path.
      */
-    static std::filesystem::path generate_temp_directory() noexcept;
+    static std::filesystem::path generate_temp_directory();
 
     /**
      * Create a file with the given contents, verifying the file was correctly written after
@@ -30,7 +30,7 @@ public:
      *
      * @return True if the file was correctly created.
      */
-    static bool write_file(const std::filesystem::path &path, const std::string &contents) noexcept;
+    static bool write_file(const std::filesystem::path &path, const std::string &contents);
 
     /**
      * Read the contents of a file.
@@ -39,7 +39,7 @@ public:
      *
      * @return Contents of the file.
      */
-    static std::string read_file(const std::filesystem::path &path) noexcept;
+    static std::string read_file(const std::filesystem::path &path);
 
     /**
      * Compare two files for equality. Two files are equal if they have the same size and the same
@@ -51,7 +51,7 @@ public:
      * @return True if the given files are equal.
      */
     static bool
-    compare_files(const std::filesystem::path &path1, const std::filesystem::path &path2) noexcept;
+    compare_files(const std::filesystem::path &path1, const std::filesystem::path &path2);
 };
 
 } // namespace fly

--- a/test/util/waitable_task_runner.cpp
+++ b/test/util/waitable_task_runner.cpp
@@ -6,7 +6,7 @@
 namespace fly {
 
 //==================================================================================================
-void WaitableTaskRunner::task_complete(const std::shared_ptr<Task> &task) noexcept
+void WaitableTaskRunner::task_complete(const std::shared_ptr<Task> &task)
 {
     if (task)
     {
@@ -23,7 +23,7 @@ WaitableParallelTaskRunner::WaitableParallelTaskRunner(
 }
 
 //==================================================================================================
-void WaitableParallelTaskRunner::task_complete(const std::shared_ptr<Task> &task) noexcept
+void WaitableParallelTaskRunner::task_complete(const std::shared_ptr<Task> &task)
 {
     ParallelTaskRunner::task_complete(task);
     WaitableTaskRunner::task_complete(task);
@@ -37,7 +37,7 @@ WaitableSequencedTaskRunner::WaitableSequencedTaskRunner(
 }
 
 //==================================================================================================
-void WaitableSequencedTaskRunner::task_complete(const std::shared_ptr<Task> &task) noexcept
+void WaitableSequencedTaskRunner::task_complete(const std::shared_ptr<Task> &task)
 {
     SequencedTaskRunner::task_complete(task);
     WaitableTaskRunner::task_complete(task);

--- a/test/util/waitable_task_runner.hpp
+++ b/test/util/waitable_task_runner.hpp
@@ -34,7 +34,7 @@ public:
      * @tparam TaskType The task subclass to wait on.
      */
     template <typename TaskType>
-    void wait_for_task_to_complete() noexcept;
+    void wait_for_task_to_complete();
 
     /**
      * Wait for a specific task type to complete execution.
@@ -46,7 +46,7 @@ public:
      * @return True if a completed task was found in the given duration.
      */
     template <typename TaskType, typename R, typename P>
-    bool wait_for_task_to_complete(std::chrono::duration<R, P> duration) noexcept;
+    bool wait_for_task_to_complete(std::chrono::duration<R, P> duration);
 
 protected:
     /**
@@ -54,7 +54,7 @@ protected:
      *
      * @param task The (possibly NULL) task that was executed or skipped.
      */
-    virtual void task_complete(const std::shared_ptr<Task> &task) noexcept = 0;
+    virtual void task_complete(const std::shared_ptr<Task> &task) = 0;
 
 private:
     ConcurrentQueue<std::size_t> m_completed_tasks;
@@ -80,7 +80,7 @@ protected:
      *
      * @param task The (possibly NULL) task that was executed or skipped.
      */
-    void task_complete(const std::shared_ptr<Task> &task) noexcept override;
+    void task_complete(const std::shared_ptr<Task> &task) override;
 };
 
 /**
@@ -102,12 +102,12 @@ protected:
      *
      * @param task The (possibly NULL) task that was executed or skipped.
      */
-    void task_complete(const std::shared_ptr<Task> &task) noexcept override;
+    void task_complete(const std::shared_ptr<Task> &task) override;
 };
 
 //==================================================================================================
 template <typename TaskType>
-void WaitableTaskRunner::wait_for_task_to_complete() noexcept
+void WaitableTaskRunner::wait_for_task_to_complete()
 {
     static_assert(std::is_base_of<Task, TaskType>::value, "Given type is not a task");
 
@@ -122,7 +122,7 @@ void WaitableTaskRunner::wait_for_task_to_complete() noexcept
 
 //==================================================================================================
 template <typename TaskType, typename R, typename P>
-bool WaitableTaskRunner::wait_for_task_to_complete(std::chrono::duration<R, P> duration) noexcept
+bool WaitableTaskRunner::wait_for_task_to_complete(std::chrono::duration<R, P> duration)
 {
     static_assert(std::is_base_of<Task, TaskType>::value, "Given type is not a task");
 


### PR DESCRIPTION
It's mostly useful for constructors, assignment operators, and conversion
operators. The STL uses noexcept traits to e.g. decide if a type can be
moved. It's not super useful on other methods, and has just been annoying
to remember.