### PR TITLE
Change logpoint separator symbols

### DIFF
--- a/fly/logger/log.cpp
+++ b/fly/logger/log.cpp
@@ -6,8 +6,13 @@
 
 namespace fly {
 
+namespace {
+    constexpr const char s_record_separator = '\x1e';
+    constexpr const char s_unit_separator = '\x1f';
+} // namespace
+
 //==================================================================================================
-Log::Log() noexcept : m_level(Level::NumLevels), m_time(-1.0), m_line(0), m_message()
+Log::Log() noexcept : m_index(0), m_level(Level::NumLevels), m_time(-1.0), m_line(0), m_message()
 {
     std::memset(m_file, 0, sizeof(m_file));
     std::memset(m_function, 0, sizeof(m_file));
@@ -15,6 +20,7 @@ Log::Log() noexcept : m_level(Level::NumLevels), m_time(-1.0), m_line(0), m_mess
 
 //==================================================================================================
 Log::Log(Log &&log) noexcept :
+    m_index(std::move(log.m_index)),
     m_level(std::move(log.m_level)),
     m_time(std::move(log.m_time)),
     m_line(std::move(log.m_line)),
@@ -26,6 +32,7 @@ Log::Log(Log &&log) noexcept :
 
 //==================================================================================================
 Log::Log(const std::shared_ptr<LoggerConfig> &config, const std::string &message) noexcept :
+    m_index(0),
     m_level(Level::NumLevels),
     m_time(-1.0),
     m_line(0),
@@ -38,6 +45,7 @@ Log::Log(const std::shared_ptr<LoggerConfig> &config, const std::string &message
 //==================================================================================================
 Log &Log::operator=(Log &&log) noexcept
 {
+    m_index = std::move(log.m_index);
     m_level = std::move(log.m_level);
     m_time = std::move(log.m_time);
     std::memmove(m_file, log.m_file, sizeof(m_file));
@@ -51,12 +59,13 @@ Log &Log::operator=(Log &&log) noexcept
 //==================================================================================================
 std::ostream &operator<<(std::ostream &stream, const Log &log)
 {
-    stream << log.m_level << '\t';
-    stream << log.m_time << '\t';
-    stream << log.m_file << '\t';
-    stream << log.m_function << '\t';
-    stream << log.m_line << '\t';
-    stream << log.m_message << '\n';
+    stream << log.m_index << s_unit_separator;
+    stream << log.m_level << s_unit_separator;
+    stream << log.m_time << s_unit_separator;
+    stream << log.m_file << s_unit_separator;
+    stream << log.m_function << s_unit_separator;
+    stream << log.m_line << s_unit_separator;
+    stream << log.m_message << s_record_separator;
 
     return stream;
 }

--- a/fly/logger/log.cpp
+++ b/fly/logger/log.cpp
@@ -7,8 +7,10 @@
 namespace fly {
 
 namespace {
+
     constexpr const char s_record_separator = '\x1e';
     constexpr const char s_unit_separator = '\x1f';
+
 } // namespace
 
 //==================================================================================================

--- a/fly/logger/log.hpp
+++ b/fly/logger/log.hpp
@@ -12,9 +12,9 @@ class LoggerConfig;
 /**
  * Struct to store data about single log. A log contains:
  *
- * 1. The log level.
- * 2. The time the log was made.
- * 3. A fixed argument.
+ * 1. The monotonically increasing index of the log.
+ * 2. The log level.
+ * 3. The time the log was made.
  * 4. The file name the log is in.
  * 5. The function name the log is in.
  * 6. The line number the log is on.

--- a/fly/logger/log.hpp
+++ b/fly/logger/log.hpp
@@ -61,6 +61,7 @@ struct Log
      */
     Log &operator=(Log &&) noexcept;
 
+    std::uintmax_t m_index;
     Level m_level;
     double m_time;
     char m_file[100];

--- a/fly/logger/logger.cpp
+++ b/fly/logger/logger.cpp
@@ -96,7 +96,7 @@ bool Logger::poll()
 
     if (m_log_queue.pop(log, m_config->queue_wait_time()) && m_log_stream.good())
     {
-        String::format(m_log_stream, "%u\t%s", m_index++, log) << std::flush;
+        m_log_stream << log << std::flush;
         std::error_code error;
 
         if (std::filesystem::file_size(m_log_file, error) > m_config->max_log_file_size())
@@ -123,6 +123,7 @@ void Logger::add_log_internal(
     {
         Log log(m_config, message);
 
+        log.m_index = m_index++;
         log.m_level = level;
         log.m_time = log_time.count();
         log.m_line = line;

--- a/test/logger/logger.cpp
+++ b/test/logger/logger.cpp
@@ -97,9 +97,9 @@ protected:
         std::size_t count = 0;
         double last_time = 0.0;
 
-        for (const std::string &log : fly::String::split(contents, '\n'))
+        for (const std::string &log : fly::String::split(contents, '\x1e'))
         {
-            const std::vector<std::string> sections = fly::String::split(log, '\t');
+            const std::vector<std::string> sections = fly::String::split(log, '\x1f');
             ASSERT_EQ(sections.size(), 7_zu);
 
             const auto index = fly::String::convert<std::size_t>(sections[0]).value();


### PR DESCRIPTION
Use 0x1e and 0x1f in place of new line and tab, respectively.