### PR TITLE
Generate code coverage only for GCC x64 builds

### DIFF
--- a/build/ci/linux.yml
+++ b/build/ci/linux.yml
@@ -25,12 +25,12 @@ jobs:
           make -j -C build/nix $(config) tests
         displayName: 'Test'
 
-      # For now, only create coverage reports for gcc.
-      - ${{ if eq(parameters.toolchain, 'gcc') }}:
-        - script: |
-            make -C build/nix $(config) coverage report=/tmp/coverage
-            bash <(curl -s https://codecov.io/bash) -f /tmp/coverage
-          displayName: 'Coverage'
+      # For now, only create coverage reports for gcc x64.
+      - script: |
+          make -C build/nix $(config) coverage report=/tmp/coverage
+          bash <(curl -s https://codecov.io/bash) -f /tmp/coverage
+        condition: and(eq('${{ parameters.toolchain }}', 'gcc'), eq('${{ parameters.arch }}', 'x64'))
+        displayName: 'Coverage'
 
     - ${{ if eq(parameters.configuration, 'Release') }}:
       - script: |


### PR DESCRIPTION
It seems like Codecov doesn't always like many pipelines uploading reports
at the same time.