### PR TITLE
Compress log files during rotation

### DIFF
--- a/fly/logger/logger.hpp
+++ b/fly/logger/logger.hpp
@@ -63,6 +63,7 @@
 
 namespace fly {
 
+class HuffmanConfig;
 class LoggerConfig;
 class LoggerTask;
 class SequencedTaskRunner;
@@ -102,12 +103,14 @@ public:
      * Constructor.
      *
      * @param task_runner Task runner for posting logger-related tasks onto.
-     * @param config Reference to logger configuration.
+     * @param logger_config Reference to logger configuration.
+     * @param huffman_config Reference to Huffman configuration.
      * @param logger_directory Path to store the log file.
      */
     Logger(
         const std::shared_ptr<SequencedTaskRunner> &task_runner,
-        const std::shared_ptr<LoggerConfig> &config,
+        const std::shared_ptr<LoggerConfig> &logger_config,
+        const std::shared_ptr<HuffmanConfig> &huffman_config,
         const std::filesystem::path &logger_directory) noexcept;
 
     /**
@@ -192,7 +195,8 @@ private:
     std::shared_ptr<SequencedTaskRunner> m_task_runner;
     std::shared_ptr<Task> m_task;
 
-    std::shared_ptr<LoggerConfig> m_config;
+    std::shared_ptr<LoggerConfig> m_logger_config;
+    std::shared_ptr<HuffmanConfig> m_huffman_config;
 
     const std::filesystem::path m_log_directory;
     std::filesystem::path m_log_file;

--- a/fly/logger/logger_config.cpp
+++ b/fly/logger/logger_config.cpp
@@ -6,10 +6,17 @@ namespace fly {
 
 //==================================================================================================
 LoggerConfig::LoggerConfig() noexcept :
+    m_default_compress_log_files(true),
     m_default_max_log_file_size(20_u64 << 20),
     m_default_max_message_size(256_u32),
     m_default_queue_wait_time(100_i64)
 {
+}
+
+//==================================================================================================
+bool LoggerConfig::compress_log_files() const
+{
+    return get_value<bool>("compress_log_files", m_default_compress_log_files);
 }
 
 //==================================================================================================

--- a/fly/logger/logger_config.hpp
+++ b/fly/logger/logger_config.hpp
@@ -24,6 +24,11 @@ public:
     LoggerConfig() noexcept;
 
     /**
+     * @return True if log files should be compressed after reaching the max log file size.
+     */
+    bool compress_log_files() const;
+
+    /**
      * @return Max log file size (in bytes) before rotating the log file.
      */
     std::uintmax_t max_log_file_size() const;
@@ -39,6 +44,7 @@ public:
     std::chrono::milliseconds queue_wait_time() const;
 
 protected:
+    bool m_default_compress_log_files;
     std::uintmax_t m_default_max_log_file_size;
     std::uint32_t m_default_max_message_size;
     std::chrono::milliseconds::rep m_default_queue_wait_time;


### PR DESCRIPTION
When a log file becomes full, compress the log file by default. This may
be disabled via LoggerConfig. Using the default max log file size of 20MB
in release mode, the RolloverCompressed unit test sees a compression ratio
of about 26% in 0.12 seconds.

For now, just compress using Huffman encoding. Eventually I'll get around
to writing at least an LZ coder library as well.