### PR TITLE
Custom reporter for Catch2 unit tests

### DIFF
--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,2 +1,67 @@
 #define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_DEFAULT_REPORTER "libfly"
+
 #include <catch2/catch.hpp>
+
+namespace Catch {
+
+/**
+ * A Catch2 test reporter for reporting colorful test and section names to console.
+ */
+class FlyReporter : public ConsoleReporter
+{
+public:
+    FlyReporter(const ReporterConfig &config) : ConsoleReporter(config)
+    {
+    }
+
+    ~FlyReporter() override = default;
+
+    static std::string getDescription()
+    {
+        return "Catch2 test reporter for libfly";
+    }
+
+    void testCaseStarting(const TestCaseInfo &info) override
+    {
+        stream << Colour(Colour::BrightGreen) << "[==== Test Case: " << info.name << " ====]\n";
+
+        ConsoleReporter::testCaseStarting(info);
+        m_current_test_case = info.name;
+    }
+
+    void sectionStarting(const SectionInfo &info) override
+    {
+        if (info.name != m_current_test_case)
+        {
+            // Explicitly flush the stream so this output is not included in tests capturing stdout.
+            stream << Colour(Colour::Blue) << "[ " << info.name << " ]" << std::endl;
+        }
+
+        ConsoleReporter::sectionStarting(info);
+    }
+
+    void testCaseEnded(const TestCaseStats &stats) override
+    {
+        const std::string &name = stats.testInfo.name;
+
+        if (stats.totals.assertions.allOk())
+        {
+            stream << Colour(Colour::ResultSuccess) << "[==== PASSED " << name << " ====]\n\n";
+        }
+        else
+        {
+            stream << Colour(Colour::ResultError) << "[==== FAILED " << name << " ====]\n\n";
+        }
+
+        ConsoleReporter::testCaseEnded(stats);
+        m_current_test_case.clear();
+    }
+
+private:
+    std::string m_current_test_case;
+};
+
+CATCH_REGISTER_REPORTER("libfly", FlyReporter)
+
+} // namespace Catch


### PR DESCRIPTION
Catch2 doesn't report test case or section names. For tests which have
a fair amount of output, this makes it pretty difficult to differentiate
tests. Define a custom reporter to pretty-print these names.

It is a bit more verbose than I'd like (sections that only serve as
common setup steps also get reported). But it's fine for now.