### PR TITLE
Move numeric literal suffixes to the fly namespace

### DIFF
--- a/fly/types/numeric/literals.hpp
+++ b/fly/types/numeric/literals.hpp
@@ -5,73 +5,98 @@
 #include <cstddef>
 #include <cstdint>
 
+namespace fly {
+
 /**
  * Type-safe, fixed-width integer literal suffixes not provided by the STL.
  *
  * The expression that precedes the literal suffix is parsed and validated at compile time.
  * Compilation will fail if any of the following error conditions are met:
  *
- * 1. The expression preceding the literal suffix is invalid. All standard integer literals are
- *    accepted.
- * 2. The value represented by the preceding expression does not fit in the type specified by the
- *    suffix.
- * 3. A character in the preceding expression does not match the corresponding base (e.g. 0b2 is an
- *    invalid expression).
+ *     1. The expression preceding the literal suffix is invalid. All standard integer literals are
+ *        accepted.
+ *     2. The value represented by the preceding expression does not fit in the type specified by
+ *        the suffix.
+ *     3. A character in the preceding expression does not match the corresponding base (e.g. 0b2 is
+ *        an invalid expression).
+ *
+ * The inline namespaces are to allow importing literal suffixes in the fly namespace with explicit
+ * control, without polluting the global namespace. Callers may import the literal suffixes in this
+ * file in any of the following ways:
+ *
+ *     // Import only the literal suffixes declared in this file. This is recommended.
+ *     using namespace fly::literals::numeric_literals;
+ *
+ *     // Import all literal suffixes declared in the fly namespace. Okay, but not recommended.
+ *     using namespace fly::literals;
+ *
+ *     // Import a specific literal suffix declared in this file. Okay, but can be verbose.
+ *     using fly::literals::numeric_literals::operator"" _i8;
+ *
+ *     // Import all symbols from namespace fly. Okay, but strongly discouraged.
+ *     using namespace fly;
  *
  * @author Timothy Flynn (trflynn89@pm.me)
  * @version December 15, 2019
  */
+inline namespace literals {
+    inline namespace numeric_literals {
 
-template <char... Literals>
-constexpr inline std::int8_t operator"" _i8()
-{
-    return fly::detail::literal<std::int8_t, Literals...>();
-}
+        template <char... Literals>
+        constexpr inline std::int8_t operator"" _i8()
+        {
+            return fly::detail::literal<std::int8_t, Literals...>();
+        }
 
-template <char... Literals>
-constexpr inline std::int16_t operator"" _i16()
-{
-    return fly::detail::literal<std::int16_t, Literals...>();
-}
+        template <char... Literals>
+        constexpr inline std::int16_t operator"" _i16()
+        {
+            return fly::detail::literal<std::int16_t, Literals...>();
+        }
 
-template <char... Literals>
-constexpr inline std::int32_t operator"" _i32()
-{
-    return fly::detail::literal<std::int32_t, Literals...>();
-}
+        template <char... Literals>
+        constexpr inline std::int32_t operator"" _i32()
+        {
+            return fly::detail::literal<std::int32_t, Literals...>();
+        }
 
-template <char... Literals>
-constexpr inline std::int64_t operator"" _i64()
-{
-    return fly::detail::literal<std::int64_t, Literals...>();
-}
+        template <char... Literals>
+        constexpr inline std::int64_t operator"" _i64()
+        {
+            return fly::detail::literal<std::int64_t, Literals...>();
+        }
 
-template <char... Literals>
-constexpr inline std::uint8_t operator"" _u8()
-{
-    return fly::detail::literal<std::uint8_t, Literals...>();
-}
+        template <char... Literals>
+        constexpr inline std::uint8_t operator"" _u8()
+        {
+            return fly::detail::literal<std::uint8_t, Literals...>();
+        }
 
-template <char... Literals>
-constexpr inline std::uint16_t operator"" _u16()
-{
-    return fly::detail::literal<std::uint16_t, Literals...>();
-}
+        template <char... Literals>
+        constexpr inline std::uint16_t operator"" _u16()
+        {
+            return fly::detail::literal<std::uint16_t, Literals...>();
+        }
 
-template <char... Literals>
-constexpr inline std::uint32_t operator"" _u32()
-{
-    return fly::detail::literal<std::uint32_t, Literals...>();
-}
+        template <char... Literals>
+        constexpr inline std::uint32_t operator"" _u32()
+        {
+            return fly::detail::literal<std::uint32_t, Literals...>();
+        }
 
-template <char... Literals>
-constexpr inline std::uint64_t operator"" _u64()
-{
-    return fly::detail::literal<std::uint64_t, Literals...>();
-}
+        template <char... Literals>
+        constexpr inline std::uint64_t operator"" _u64()
+        {
+            return fly::detail::literal<std::uint64_t, Literals...>();
+        }
 
-template <char... Literals>
-constexpr inline std::size_t operator"" _zu()
-{
-    return fly::detail::literal<std::size_t, Literals...>();
-}
+        template <char... Literals>
+        constexpr inline std::size_t operator"" _zu()
+        {
+            return fly::detail::literal<std::size_t, Literals...>();
+        }
+
+    } // namespace numeric_literals
+} // namespace literals
+
+} // namespace fly

--- a/test/coders/huffman_coder.cpp
+++ b/test/coders/huffman_coder.cpp
@@ -14,6 +14,8 @@
 #include <string>
 #include <vector>
 
+using namespace fly::literals::numeric_literals;
+
 namespace {
 
 /**

--- a/test/config/config_manager.cpp
+++ b/test/config/config_manager.cpp
@@ -15,6 +15,8 @@
 #include <memory>
 #include <string>
 
+using namespace fly::literals::numeric_literals;
+
 namespace {
 
 /**

--- a/test/logger/logger.cpp
+++ b/test/logger/logger.cpp
@@ -21,6 +21,8 @@
 #include <string>
 #include <vector>
 
+using namespace fly::literals::numeric_literals;
+
 namespace {
 
 /**

--- a/test/path/path_monitor.cpp
+++ b/test/path/path_monitor.cpp
@@ -21,6 +21,8 @@
 #include "test/util/path_util.hpp"
 #include "test/util/waitable_task_runner.hpp"
 
+using namespace fly::literals::numeric_literals;
+
 namespace {
 
 std::chrono::seconds s_wait_time(5);

--- a/test/system/system_monitor.cpp
+++ b/test/system/system_monitor.cpp
@@ -18,6 +18,8 @@
 
 #include "test/util/waitable_task_runner.hpp"
 
+using namespace fly::literals::numeric_literals;
+
 namespace {
 
 /**

--- a/test/types/bit_stream.cpp
+++ b/test/types/bit_stream.cpp
@@ -8,6 +8,8 @@
 #include <limits>
 #include <sstream>
 
+using namespace fly::literals::numeric_literals;
+
 TEST_CASE("BitStream", "[bit_stream]")
 {
     std::istringstream input_stream(std::ios::in | std::ios::binary);

--- a/test/types/concurrent_container.cpp
+++ b/test/types/concurrent_container.cpp
@@ -11,6 +11,8 @@
 #include <type_traits>
 #include <vector>
 
+using namespace fly::literals::numeric_literals;
+
 TEMPLATE_PRODUCT_TEST_CASE(
     "ConcurrentContainer",
     "[concurrency]",

--- a/test/types/literals.cpp
+++ b/test/types/literals.cpp
@@ -5,6 +5,8 @@
 #include <cstdint>
 #include <type_traits>
 
+using namespace fly::literals::numeric_literals;
+
 TEST_CASE("Literals", "[numeric]")
 {
     SECTION("Signed 8-bit integer literals")

--- a/test/types/string_converter.cpp
+++ b/test/types/string_converter.cpp
@@ -7,6 +7,8 @@
 #include <string>
 #include <type_traits>
 
+using namespace fly::literals::numeric_literals;
+
 namespace {
 
 template <typename StringType, typename T>

--- a/test/types/string_formatter.cpp
+++ b/test/types/string_formatter.cpp
@@ -7,6 +7,8 @@
 
 #include <limits>
 
+using namespace fly::literals::numeric_literals;
+
 TEMPLATE_TEST_CASE(
     "BasicStringFormatter",
     "[string]",


### PR DESCRIPTION
To avoid polluting the global namespace, put the numeric literal suffixes
in the fly namespace. But to discourage callers from importing all of the
fly namespace (using namespace fly), also nest the suffixes in inline
namespaces.

The standard going forward will be to inline all literal suffixes in the
fly;:literals namespace, and further in a second inline namespace specific
to only that file (fly::literals::numeric_literals in this case). This is
the practice used by the STL as well.