### PR TITLE
Linux build: replace release and profile flags with mode flag

### DIFF
--- a/build/ci/linux.yml
+++ b/build/ci/linux.yml
@@ -18,7 +18,7 @@ jobs:
 
     - ${{ if eq(parameters.configuration, 'Debug') }}:
       - script: |
-          echo "##vso[task.setvariable variable=config]release=0 toolchain=${{ parameters.toolchain }} arch=${{ parameters.arch }}"
+          echo "##vso[task.setvariable variable=config]mode=debug toolchain=${{ parameters.toolchain }} arch=${{ parameters.arch }}"
         displayName: 'Configure'
 
       - script: |
@@ -33,7 +33,7 @@ jobs:
 
     - ${{ if eq(parameters.configuration, 'Release') }}:
       - script: |
-          echo "##vso[task.setvariable variable=config]release=1 toolchain=${{ parameters.toolchain }} arch=${{ parameters.arch }}"
+          echo "##vso[task.setvariable variable=config]mode=release toolchain=${{ parameters.toolchain }} arch=${{ parameters.arch }}"
         displayName: 'Configure'
 
       - script: |

--- a/build/nix/build.mk
+++ b/build/nix/build.mk
@@ -39,7 +39,7 @@ clean:
 tests: $(TEST_BINARIES)
 	$(Q)failed=0; \
 	for tgt in $(TEST_BINARIES) ; do \
-		if [[ $(toolchain) == "clang" ]] && [[ $(release) -eq 0 ]] ; then \
+		if [[ $(toolchain) == "clang" ]] && [[ $(mode) == "debug" ]] ; then \
 			export LLVM_PROFILE_FILE="$$tgt.profraw"; \
 		fi; \
 		\

--- a/build/nix/config.mk
+++ b/build/nix/config.mk
@@ -1,20 +1,17 @@
 # Define the default make configuration. Not all defaults are defined here, but
 # all command line options are listed here for convenience.
 
-# Toolchain to compile with (clang or gcc)
+# Compilation toolchain (clang, gcc)
 toolchain := clang
 
-# Compile caching system
-cacher :=
-
-# Define debug vs. release
-release := 0
-
-# Enable profiling (gcc only) (takes precedence over release)
-profile := 0
+# Compilation mode (debug, release, profile)
+mode := debug
 
 # Build 32-bit or 64-bit target
 arch := $(arch)
+
+# Compile caching system
+cacher :=
 
 # Enable stylized builds
 stylized := 1
@@ -37,6 +34,13 @@ else
     $(error Unrecognized toolchain $(toolchain), check config.mk)
 endif
 
+# Validate the provided compilation mode.
+SUPPORTED_MODES := debug release profile
+
+ifneq ($(mode), $(filter $(SUPPORTED_MODES), $(mode)))
+    $(error Compilation mode $(mode) not supported, check config.mk)
+endif
+
 # Use a compiler cache if requested
 ifneq ($(cacher), )
     CC := $(cacher) $(CC)
@@ -44,14 +48,7 @@ ifneq ($(cacher), )
 endif
 
 # Define the output directories
-ifeq ($(profile), 1)
-    OUT_DIR := $(CURDIR)/profile/$(toolchain)/$(arch)
-else ifeq ($(release), 1)
-    OUT_DIR := $(CURDIR)/release/$(toolchain)/$(arch)
-else
-    OUT_DIR := $(CURDIR)/debug/$(toolchain)/$(arch)
-endif
-
+OUT_DIR := $(CURDIR)/$(mode)/$(toolchain)/$(arch)
 BIN_DIR := $(OUT_DIR)/bin
 LIB_DIR := $(OUT_DIR)/lib
 OBJ_DIR := $(OUT_DIR)/obj
@@ -79,7 +76,7 @@ else
     $(info Obj dir = $(OBJ_DIR))
     $(info Etc dir = $(ETC_DIR))
     $(info Toolchain = $(toolchain))
-    $(info Cacher = $(cacher))
-    $(info Release = $(release))
+    $(info Mode = $(mode))
     $(info Arch = $(arch))
+    $(info Cacher = $(cacher))
 endif

--- a/build/nix/flags.mk
+++ b/build/nix/flags.mk
@@ -47,11 +47,9 @@ CF_ALL += \
     \
     -pedantic
 
-ifeq ($(profile), 0)
-ifeq ($(release), 0)
+ifeq ($(mode), debug)
     CF_ALL += \
         -Winline
-endif
 endif
 
 ifeq ($(toolchain), clang)
@@ -66,33 +64,31 @@ else ifeq ($(toolchain), gcc)
         -Wsign-promo \
         -Wsuggest-override
 
-    ifeq ($(profile), 0)
-    ifeq ($(release), 0)
+    ifeq ($(mode), debug)
         CF_ALL += \
             -Wsuggest-final-methods \
             -Wsuggest-final-types
     endif
-    endif
 endif
 
-# Add profiling symbols for profile builds, optimize release builds, and add debug symbols & use
-# address sanitizer for debug builds.
-ifeq ($(profile), 1)
-    ifeq ($(toolchain), gcc)
-        CF_ALL += -O2 -g -pg
-        LDFLAGS += -pg
-    else
-        $(error Profiling not supported with toolchain $(toolchain), check flags.mk)
-    endif
-else ifeq ($(release), 1)
-    CF_ALL += -O2
-else
+# Add debug symbols & use address sanitizer for debug builds, optimize release builds, and add
+# profiling symbols for profile builds.
+ifeq ($(mode), debug)
     CF_ALL += -O0 -g -fsanitize=address -fno-omit-frame-pointer
 
     ifeq ($(toolchain), clang)
         CF_ALL += -fprofile-instr-generate -fcoverage-mapping
     else ifeq ($(toolchain), gcc)
         CF_ALL += --coverage
+    endif
+else ifeq ($(mode), release)
+    CF_ALL += -O2
+else ifeq ($(mode), profile)
+    ifeq ($(toolchain), gcc)
+        CF_ALL += -O2 -g -pg
+        LDFLAGS += -pg
+    else
+        $(error Profiling not supported with toolchain $(toolchain), check flags.mk)
     endif
 endif
 


### PR DESCRIPTION
Felt awkward setting release=1 or profile=1 and having to know which
would take precedence. Replace these with a single mode flag to chose
debug, release, or profile.