### PR TITLE
Extend Linux CI to compile with GCC in release mode

### DIFF
--- a/.azure.yml
+++ b/.azure.yml
@@ -8,62 +8,76 @@ trigger:
     - '*'
 
 jobs:
-  #### Linux ####
+  #### Clang ####
 
   - template: build/ci/linux.yml
     parameters:
-      configuration: 'Debug'
       toolchain: 'clang'
+      mode: 'Debug'
       arch: 'x86'
 
   - template: build/ci/linux.yml
     parameters:
-      configuration: 'Debug'
       toolchain: 'clang'
+      mode: 'Debug'
       arch: 'x64'
 
   - template: build/ci/linux.yml
     parameters:
-      configuration: 'Debug'
-      toolchain: 'gcc'
+      toolchain: 'clang'
+      mode: 'Release'
       arch: 'x86'
 
   - template: build/ci/linux.yml
     parameters:
-      configuration: 'Debug'
+      toolchain: 'clang'
+      mode: 'Release'
+      arch: 'x64'
+
+  #### GCC ####
+
+  - template: build/ci/linux.yml
+    parameters:
       toolchain: 'gcc'
+      mode: 'Debug'
+      arch: 'x86'
+
+  - template: build/ci/linux.yml
+    parameters:
+      toolchain: 'gcc'
+      mode: 'Debug'
       arch: 'x64'
 
   - template: build/ci/linux.yml
     parameters:
-      configuration: 'Release'
-      toolchain: 'clang'
+      toolchain: 'gcc'
+      mode: 'Release'
       arch: 'x86'
 
   - template: build/ci/linux.yml
     parameters:
-      configuration: 'Release'
-      toolchain: 'clang'
+      toolchain: 'gcc'
+      mode: 'Release'
       arch: 'x64'
 
   #### Windows ####
 
   - template: build/ci/windows.yml
     parameters:
-      configuration: 'Debug'
+      mode: 'Debug'
       arch: 'x86'
 
   - template: build/ci/windows.yml
     parameters:
-      configuration: 'Debug'
+      mode: 'Debug'
       arch: 'x64'
 
   - template: build/ci/windows.yml
     parameters:
-      configuration: 'Release'
+      mode: 'Release'
       arch: 'x86'
 
   - template: build/ci/windows.yml
     parameters:
-      configuration: 'Release'
+      mode: 'Release'
       arch: 'x64'

--- a/build/ci/linux.yml
+++ b/build/ci/linux.yml
@@ -1,10 +1,10 @@
 parameters:
-  configuration: 'Debug'
   toolchain: 'clang'
+  mode: 'Debug'
   arch: 'x64'
 
 jobs:
-  - job: 'Linux_${{ parameters.configuration }}_${{ parameters.toolchain }}_${{ parameters.arch }}'
+  - job: 'Linux_${{ parameters.toolchain }}_${{ parameters.mode }}_${{ parameters.arch }}'
 
     pool:
       vmImage: ubuntu-20.04
@@ -16,7 +16,7 @@ jobs:
     steps:
     - template: setup.yml
 
-    - ${{ if eq(parameters.configuration, 'Debug') }}:
+    - ${{ if eq(parameters.mode, 'Debug') }}:
       - script: |
           echo "##vso[task.setvariable variable=config]mode=debug toolchain=${{ parameters.toolchain }} arch=${{ parameters.arch }}"
         displayName: 'Configure'
@@ -31,7 +31,7 @@ jobs:
         condition: and(eq('${{ parameters.toolchain }}', 'clang'), eq('${{ parameters.arch }}', 'x64'))
         displayName: 'Coverage'
 
-    - ${{ if eq(parameters.configuration, 'Release') }}:
+    - ${{ if eq(parameters.mode, 'Release') }}:
       - script: |
           echo "##vso[task.setvariable variable=config]mode=release toolchain=${{ parameters.toolchain }} arch=${{ parameters.arch }}"
         displayName: 'Configure'
@@ -40,9 +40,10 @@ jobs:
           make -j $(nproc) -C build/nix $(config) libfly
         displayName: 'Build'
 
-      - template: package.yml
-        parameters:
-          contents: 'build/nix/release/${{ parameters.toolchain }}/${{ parameters.arch }}/etc/libfly-*.tar.bz2'
+      - ${{ if eq(parameters.toolchain, 'clang') }}:
+        - template: package.yml
+          parameters:
+            contents: 'build/nix/release/${{ parameters.toolchain }}/${{ parameters.arch }}/etc/libfly-*.tar.bz2'
 
     - script: |
         make -j -C build/nix $(config) install

--- a/build/ci/windows.yml
+++ b/build/ci/windows.yml
@@ -1,9 +1,9 @@
 parameters:
-  configuration: 'Debug'
+  mode: 'Debug'
   arch: 'x64'
 
 jobs:
-  - job: 'Windows_${{ parameters.configuration }}_${{ parameters.arch }}'
+  - job: 'Windows_${{ parameters.mode }}_${{ parameters.arch }}'
     pool:
       vmImage: windows-2019
 
@@ -13,16 +13,16 @@ jobs:
     - task: VSBuild@1
       inputs:
         solution: 'build\win\libfly.sln'
-        configuration: ${{ parameters.configuration }}
+        configuration: ${{ parameters.mode }}
         platform: ${{ parameters.arch }}
         maximumCpuCount: true
       displayName: 'Build'
 
-    - ${{ if eq(parameters.configuration, 'Release') }}:
+    - ${{ if eq(parameters.mode, 'Release') }}:
       - task: PowerShell@2
         inputs:
           filePath: build\win\test.ps1
-          arguments: -configuration ${{ parameters.configuration }} -arch ${{ parameters.arch }}
+          arguments: -mode ${{ parameters.mode }} -arch ${{ parameters.arch }}
           failOnStderr: false
         displayName: 'Test'
 

--- a/build/win/test.ps1
+++ b/build/win/test.ps1
@@ -1,14 +1,14 @@
 param (
-    [Parameter(Mandatory=$true)][string]$configuration,
+    [Parameter(Mandatory=$true)][string]$mode,
     [Parameter(Mandatory=$true)][string]$arch
 )
 
 # Run all unit tests for an architecture.
-function Run-Libfly-Test($configuration, $arch)
+function Run-Libfly-Test($mode, $arch)
 {
     Write-Output "Running $arch tests"
 
-    $full_path = $PSScriptRoot + "\" + $configuration + "\msvc\" + $arch
+    $full_path = $PSScriptRoot + "\" + $mode + "\msvc\" + $arch
     $tests_passed = 0
     $tests_failed = 0
 
@@ -33,4 +33,4 @@ function Run-Libfly-Test($configuration, $arch)
 }
 
 # Run the tests
-Run-Libfly-Test $configuration $arch
+Run-Libfly-Test $mode $arch


### PR DESCRIPTION
Since GCC in release mode was broken, ensure it can compile during CI.
The official release package will continue to be provided only by Clang.