### PR TITLE
Linux build: do not ignore system header dependencies

### DIFF
--- a/build/nix/flags.mk
+++ b/build/nix/flags.mk
@@ -12,7 +12,7 @@ LDFLAGS := -L$(LIB_DIR)
 LDLIBS :=
 
 # Compiler flags for both C and C++ files
-CF_ALL := -MMD -MP -fPIC
+CF_ALL := -MD -MP -fPIC
 CF_ALL += -I$(SOURCE_ROOT)
 
 ifeq ($(arch), x86)


### PR DESCRIPTION
libfly itself is included as system headers when installed. Files should
be rebuilt if a new version is installed.