### PR TITLE
Move macOS Mach kernel calls to wrapper methods

### DIFF
--- a/fly/system/files.mk
+++ b/fly/system/files.mk
@@ -10,5 +10,6 @@ ifeq ($(SYSTEM), LINUX)
         $(d)/nix/system_monitor_impl.cpp
 else ifeq ($(SYSTEM), MACOS)
     SRC_$(d) += \
-        $(d)/mac/system_monitor_impl.cpp
+        $(d)/mac/mach_api.mm \
+        $(d)/mac/system_monitor_impl.mm
 endif

--- a/fly/system/mac/mach_api.h
+++ b/fly/system/mac/mach_api.h
@@ -1,0 +1,113 @@
+#pragma once
+
+#include <mach/mach.h>
+
+namespace fly::detail {
+
+/**
+ * Fetch basic information about this macOS host. Uses the following structures and methods:
+ *
+ *     host_basic_info_data_t:
+ *     https://opensource.apple.com/source/xnu/xnu-6153.81.5/osfmk/mach/host_info.h.auto.
+ *
+ *     HOST_BASIC_INFO:
+ *     https://opensource.apple.com/source/xnu/xnu-6153.81.5/osfmk/mach/host_info.h.auto.html
+ *
+ *     ::host_info():
+ *     https://opensource.apple.com/source/xnu/xnu-6153.81.5/osfmk/mach/mach_host.defs.auto.html
+ *
+ * @param host_info Reference to the structure to hold the fetched data.
+ *
+ * @return True if the data could be fetched.
+ */
+bool host_basic_info(host_basic_info_data_t &host_info);
+
+/**
+ * Fetch CPU load statistics about this macOS host. Uses the following structures and methods:
+ *
+ *     host_cpu_load_info_data_t:
+ *     https://opensource.apple.com/source/xnu/xnu-6153.81.5/osfmk/mach/host_info.h.auto.html
+ *
+ *     HOST_CPU_LOAD_INFO:
+ *     https://opensource.apple.com/source/xnu/xnu-6153.81.5/osfmk/mach/host_info.h.auto.html
+ *
+ *     ::host_statistics():
+ *     https://opensource.apple.com/source/xnu/xnu-6153.81.5/osfmk/mach/mach_host.defs.auto.html
+ *
+ * @param cpu_load Reference to the structure to hold the fetched data.
+ *
+ * @return True if the data could be fetched.
+ */
+bool host_cpu_load(host_cpu_load_info_data_t &cpu_load);
+
+/**
+ * Fetch the page size for this macOS host. Uses the following structures and methods:
+ *
+ *     vm_size_t:
+ *     https://opensource.apple.com/source/xnu/xnu-6153.81.5/osfmk/mach/vm_types.h.auto.html
+ *
+ *     ::host_page_size():
+ *     https://opensource.apple.com/source/xnu/xnu-6153.81.5/libsyscall/mach/mach/mach_init.h.auto.html
+ *
+ * @param page_size Reference to the structure to hold the fetched data.
+ *
+ * @return True if the data could be fetched.
+ */
+bool host_page_size(vm_size_t &page_size);
+
+/**
+ * Fetch virtual memory statistics about this macOS host. Uses the following structures and methods:
+ *
+ *     vm_statistics64_data_t:
+ *     https://opensource.apple.com/source/xnu/xnu-6153.81.5/osfmk/mach/vm_statistics.h.auto.html
+ *
+ *     HOST_VM_INFO64:
+ *     https://opensource.apple.com/source/xnu/xnu-6153.81.5/osfmk/mach/host_info.h.auto.html
+ *
+ *     ::host_statistics64():
+ *     https://opensource.apple.com/source/xnu/xnu-6153.81.5/osfmk/mach/mach_host.defs.auto.html
+ *
+ * @param vm_info Reference to the structure to hold the fetched data.
+ *
+ * @return True if the data could be fetched.
+ */
+bool host_vm_info(vm_statistics64_data_t &vm_info);
+
+/**
+ * Fetch basic information about this macOS process. Uses the following structures and methods:
+ *
+ *     task_basic_info_64_data_t:
+ *     https://opensource.apple.com/source/xnu/xnu-6153.81.5/osfmk/mach/task_info.h.auto.html
+ *
+ *     TASK_BASIC_INFO_64:
+ *     https://opensource.apple.com/source/xnu/xnu-6153.81.5/osfmk/mach/task_info.h.auto.html
+ *
+ *     ::task_info():
+ *     https://opensource.apple.com/source/xnu/xnu-6153.81.5/osfmk/mach/task.defs.auto.html
+ *
+ * @param task_info Reference to the structure to hold the fetched data.
+ *
+ * @return True if the data could be fetched.
+ */
+bool task_basic_info(task_basic_info_64_data_t &task_info);
+
+/**
+ * Fetch live thread time information about this macOS process. Uses the following structures and
+ * methods:
+ *
+ *     task_thread_times_info_data_t:
+ *     https://opensource.apple.com/source/xnu/xnu-6153.81.5/osfmk/mach/task_info.h.auto.html
+ *
+ *     TASK_THREAD_TIMES_INFO:
+ *     https://opensource.apple.com/source/xnu/xnu-6153.81.5/osfmk/mach/task_info.h.auto.html
+ *
+ *     ::task_info():
+ *     https://opensource.apple.com/source/xnu/xnu-6153.81.5/osfmk/mach/task.defs.auto.html
+ *
+ * @param thread_times Reference to the structure to hold the fetched data.
+ *
+ * @return True if the data could be fetched.
+ */
+bool task_thread_times(task_thread_times_info_data_t &thread_times);
+
+} // namespace fly::detail

--- a/fly/system/mac/mach_api.mm
+++ b/fly/system/mac/mach_api.mm
@@ -1,0 +1,99 @@
+#include "fly/system/mac/mach_api.h"
+
+#include "fly/logger/logger.hpp"
+
+namespace fly::detail {
+
+namespace {
+
+    bool check_kernel_status(const char *caller, const kern_return_t &status)
+    {
+        if (status != KERN_SUCCESS)
+        {
+            LOGW("Kernel error gethering %s (%d): %s", caller, status, ::mach_error_string(status));
+            return false;
+        }
+
+        return true;
+    }
+
+} // namespace
+
+//==================================================================================================
+bool host_basic_info(host_basic_info_data_t &basic_info)
+{
+    mach_msg_type_number_t count = HOST_BASIC_INFO_COUNT;
+
+    const kern_return_t status = ::host_info(
+        mach_host_self(),
+        HOST_BASIC_INFO,
+        reinterpret_cast<host_info_t>(&basic_info),
+        &count);
+
+    return check_kernel_status(__FUNCTION__, status);
+}
+
+//==================================================================================================
+bool host_cpu_load(host_cpu_load_info_data_t &cpu_load)
+{
+    mach_msg_type_number_t count = HOST_CPU_LOAD_INFO_COUNT;
+
+    const kern_return_t status = ::host_statistics(
+        mach_host_self(),
+        HOST_CPU_LOAD_INFO,
+        reinterpret_cast<host_info_t>(&cpu_load),
+        &count);
+
+    return check_kernel_status(__FUNCTION__, status);
+}
+
+//==================================================================================================
+bool host_page_size(vm_size_t &page_size)
+{
+    const kern_return_t status = ::host_page_size(mach_host_self(), &page_size);
+    return check_kernel_status(__FUNCTION__, status);
+}
+
+//==================================================================================================
+bool host_vm_info(vm_statistics64_data_t &vm_info)
+{
+    mach_msg_type_number_t count = HOST_VM_INFO64_COUNT;
+
+    const kern_return_t status = ::host_statistics64(
+        mach_host_self(),
+        HOST_VM_INFO64,
+        reinterpret_cast<host_info64_t>(&vm_info),
+        &count);
+
+    return check_kernel_status(__FUNCTION__, status);
+}
+
+//==================================================================================================
+bool task_basic_info(task_basic_info_64_data_t &task_info)
+{
+    mach_msg_type_number_t count = TASK_BASIC_INFO_64_COUNT;
+
+    const kern_return_t status = ::task_info(
+        mach_task_self(),
+        TASK_BASIC_INFO_64,
+        reinterpret_cast<task_info_t>(&task_info),
+        &count);
+
+    return check_kernel_status(__FUNCTION__, status);
+}
+
+//==================================================================================================
+bool task_thread_times(task_thread_times_info_data_t &thread_times)
+{
+    mach_msg_type_number_t count = TASK_THREAD_TIMES_INFO_COUNT;
+
+    const kern_return_t status = ::task_info(
+        mach_task_self(),
+        TASK_THREAD_TIMES_INFO,
+        reinterpret_cast<task_info_t>(&thread_times),
+        &count);
+
+    return check_kernel_status(__FUNCTION__, status);
+}
+
+} // namespace fly::detail

--- a/fly/system/mac/system_monitor_impl.mm
+++ b/fly/system/mac/system_monitor_impl.mm
@@ -1,15 +1,22 @@
 #include "fly/system/mac/system_monitor_impl.hpp"
 
-#include "fly/logger/logger.hpp"
+#include "fly/system/mac/mach_api.h"
 #include "fly/system/system_config.hpp"
 #include "fly/task/task_runner.hpp"
 
 #import <Foundation/Foundation.h>
-#include <mach/mach.h>
-
-#include <thread>
 
 namespace fly {
+
+namespace {
+
+    std::uint64_t time_value_to_microseconds(const time_value_t &time_value)
+    {
+        return (static_cast<std::uint64_t>(time_value.seconds) * 1'000'000) +
+            static_cast<std::uint64_t>(time_value.microseconds);
+    }
+
+} // namespace
 
 //==================================================================================================
 SystemMonitorImpl::SystemMonitorImpl(
@@ -29,27 +36,16 @@ void SystemMonitorImpl::update_system_cpu_count()
 //==================================================================================================
 void SystemMonitorImpl::update_system_cpu_usage()
 {
-    const mach_port_t host = mach_host_self();
-    kern_return_t status = KERN_SUCCESS;
-
-    host_cpu_load_info_data_t host_info {};
-    mach_msg_type_number_t host_info_count = HOST_CPU_LOAD_INFO_COUNT;
-
-    status = ::host_statistics(
-        host,
-        HOST_CPU_LOAD_INFO,
-        reinterpret_cast<host_info_t>(&host_info),
-        &host_info_count);
-    if (status != KERN_SUCCESS)
+    host_cpu_load_info_data_t cpu_load {};
+    if (!detail::host_cpu_load(cpu_load))
     {
-        LOGW("Could not poll system CPU (%d): %s", status, ::mach_error_string(status));
         return;
     }
 
-    const auto user = static_cast<std::uint64_t>(host_info.cpu_ticks[CPU_STATE_USER]);
-    const auto system = static_cast<std::uint64_t>(host_info.cpu_ticks[CPU_STATE_SYSTEM]);
-    const auto idle = static_cast<std::uint64_t>(host_info.cpu_ticks[CPU_STATE_IDLE]);
-    const auto nice = static_cast<std::uint64_t>(host_info.cpu_ticks[CPU_STATE_NICE]);
+    const auto user = static_cast<std::uint64_t>(cpu_load.cpu_ticks[CPU_STATE_USER]);
+    const auto system = static_cast<std::uint64_t>(cpu_load.cpu_ticks[CPU_STATE_SYSTEM]);
+    const auto idle = static_cast<std::uint64_t>(cpu_load.cpu_ticks[CPU_STATE_IDLE]);
+    const auto nice = static_cast<std::uint64_t>(cpu_load.cpu_ticks[CPU_STATE_NICE]);
 
     if ((user >= m_prev_system_user_time) && (system >= m_prev_system_system_time) &&
         (idle >= m_prev_system_idle_time) && (nice >= m_prev_system_nice_time))
@@ -70,32 +66,15 @@ void SystemMonitorImpl::update_system_cpu_usage()
 //==================================================================================================
 void SystemMonitorImpl::update_process_cpu_usage()
 {
-    const mach_port_t task = mach_task_self();
-    kern_return_t status = KERN_SUCCESS;
-
-    task_thread_times_info_data_t task_info {};
-    mach_msg_type_number_t task_info_count = TASK_THREAD_TIMES_INFO_COUNT;
-
-    status = ::task_info(
-        task,
-        TASK_THREAD_TIMES_INFO,
-        reinterpret_cast<task_info_t>(&task_info),
-        &task_info_count);
-    if (status != KERN_SUCCESS)
+    task_thread_times_info_data_t thread_times {};
+    if (!detail::task_thread_times(thread_times))
     {
-        LOGW("Could not poll process CPU (%d): %s", status, ::mach_error_string(status));
         return;
     }
 
-    // Convert a time_value_t to microseconds.
-    auto time_value_to_microseconds = [](const time_value_t &time_value) -> std::uint64_t {
-        return (static_cast<std::uint64_t>(time_value.seconds) * 1'000'000) +
-            static_cast<std::uint64_t>(time_value.microseconds);
-    };
-
     const auto now = std::chrono::high_resolution_clock::now();
-    const auto user = time_value_to_microseconds(task_info.user_time);
-    const auto system = time_value_to_microseconds(task_info.system_time);
+    const auto user = time_value_to_microseconds(thread_times.user_time);
+    const auto system = time_value_to_microseconds(thread_times.system_time);
 
     if ((m_prev_process_user_time != 0) && (now > m_prev_time) &&
         (user >= m_prev_process_user_time) && (system >= m_prev_process_system_time))
@@ -115,48 +94,26 @@ void SystemMonitorImpl::update_process_cpu_usage()
 //==================================================================================================
 void SystemMonitorImpl::update_system_memory_usage()
 {
-    const mach_port_t host = mach_host_self();
-    kern_return_t status = KERN_SUCCESS;
-
-    host_basic_info host_info {};
-    mach_msg_type_number_t host_info_count = HOST_BASIC_INFO_COUNT;
-
-    status = ::host_info(
-        host,
-        HOST_BASIC_INFO,
-        reinterpret_cast<host_info_t>(&host_info),
-        &host_info_count);
-    if (status != KERN_SUCCESS)
+    host_basic_info_data_t basic_info {};
+    if (!detail::host_basic_info(basic_info))
     {
-        LOGW("Could not poll system host memory (%d): %s", status, ::mach_error_string(status));
+        return;
+    }
+
+    vm_statistics64_data_t vm_info {};
+    if (!detail::host_vm_info(vm_info))
+    {
         return;
     }
 
     vm_size_t page_size = 0;
-
-    status = ::host_page_size(host, &page_size);
-    if (status != KERN_SUCCESS)
+    if (!detail::host_page_size(page_size))
     {
-        LOGW("Could not poll system page size (%d): %s", status, ::mach_error_string(status));
         return;
     }
 
-    vm_statistics64_data_t host_stats {};
-    mach_msg_type_number_t host_stats_count = HOST_VM_INFO64_COUNT;
-
-    status = ::host_statistics64(
-        host,
-        HOST_VM_INFO,
-        reinterpret_cast<host_info64_t>(&host_stats),
-        &host_stats_count);
-    if (status != KERN_SUCCESS)
-    {
-        LOGW("Could not poll system memory (%d): %s", status, ::mach_error_string(status));
-        return;
-    }
-
-    const auto total_memory = static_cast<std::uint64_t>(host_info.max_mem);
-    const auto free_memory = static_cast<std::uint64_t>(host_stats.free_count) * page_size;
+    const auto total_memory = static_cast<std::uint64_t>(basic_info.max_mem);
+    const auto free_memory = static_cast<std::uint64_t>(vm_info.free_count) * page_size;
 
     m_total_system_memory.store(total_memory);
     m_system_memory_usage.store(total_memory - free_memory);
@@ -165,20 +122,9 @@ void SystemMonitorImpl::update_system_memory_usage()
 //==================================================================================================
 void SystemMonitorImpl::update_process_memory_usage()
 {
-    const mach_port_t task = mach_task_self();
-    kern_return_t status = KERN_SUCCESS;
-
     task_basic_info_64_data_t task_info {};
-    mach_msg_type_number_t task_info_count = TASK_BASIC_INFO_64_COUNT;
-
-    status = ::task_info(
-        task,
-        TASK_BASIC_INFO_64,
-        reinterpret_cast<task_info_t>(&task_info),
-        &task_info_count);
-    if (status != KERN_SUCCESS)
+    if (!detail::task_basic_info(task_info))
     {
-        LOGW("Could not poll process memory (%d): %s", status, ::mach_error_string(status));
         return;
     }
 


### PR DESCRIPTION
The kernel calls are a bit ugly. Move them to their own wrapper file to
keep these details hidden. This also makes it easier to document where
the kernel data is located on opensource.apple.com for reference.