### PR TITLE
Build system: Clean up use of the variable $(t)

### DIFF
--- a/build/nix/files.mk
+++ b/build/nix/files.mk
@@ -6,68 +6,61 @@ SPACE +=
 
 # Define output files for compiled C/C++/Objective-C/Objective-C++ targets.
 #
-# $(1) = The target's name.
-# $(2) = The C/C++/Objective-C/Objective-C++ files to be compiled.
+# $(1) = The C/C++/Objective-C/Objective-C++ files to be compiled.
 define OBJ_OUT_FILES
 
 OBJ_DIR_$(d) := $(OBJ_DIR)/$$(subst $(SOURCE_ROOT)/,,$(d))
 
-o_$(d) := $$(addsuffix .o, $$(subst $(d),,$$(basename $(2))))
+o_$(d) := $$(addsuffix .o, $$(subst $(d),,$$(basename $(1))))
 o_$(d) := $$(addprefix $$(OBJ_DIR_$(d)), $$(o_$(d)))
 
-OBJ_$$(strip $(1)) += $$(o_$(d))
+OBJ_$(t) += $$(o_$(d))
 DEP_$(d) := $$(o_$(d):%.o=%.d)
 
 endef
 
 # Define the output files for compiled Java targets.
 #
-# $(1) = The target's name.
-# $(2) = The Java files to be compiled.
+# $(1) = The Java files to be compiled.
 define JAVA_OUT_FILES
 
-t := $$(strip $(1))
-
-c_$(d) := $$(subst $(SOURCE_ROOT)/$$(TARGET_PATH_$$(t))/,,$(2))
+c_$(d) := $$(subst $(SOURCE_ROOT)/$$(TARGET_PATH_$(t))/,,$(1))
 c_$(d) := $$(addsuffix .class, $$(basename $$(c_$(d))))
 
-SOURCES_$$(t) += $(2)
+SOURCES_$(t) += $(1)
 
 # For each Java class file, form the command line argument to include those class files in the
 # target JAR. The format for each class file will be: -C '$(CLASS_DIR)' '$(class file)'
 #
 # Note the file paths are surrounded in single quotes. If a file path contains the $ symbol,
 # this will prevent Make/Bash from evaluating the file name as a variable.
-CONTENTS_$$(t) += $$(foreach class, $$(c_$(d)), -C '$(CLASS_DIR)' '$$(class)')
+CONTENTS_$(t) += $$(foreach class, $$(c_$(d)), -C '$(CLASS_DIR)' '$$(class)')
 
 endef
 
 # Define the files and command line arguments for Java compilation and JAR creation.
 #
-# $(1) = The target's name.
-# $(2) = The paths to any JARs or packages to reference for compilation.
-# $(3) = The paths to any resources to include in the executable JAR.
+# $(1) = The paths to any JARs or packages to reference for compilation.
+# $(2) = The paths to any resources to include in the executable JAR.
 define JAVA_JAR_FILES
 
-t := $$(strip $(1))
-
-ifneq ($(2),)
+ifneq ($(1),)
     # Form the command line argument to include each provided class path.
-    CLASS_PATH_$$(t) := -cp $(subst $(SPACE),:,$(strip $(2)))
+    CLASS_PATH_$(t) := -cp $(subst $(SPACE),:,$(strip $(1)))
 
     # For all JAR files specified in the class path, determine the classes stored in the class path
     # JAR and form the command line argument to include those classes in the target JAR. The format
     # for each class will be: -C '$(CLASS_DIR)' '$(class file)'
-    CLASS_PATH_JAR_$$(t) := $(filter %.jar, $(strip $(2)))
+    CLASS_PATH_JAR_$(t) := $(filter %.jar, $(strip $(1)))
 
-    ifneq ($$(CLASS_PATH_JAR_$$(t)),)
-        j_$$(t) := $$(foreach jar, $$(CLASS_PATH_JAR_$$(t)), $$(shell unzip -Z1 $$(jar) "*.class"))
-        CONTENTS_$$(t) += $$(foreach class, $$(j_$$(t)), -C '$(CLASS_DIR)' '$$(class)')
+    ifneq ($$(CLASS_PATH_JAR_$(t)),)
+        j_$(t) := $$(foreach jar, $$(CLASS_PATH_JAR_$(t)), $$(shell unzip -Z1 $$(jar) "*.class"))
+        CONTENTS_$(t) += $$(foreach class, $$(j_$(t)), -C '$(CLASS_DIR)' '$$(class)')
     endif
 endif
 
 # Form the command line argument to include each provided resource path in the target JAR. The
 # format for each resource of the form /path/to/resource will be: -C '/path/to' 'resource'
-CONTENTS_$$(t) += $$(foreach res, $(3), -C '$$(dir $$(res))' '$$(notdir $$(res))')
+CONTENTS_$(t) += $$(foreach res, $(2), -C '$$(dir $$(res))' '$$(notdir $$(res))')
 
 endef

--- a/build/nix/target.mk
+++ b/build/nix/target.mk
@@ -11,6 +11,7 @@ TEST_BINARIES :=
 # $(1) = The target's name.
 define DEFINE_TARGET
 
+# Define the global variable $(t) to refer to the current target.
 t := $$(strip $(1))
 
 # Define the path to the target output binary/library
@@ -45,14 +46,11 @@ $$(t): $$(TARGET_FILE_$$(t)) $$(TARGET_PACKAGE_$$(t))
 
 # Define the compilation goals for the target
 ifeq ($$(TARGET_TYPE_$$(t)), BIN)
-    $(call DEFINE_BIN_RULES, $$(t), $$(TARGET_PATH_$$(t)), \
-        $$(TARGET_FILE_$$(t)), $$(TARGET_PACKAGE_$$(t)))
+    $(call DEFINE_BIN_RULES, $$(TARGET_PATH_$$(t)), $$(TARGET_FILE_$$(t)), $$(TARGET_PACKAGE_$$(t)))
 else ifeq ($$(TARGET_TYPE_$$(t)), LIB)
-    $(call DEFINE_LIB_RULES, $$(t), $$(TARGET_PATH_$$(t)), \
-        $$(TARGET_FILE_$$(t)), $$(TARGET_PACKAGE_$$(t)))
+    $(call DEFINE_LIB_RULES, $$(TARGET_PATH_$$(t)), $$(TARGET_FILE_$$(t)), $$(TARGET_PACKAGE_$$(t)))
 else ifeq ($$(TARGET_TYPE_$$(t)), JAR)
-    $(call DEFINE_JAR_RULES, $$(t), $$(TARGET_PATH_$$(t)), \
-        $$(TARGET_FILE_$$(t)), $$(TARGET_PACKAGE_$$(t)))
+    $(call DEFINE_JAR_RULES, $$(TARGET_PATH_$$(t)), $$(TARGET_FILE_$$(t)), $$(TARGET_PACKAGE_$$(t)))
 endif
 
 endef

--- a/fly/files.mk
+++ b/fly/files.mk
@@ -16,11 +16,10 @@ SRC_DIRS_$(d) := \
     fly/types/string
 
 # Add libfly.so to release package
-$(eval $(call ADD_REL_LIB, libfly))
+$(eval $(call ADD_REL_LIB))
 
 # Add all header files to release package
-$(eval $(call ADD_REL_INC, libfly, $(d), *.hpp, fly))
+$(eval $(call ADD_REL_INC, $(d), *.hpp, fly))
 
-# Add make system files to release package
-$(eval $(call ADD_REL_SRC, libfly, $(BUILD_ROOT), *.mk, fly))
-$(eval $(call ADD_REL_SRC, libfly, $(BUILD_ROOT)/../ci, *.js, fly))
+# Add build system files to release package
+$(eval $(call ADD_REL_SRC, $(BUILD_ROOT), *.mk, fly))


### PR DESCRIPTION
Turns out Make was getting confused with so many places defining this
variable as:

    t := $$(strip $(1))

There's no reason to define it more than once. Define it in target.mk
and treat it as a first-pass variable in all other places.