### PR TITLE
Ensure JAR contains compiled anonymous inner classes

### DIFF
--- a/build/nix/files.mk
+++ b/build/nix/files.mk
@@ -19,48 +19,42 @@ DEP_$(d) := $$(o_$(d):%.o=%.d)
 
 endef
 
-# Define the output files for compiled Java targets.
+# Define the source files for compiled Java targets.
 #
 # $(1) = The Java files to be compiled.
-define JAVA_OUT_FILES
-
-c_$(d) := $$(subst $(SOURCE_ROOT)/$$(TARGET_PATH_$(t))/,,$(1))
-c_$(d) := $$(addsuffix .class, $$(basename $$(c_$(d))))
+define JAVA_SRC_FILES
 
 SOURCES_$(t) += $(1)
-
-# For each Java class file, form the command line argument to include those class files in the
-# target JAR. The format for each class file will be: -C '$(CLASS_DIR)' '$(class file)'
-#
-# Note the file paths are surrounded in single quotes. If a file path contains the $ symbol,
-# this will prevent Make/Bash from evaluating the file name as a variable.
-CONTENTS_$(t) += $$(foreach class, $$(c_$(d)), -C '$(CLASS_DIR)' '$$(class)')
 
 endef
 
 # Define the files and command line arguments for Java compilation and JAR creation.
 #
+# For now, all Java source files are compiled to a subdirectory of $(CLASS_DIR). The entirety of the
+# subdirectory's contents are then added to the JAR. Ideally, the build system could track compiled
+# class files for explicit inclusion. But the Jar must also contain class files of anonymous inner
+# classes. Including everything is a temporary solution until a way to determine those extra class
+# files is implemented.
+#
 # $(1) = The paths to any JARs or packages to reference for compilation.
 # $(2) = The paths to any resources to include in the executable JAR.
 define JAVA_JAR_FILES
+
+CLASS_DIR_$(t) := $(CLASS_DIR)/$(t)
+
+# Form the command line argument to include the target's entire class directory.
+CONTENTS_$(t) += -C $$(CLASS_DIR_$(t)) '.'
 
 ifneq ($(1),)
     # Form the command line argument to include each provided class path.
     CLASS_PATH_$(t) := -cp $(subst $(SPACE),:,$(strip $(1)))
 
-    # For all JAR files specified in the class path, determine the classes stored in the class path
-    # JAR and form the command line argument to include those classes in the target JAR. The format
-    # for each class will be: -C '$(CLASS_DIR)' '$(class file)'
+    # Track each JAR file specified in the class path for extraction.
     CLASS_PATH_JAR_$(t) := $(filter %.jar, $(strip $(1)))
-
-    ifneq ($$(CLASS_PATH_JAR_$(t)),)
-        j_$(t) := $$(foreach jar, $$(CLASS_PATH_JAR_$(t)), $$(shell unzip -Z1 $$(jar) "*.class"))
-        CONTENTS_$(t) += $$(foreach class, $$(j_$(t)), -C '$(CLASS_DIR)' '$$(class)')
-    endif
 endif
 
 # Form the command line argument to include each provided resource path in the target JAR. The
 # format for each resource of the form /path/to/resource will be: -C '/path/to' 'resource'
-CONTENTS_$(t) += $$(foreach res, $(2), -C '$$(dir $$(res))' '$$(notdir $$(res))')
+CONTENTS_$(t) += $$(foreach res, $(2), -C $$(dir $$(res)) $$(notdir $$(res)))
 
 endef

--- a/build/nix/flags.mk
+++ b/build/nix/flags.mk
@@ -54,7 +54,7 @@ ifeq ($(SYSTEM), MACOS)
 endif
 
 # Compiler flags for Java files.
-JFLAGS := -deprecation -d $(CLASS_DIR)
+JFLAGS :=
 
 ifeq ($(arch), x86)
     CF_ALL += -m32
@@ -115,6 +115,10 @@ else ifeq ($(toolchain), gcc)
         endif
     endif
 endif
+
+JFLAGS += \
+    -Werror \
+    -Xlint
 
 # Add debug symbols & use address sanitizer for debug builds, optimize release builds, and add
 # profiling symbols for profile builds.


### PR DESCRIPTION
If a Java class contains an anonymous inner class, then javac will
create multiple class files for that class. This entirely breaks the
build system's current strategy of maintaining a 1-to-1 mapping of Java
files to class files.

I'm not yet sure of a foolproof way to determine the exact class files
that javac will create. Until then, compile a target to a subdirectory
of $(CLASS_DIR), and include that entire subdirectory in the JAR.