### PR TITLE
Overhaul of logging system

### DIFF
--- a/build/win/libfly/libfly.vcxproj
+++ b/build/win/libfly/libfly.vcxproj
@@ -164,10 +164,14 @@
     <ClInclude Include="..\..\..\fly\coders\huffman\huffman_types.hpp" />
     <ClInclude Include="..\..\..\fly\config\config.hpp" />
     <ClInclude Include="..\..\..\fly\config\config_manager.hpp" />
+    <ClInclude Include="..\..\..\fly\logger\detail\console_sink.hpp" />
+    <ClInclude Include="..\..\..\fly\logger\detail\file_sink.hpp" />
     <ClInclude Include="..\..\..\fly\logger\detail\logger_macros.hpp" />
+    <ClInclude Include="..\..\..\fly\logger\detail\registry.hpp" />
     <ClInclude Include="..\..\..\fly\logger\detail\styler_proxy.hpp" />
     <ClInclude Include="..\..\..\fly\logger\detail\win\styler_proxy_impl.hpp" />
     <ClInclude Include="..\..\..\fly\logger\log.hpp" />
+    <ClInclude Include="..\..\..\fly\logger\log_sink.hpp" />
     <ClInclude Include="..\..\..\fly\logger\logger.hpp" />
     <ClInclude Include="..\..\..\fly\logger\logger_config.hpp" />
     <ClInclude Include="..\..\..\fly\logger\styler.hpp" />
@@ -227,6 +231,9 @@
     <ClCompile Include="..\..\..\fly\coders\huffman\huffman_types.cpp" />
     <ClCompile Include="..\..\..\fly\config\config.cpp" />
     <ClCompile Include="..\..\..\fly\config\config_manager.cpp" />
+    <ClCompile Include="..\..\..\fly\logger\detail\console_sink.cpp" />
+    <ClCompile Include="..\..\..\fly\logger\detail\file_sink.cpp" />
+    <ClCompile Include="..\..\..\fly\logger\detail\registry.cpp" />
     <ClCompile Include="..\..\..\fly\logger\detail\styler_proxy.cpp" />
     <ClCompile Include="..\..\..\fly\logger\detail\win\styler_proxy_impl.cpp" />
     <ClCompile Include="..\..\..\fly\logger\log.cpp" />

--- a/build/win/libfly/libfly.vcxproj.filters
+++ b/build/win/libfly/libfly.vcxproj.filters
@@ -118,10 +118,22 @@
     <ClInclude Include="..\..\..\fly\logger\logger_config.hpp">
       <Filter>logger</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\fly\logger\log_sink.hpp">
+      <Filter>logger</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\..\fly\logger\styler.hpp">
       <Filter>logger</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\fly\logger\detail\console_sink.hpp">
+      <Filter>logger\detail</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\fly\logger\detail\file_sink.hpp">
+      <Filter>logger\detail</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\..\fly\logger\detail\logger_macros.hpp">
+      <Filter>logger\detail</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\fly\logger\detail\registry.hpp">
       <Filter>logger\detail</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\fly\logger\detail\styler_proxy.hpp">
@@ -305,6 +317,15 @@
     </ClCompile>
     <ClCompile Include="..\..\..\fly\logger\logger_config.cpp">
       <Filter>logger</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\fly\logger\detail\console_sink.cpp">
+      <Filter>logger\detail</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\fly\logger\detail\file_sink.cpp">
+      <Filter>logger\detail</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\fly\logger\detail\registry.cpp">
+      <Filter>logger\detail</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\fly\logger\detail\styler_proxy.cpp">
       <Filter>logger\detail</Filter>

--- a/build/win/libfly_unit_tests/libfly_unit_tests.vcxproj
+++ b/build/win/libfly_unit_tests/libfly_unit_tests.vcxproj
@@ -202,6 +202,8 @@
     <ClCompile Include="..\..\..\test\coders\huffman_coder.cpp" />
     <ClCompile Include="..\..\..\test\config\config.cpp" />
     <ClCompile Include="..\..\..\test\config\config_manager.cpp" />
+    <ClCompile Include="..\..\..\test\logger\console_logger.cpp" />
+    <ClCompile Include="..\..\..\test\logger\file_logger.cpp" />
     <ClCompile Include="..\..\..\test\logger\logger.cpp" />
     <ClCompile Include="..\..\..\test\logger\styler.cpp" />
     <ClCompile Include="..\..\..\test\parser\ini_parser.cpp" />

--- a/build/win/libfly_unit_tests/libfly_unit_tests.vcxproj.filters
+++ b/build/win/libfly_unit_tests/libfly_unit_tests.vcxproj.filters
@@ -49,6 +49,12 @@
     <ClCompile Include="..\..\..\test\config\config_manager.cpp">
       <Filter>config</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\test\logger\console_logger.cpp">
+      <Filter>logger</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\test\logger\file_logger.cpp">
+      <Filter>logger</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\test\logger\logger.cpp">
       <Filter>logger</Filter>
     </ClCompile>

--- a/fly/logger/detail/console_sink.cpp
+++ b/fly/logger/detail/console_sink.cpp
@@ -1,0 +1,57 @@
+#include "fly/logger/detail/console_sink.hpp"
+
+#include "fly/logger/log.hpp"
+#include "fly/logger/styler.hpp"
+#include "fly/system/system.hpp"
+#include "fly/types/string/string.hpp"
+
+#include <iostream>
+#include <optional>
+#include <string>
+
+namespace fly::detail {
+
+//==================================================================================================
+bool ConsoleSink::initialize()
+{
+    return true;
+}
+
+//==================================================================================================
+bool ConsoleSink::stream(fly::Log &&log)
+{
+    std::ostream *stream = &std::cout;
+    fly::Style style = fly::Style::Default;
+    std::optional<fly::Color> color;
+
+    switch (log.m_level)
+    {
+        case Log::Level::Info:
+            color.emplace(fly::Color::Green);
+            break;
+
+        case Log::Level::Warn:
+            stream = &std::cerr;
+            color.emplace(fly::Color::Yellow);
+            break;
+
+        case Log::Level::Error:
+            stream = &std::cerr;
+            style = fly::Style::Bold;
+            color.emplace(fly::Color::Red);
+            break;
+
+        default:
+            break;
+    }
+
+    {
+        auto styler = color ? fly::Styler(std::move(style), std::move(*color)) : fly::Styler(style);
+        String::format(*stream, "%s%s %s", styler, fly::System::local_time(), log.m_trace);
+    }
+
+    *stream << ": " << log.m_message << std::endl;
+    return true;
+}
+
+} // namespace fly::detail

--- a/fly/logger/detail/console_sink.hpp
+++ b/fly/logger/detail/console_sink.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "fly/logger/log_sink.hpp"
+
+namespace fly {
+struct Log;
+} // namespace fly
+
+namespace fly::detail {
+
+/**
+ * A log sink for streaming log points to the console. Logs are formated with style and color
+ * depending on the log level to be visually distinguishable.
+ *
+ * @author Timothy Flynn (trflynn89@pm.me)
+ * @version October 11, 2020
+ */
+class ConsoleSink : public fly::LogSink
+{
+public:
+    /**
+     * @return True.
+     */
+    bool initialize() override;
+
+    /**
+     * Format and stream the given log point. Informational-level log points are logged to the
+     * standard output stream; error-level log points are logged to the standard error stream.
+     *
+     * @param log The log point to stream.
+     *
+     * @return True.
+     */
+    bool stream(fly::Log &&log) override;
+};
+
+} // namespace fly::detail

--- a/fly/logger/detail/file_sink.cpp
+++ b/fly/logger/detail/file_sink.cpp
@@ -1,0 +1,85 @@
+#include "fly/logger/detail/file_sink.hpp"
+
+#include "fly/coders/coder_config.hpp"
+#include "fly/coders/huffman/huffman_encoder.hpp"
+#include "fly/logger/log.hpp"
+#include "fly/logger/logger_config.hpp"
+#include "fly/system/system.hpp"
+#include "fly/types/string/string.hpp"
+
+#include <string>
+#include <system_error>
+
+namespace fly::detail {
+
+//==================================================================================================
+FileSink::FileSink(
+    const std::shared_ptr<fly::LoggerConfig> &logger_config,
+    const std::shared_ptr<fly::CoderConfig> &coder_config,
+    const std::filesystem::path &logger_directory) :
+    m_logger_config(logger_config),
+    m_coder_config(coder_config),
+    m_log_directory(logger_directory)
+{
+}
+
+//==================================================================================================
+bool FileSink::initialize()
+{
+    return create_log_file();
+}
+
+//==================================================================================================
+bool FileSink::stream(fly::Log &&log)
+{
+    if (m_log_stream.good())
+    {
+        m_log_stream << log << std::flush;
+        std::error_code error;
+
+        if (std::filesystem::file_size(m_log_file, error) > m_logger_config->max_log_file_size())
+        {
+            return create_log_file();
+        }
+
+        return true;
+    }
+
+    return false;
+}
+
+//==================================================================================================
+bool FileSink::create_log_file()
+{
+    if (m_log_stream.is_open())
+    {
+        m_log_stream.close();
+
+        if (m_logger_config->compress_log_files())
+        {
+            std::filesystem::path compressed_log_file = m_log_file;
+            compressed_log_file.replace_extension(".log.enc");
+
+            fly::HuffmanEncoder encoder(m_coder_config);
+
+            if (encoder.encode_file(m_log_file, compressed_log_file))
+            {
+                std::filesystem::remove(m_log_file);
+            }
+        }
+    }
+
+    const std::string random = fly::String::generate_random_string(10);
+    std::string time = fly::System::local_time();
+
+    fly::String::replace_all(time, ":", '-');
+    fly::String::replace_all(time, " ", '_');
+
+    std::string file_name = fly::String::format("Log_%d_%s_%s.log", ++m_log_index, time, random);
+    m_log_file = m_log_directory / std::move(file_name);
+
+    m_log_stream.open(m_log_file, std::ios::out);
+    return m_log_stream.good();
+}
+
+} // namespace fly::detail

--- a/fly/logger/detail/file_sink.hpp
+++ b/fly/logger/detail/file_sink.hpp
@@ -1,0 +1,74 @@
+#pragma once
+
+#include "fly/logger/log_sink.hpp"
+
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+
+namespace fly {
+class CoderConfig;
+class LoggerConfig;
+struct Log;
+} // namespace fly
+
+namespace fly::detail {
+
+/**
+ * A log sink for streaming log points to a file. Log files are size-limted, rotated, and optionally
+ * compressed.
+ *
+ * @author Timothy Flynn (trflynn89@pm.me)
+ * @version October 11, 2020
+ */
+class FileSink : public fly::LogSink
+{
+public:
+    /**
+     * Constructor.
+     *
+     * @param logger_config Reference to the logger configuration.
+     * @param coder_config Reference to the coder configuration.
+     * @param logger_directory Path to store the log files.
+     */
+    FileSink(
+        const std::shared_ptr<fly::LoggerConfig> &logger_config,
+        const std::shared_ptr<fly::CoderConfig> &coder_config,
+        const std::filesystem::path &logger_directory);
+
+    /**
+     * Create the initial log file.
+     *
+     * @return True if the log file could be created.
+     */
+    bool initialize() override;
+
+    /**
+     * Stream the given log point to the currently opened file. If the log file has exceeded its
+     * maximum size after streaming, rotate the log file.
+     *
+     * @param log The log point to stream.
+     *
+     * @return True if the log file is healthy, and if needed, a new log file could be created.
+     */
+    bool stream(fly::Log &&log) override;
+
+private:
+    /**
+     * Create a log file. If a log file is already open, close it.
+     *
+     * @return True if the log file could be created.
+     */
+    bool create_log_file();
+
+    std::shared_ptr<fly::LoggerConfig> m_logger_config;
+    std::shared_ptr<fly::CoderConfig> m_coder_config;
+
+    const std::filesystem::path m_log_directory;
+    std::filesystem::path m_log_file;
+    std::ofstream m_log_stream;
+    std::uint32_t m_log_index {0};
+};
+
+} // namespace fly::detail

--- a/fly/logger/detail/logger_macros.hpp
+++ b/fly/logger/detail/logger_macros.hpp
@@ -1,26 +1,17 @@
 #pragma once
 
 /**
- * Helper macro to add a log, so all of the public logging macros do not have to insert the file,
- * function, and line macros.
- */
-#define _FLY_ADD_LOG(level, message)                                                               \
-    fly::Logger::add_log(level, __FILE__, __FUNCTION__, __LINE__, message)
-
-/**
  * Return the first argument in a list of variadic arguments, expected to be the logging format
  * string.
  *
  * Note that __VA_ARGS__ is wrapped in parentheses. MSVC apparently parses __VA_ARGS__ in a way that
- * is not standards compliant. See:
- *
- *     https://stackoverflow.com/q/5134523
+ * is not standards compliant. See: https://stackoverflow.com/q/5134523
  *
  * The macros used here are still standards compliant, but are unfortunately quite a bit messier
  * than they need to be. The basic trick is to pass (__VA_ARGS__) into a helper macro, which in turn
  * uses that to form a call to a second helper macro that can actually parse __VA_ARGS__.
  */
-#define _FLY_FORMAT_STRING(...) _FLY_FORMAT_STRING_HELPER((__VA_ARGS__, _))
+#define FLY_FORMAT_STRING(...) FLY_FORMAT_STRING_HELPER((__VA_ARGS__, _))
 
 /**
  * Return all but the first argument in a list of variadic arguments, expected to be the arguments
@@ -33,31 +24,31 @@
  *
  * Currently supports up to and including 50 arguments.
  *
- * Note that the same __VA_ARGS__ mess described in _FLY_FORMAT_STRING is used here.
+ * Note that the same __VA_ARGS__ mess described in FLY_FORMAT_STRING is used here.
  */
-#define _FLY_FORMAT_ARGS(...)                                                                      \
-    _FLY_FORMAT_ARGS_HELPER(_FLY_FORMAT_ARGS_LABEL(__VA_ARGS__), (__VA_ARGS__))
+#define FLY_FORMAT_ARGS(...)                                                                       \
+    FLY_FORMAT_ARGS_HELPER(FLY_FORMAT_ARGS_LABEL(__VA_ARGS__), (__VA_ARGS__))
 
 //==================================================================================================
-#define _FLY_FORMAT_STRING_HELPER(args) _FLY_FORMAT_STRING_HELPER2 args
+#define FLY_FORMAT_STRING_HELPER(args) FLY_FORMAT_STRING_HELPER2 args
 
-#define _FLY_FORMAT_STRING_HELPER2(first, ...) first
+#define FLY_FORMAT_STRING_HELPER2(first, ...) first
 
 //==================================================================================================
-#define _FLY_FORMAT_ARGS_HELPER(label, args) _FLY_FORMAT_ARGS_HELPER2(label, args)
+#define FLY_FORMAT_ARGS_HELPER(label, args) FLY_FORMAT_ARGS_HELPER2(label, args)
 
-#define _FLY_FORMAT_ARGS_HELPER2(label, args) _FLY_FORMAT_ARGS_HELPER_##label(args)
+#define FLY_FORMAT_ARGS_HELPER2(label, args) FLY_FORMAT_ARGS_HELPER_##label(args)
 
-#define _FLY_FORMAT_ARGS_HELPER_SINGLE(first)
+#define FLY_FORMAT_ARGS_HELPER_SINGLE(first)
 
-#define _FLY_FORMAT_ARGS_HELPER_MULTIPLE(args) _FLY_FORMAT_ARGS_HELPER_MULTIPLE2 args
+#define FLY_FORMAT_ARGS_HELPER_MULTIPLE(args) FLY_FORMAT_ARGS_HELPER_MULTIPLE2 args
 
-#define _FLY_FORMAT_ARGS_HELPER_MULTIPLE2(first, ...) , __VA_ARGS__
+#define FLY_FORMAT_ARGS_HELPER_MULTIPLE2(first, ...) , __VA_ARGS__
 
-#define _FLY_FORMAT_ARGS_EXPAND(x) x
+#define FLY_FORMAT_ARGS_EXPAND(x) x
 
-#define _FLY_FORMAT_ARGS_LABEL(...)                                                                \
-    _FLY_FORMAT_ARGS_EXPAND(_FLY_FORMAT_ARGS_LABEL_HELPER(                                         \
+#define FLY_FORMAT_ARGS_LABEL(...)                                                                 \
+    FLY_FORMAT_ARGS_EXPAND(FLY_FORMAT_ARGS_LABEL_HELPER(                                           \
         __VA_ARGS__,                                                                               \
         MULTIPLE,                                                                                  \
         MULTIPLE,                                                                                  \
@@ -111,7 +102,7 @@
         SINGLE,                                                                                    \
         _))
 
-#define _FLY_FORMAT_ARGS_LABEL_HELPER(                                                             \
+#define FLY_FORMAT_ARGS_LABEL_HELPER(                                                              \
     ARG_01,                                                                                        \
     ARG_02,                                                                                        \
     ARG_03,                                                                                        \

--- a/fly/logger/detail/registry.cpp
+++ b/fly/logger/detail/registry.cpp
@@ -1,0 +1,42 @@
+#include "fly/logger/detail/registry.hpp"
+
+#include "fly/logger/logger.hpp"
+#include "fly/logger/logger_config.hpp"
+
+namespace fly::detail {
+
+//==================================================================================================
+Registry::Registry() :
+    m_initial_default_logger(
+        fly::Logger::create_console_logger(std::make_shared<fly::LoggerConfig>()))
+{
+    set_default_logger(m_initial_default_logger);
+}
+
+//==================================================================================================
+Registry &Registry::instance()
+{
+    static Registry s_singleton;
+    return s_singleton;
+}
+
+//==================================================================================================
+void Registry::set_default_logger(const std::shared_ptr<Logger> &default_logger)
+{
+    if (default_logger)
+    {
+        m_default_logger = default_logger;
+    }
+    else
+    {
+        m_default_logger = m_initial_default_logger;
+    }
+}
+
+//==================================================================================================
+Logger *Registry::get_default_logger() const
+{
+    return m_default_logger.get();
+}
+
+} // namespace fly::detail

--- a/fly/logger/detail/registry.hpp
+++ b/fly/logger/detail/registry.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <memory>
+
+namespace fly {
+class Logger;
+} // namespace fly
+
+namespace fly::detail {
+
+/**
+ * Singleton class to register and store created loggers. Currently is only used to manage the
+ * default logger, but should be extended to manage all loggers.
+ *
+ * Upon creation, sets the default logger to a synchronous console logger.
+ *
+ * @author Timothy Flynn (trflynn89@pm.me)
+ * @version October 11, 2020
+ */
+class Registry
+{
+public:
+    /**
+     * @return A reference to the singleton registry instance.
+     */
+    static Registry &instance();
+
+    /**
+     * Set the default logger instance for the LOG* macro functions. If the provided logger is null,
+     * the default logger is reset to the initial synchronous console logger.
+     *
+     * @param logger The logger instance.
+     */
+    void set_default_logger(const std::shared_ptr<Logger> &default_logger);
+
+    /**
+     * @return The default logger instance for the LOG* macro functions.
+     */
+    Logger *get_default_logger() const;
+
+private:
+    /**
+     * Constructor. Creates the initial default logger.
+     */
+    Registry();
+
+    std::shared_ptr<Logger> m_initial_default_logger;
+    std::shared_ptr<Logger> m_default_logger;
+};
+
+} // namespace fly::detail

--- a/fly/logger/files.mk
+++ b/fly/logger/files.mk
@@ -1,5 +1,8 @@
 SRC_$(d) := \
+    $(d)/detail/console_sink.cpp \
+    $(d)/detail/file_sink.cpp \
     $(d)/detail/nix/styler_proxy_impl.cpp \
+    $(d)/detail/registry.cpp \
     $(d)/detail/styler_proxy.cpp \
     $(d)/log.cpp \
     $(d)/logger.cpp \

--- a/fly/logger/log.cpp
+++ b/fly/logger/log.cpp
@@ -1,7 +1,5 @@
 #include "fly/logger/log.hpp"
 
-#include "fly/logger/logger_config.hpp"
-
 namespace fly {
 
 namespace {
@@ -12,20 +10,19 @@ namespace {
 } // namespace
 
 //==================================================================================================
-Log::Log(Log &&log) noexcept :
-    m_index(std::move(log.m_index)),
-    m_level(std::move(log.m_level)),
-    m_time(std::move(log.m_time)),
-    m_file(std::move(log.m_file)),
-    m_function(std::move(log.m_function)),
-    m_line(std::move(log.m_line)),
-    m_message(std::move(log.m_message))
+Log::Log(Trace &&trace, std::string &&message, std::uint32_t max_message_size) noexcept :
+    m_trace(std::move(trace)),
+    m_message(std::move(message), 0, max_message_size)
 {
 }
 
 //==================================================================================================
-Log::Log(const std::shared_ptr<LoggerConfig> &config, std::string &&message) noexcept :
-    m_message(std::move(message), 0, config->max_message_size())
+Log::Log(Log &&log) noexcept :
+    m_index(std::move(log.m_index)),
+    m_level(std::move(log.m_level)),
+    m_trace(std::move(log.m_trace)),
+    m_time(std::move(log.m_time)),
+    m_message(std::move(log.m_message))
 {
 }
 
@@ -34,10 +31,8 @@ Log &Log::operator=(Log &&log) noexcept
 {
     m_index = std::move(log.m_index);
     m_level = std::move(log.m_level);
+    m_trace = std::move(log.m_trace);
     m_time = std::move(log.m_time);
-    m_file = std::move(log.m_file);
-    m_function = std::move(log.m_function);
-    m_line = std::move(log.m_line);
     m_message = std::move(log.m_message);
 
     return *this;
@@ -49,9 +44,7 @@ std::ostream &operator<<(std::ostream &stream, const Log &log)
     stream << log.m_index << s_unit_separator;
     stream << log.m_level << s_unit_separator;
     stream << log.m_time << s_unit_separator;
-    stream << log.m_file << s_unit_separator;
-    stream << log.m_function << s_unit_separator;
-    stream << log.m_line << s_unit_separator;
+    stream << log.m_trace << s_unit_separator;
     stream << log.m_message << s_record_separator;
 
     return stream;
@@ -61,6 +54,19 @@ std::ostream &operator<<(std::ostream &stream, const Log &log)
 std::ostream &operator<<(std::ostream &stream, const Log::Level &level)
 {
     stream << static_cast<int>(level);
+    return stream;
+}
+
+//==================================================================================================
+std::ostream &operator<<(std::ostream &stream, const Log::Trace &trace)
+{
+    if ((trace.m_file != nullptr) && (trace.m_function != nullptr))
+    {
+        stream << trace.m_file << ':';
+        stream << trace.m_function << ':';
+        stream << trace.m_line;
+    }
+
     return stream;
 }
 

--- a/fly/logger/log.hpp
+++ b/fly/logger/log.hpp
@@ -7,18 +7,14 @@
 
 namespace fly {
 
-class LoggerConfig;
-
 /**
  * Struct to store data about single log. A log contains:
  *
  * 1. The monotonically increasing index of the log.
  * 2. The log level.
  * 3. The time the log was made.
- * 4. The file name the log is in.
- * 5. The function name the log is in.
- * 6. The line number the log is on.
- * 7. The message being logged.
+ * 4. Trace information about the log point (file name, function name, line number).
+ * 5. The message being logged.
  *
  * @author Timothy Flynn (trflynn89@pm.me)
  * @version July 18, 2016
@@ -39,22 +35,33 @@ struct Log
     };
 
     /**
+     * Structure to store trace information about a log point.
+     */
+    struct Trace
+    {
+        const char *m_file {nullptr};
+        const char *m_function {nullptr};
+        std::uint32_t m_line {0};
+    };
+
+    /**
      * Default constructor.
      */
     Log() = default;
 
     /**
-     * Move constructor.
-     */
-    Log(Log &&log) noexcept;
-
-    /**
      * Constructor. Initialize with a message.
      *
+     * @param trace The trace information for the log point.
      * @param config Reference to the logger config.
      * @param message Message to store.
      */
-    Log(const std::shared_ptr<LoggerConfig> &config, std::string &&message) noexcept;
+    Log(Trace &&trace, std::string &&message, std::uint32_t max_message_size) noexcept;
+
+    /**
+     * Move constructor.
+     */
+    Log(Log &&log) noexcept;
 
     /**
      * Move assignment operator.
@@ -63,15 +70,13 @@ struct Log
 
     std::uintmax_t m_index {0};
     Level m_level {Level::NumLevels};
+    Trace m_trace {};
     double m_time {-1.0};
-    const char *m_file;
-    const char *m_function;
-    std::uint32_t m_line {0};
     std::string m_message;
-
-    friend std::ostream &operator<<(std::ostream &stream, const Log &log);
-
-    friend std::ostream &operator<<(std::ostream &stream, const Level &level);
 };
+
+std::ostream &operator<<(std::ostream &stream, const Log &log);
+std::ostream &operator<<(std::ostream &stream, const Log::Level &level);
+std::ostream &operator<<(std::ostream &stream, const Log::Trace &trace);
 
 } // namespace fly

--- a/fly/logger/log_sink.hpp
+++ b/fly/logger/log_sink.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+namespace fly {
+
+struct Log;
+
+/**
+ * Virtual interface to receive log points and stream them however desired.
+ *
+ * Concrete implementations should not assume thread safety, as the thread on which log points are
+ * received depends on whether the owning logger instance is synchronous or asynchronous.
+ *
+ * @author Timothy Flynn (trflynn89@pm.me)
+ * @version October 11, 2020
+ */
+class LogSink
+{
+public:
+    virtual ~LogSink() = default;
+
+    /**
+     * Initialize the sink. If initialization fails, the logger will not be started and will not
+     * accept any new log points.
+     *
+     * @return True if initialization was successful.
+     */
+    virtual bool initialize() = 0;
+
+    /**
+     * Format and stream the given log point. If streaming fails, the logger will be stopped and
+     * will not accept any new log points.
+     *
+     * @param log The log point to stream.
+     *
+     * @return True if the streaming the log point was successful.
+     */
+    virtual bool stream(Log &&log) = 0;
+};
+
+} // namespace fly

--- a/fly/parser/json_parser.cpp
+++ b/fly/parser/json_parser.cpp
@@ -10,9 +10,9 @@ namespace fly {
 
 #define JLOG(...)                                                                                  \
     LOGW(                                                                                          \
-        "[line %d, column %d]: " _FLY_FORMAT_STRING(__VA_ARGS__),                                  \
+        "[line %d, column %d]: " FLY_FORMAT_STRING(__VA_ARGS__),                                   \
         m_line,                                                                                    \
-        m_column _FLY_FORMAT_ARGS(__VA_ARGS__));
+        m_column FLY_FORMAT_ARGS(__VA_ARGS__));
 
 //==================================================================================================
 JsonParser::JsonParser(const Features features) noexcept : Parser(), m_features(features)

--- a/fly/socket/socket_types.hpp
+++ b/fly/socket/socket_types.hpp
@@ -13,15 +13,15 @@
  * Wrapper logging macros to format logs with socket handles in a consistent manner.
  */
 #define SLOGD(handle, ...)                                                                         \
-    LOGD("[%d] " _FLY_FORMAT_STRING(__VA_ARGS__), handle _FLY_FORMAT_ARGS(__VA_ARGS__))
+    LOGD("[%d] " FLY_FORMAT_STRING(__VA_ARGS__), handle FLY_FORMAT_ARGS(__VA_ARGS__))
 #define SLOGI(handle, ...)                                                                         \
-    LOGI("[%d] " _FLY_FORMAT_STRING(__VA_ARGS__), handle _FLY_FORMAT_ARGS(__VA_ARGS__))
+    LOGI("[%d] " FLY_FORMAT_STRING(__VA_ARGS__), handle FLY_FORMAT_ARGS(__VA_ARGS__))
 #define SLOGW(handle, ...)                                                                         \
-    LOGW("[%d] " _FLY_FORMAT_STRING(__VA_ARGS__), handle _FLY_FORMAT_ARGS(__VA_ARGS__))
+    LOGW("[%d] " FLY_FORMAT_STRING(__VA_ARGS__), handle FLY_FORMAT_ARGS(__VA_ARGS__))
 #define SLOGS(handle, ...)                                                                         \
-    LOGS("[%d] " _FLY_FORMAT_STRING(__VA_ARGS__), handle _FLY_FORMAT_ARGS(__VA_ARGS__))
+    LOGS("[%d] " FLY_FORMAT_STRING(__VA_ARGS__), handle FLY_FORMAT_ARGS(__VA_ARGS__))
 #define SLOGE(handle, ...)                                                                         \
-    LOGE("[%d] " _FLY_FORMAT_STRING(__VA_ARGS__), handle _FLY_FORMAT_ARGS(__VA_ARGS__))
+    LOGE("[%d] " FLY_FORMAT_STRING(__VA_ARGS__), handle FLY_FORMAT_ARGS(__VA_ARGS__))
 
 namespace fly {
 

--- a/test/logger/console_logger.cpp
+++ b/test/logger/console_logger.cpp
@@ -1,0 +1,123 @@
+#include "fly/fly.hpp"
+#include "fly/logger/logger.hpp"
+#include "fly/logger/logger_config.hpp"
+#include "fly/types/string/string.hpp"
+#include "test/util/capture_stream.hpp"
+
+#include <catch2/catch.hpp>
+
+#include <memory>
+
+TEST_CASE("ConsoleLogger", "[logger]")
+{
+    auto logger = fly::Logger::create_console_logger(std::make_shared<fly::LoggerConfig>());
+
+    SECTION("Debug log points")
+    {
+        fly::test::CaptureStream capture(fly::test::CaptureStream::Stream::Stdout);
+        logger->debug("Debug Log");
+
+        const std::string contents = capture();
+        REQUIRE_FALSE(contents.empty());
+
+        CHECK(contents.find("Debug Log") != std::string::npos);
+    }
+
+    SECTION("Informational log points")
+    {
+        fly::test::CaptureStream capture(fly::test::CaptureStream::Stream::Stdout);
+        logger->info("Info Log");
+
+        const std::string contents = capture();
+        REQUIRE_FALSE(contents.empty());
+
+        CHECK(contents.find("Info Log") != std::string::npos);
+    }
+
+    SECTION("Warning log points")
+    {
+        fly::test::CaptureStream capture(fly::test::CaptureStream::Stream::Stderr);
+        logger->warn("Warning Log");
+
+        const std::string contents = capture();
+        REQUIRE_FALSE(contents.empty());
+
+        CHECK(contents.find("Warning Log") != std::string::npos);
+    }
+
+    SECTION("Error log points")
+    {
+        fly::test::CaptureStream capture(fly::test::CaptureStream::Stream::Stderr);
+        logger->error("Error Log");
+
+        const std::string contents = capture();
+        REQUIRE_FALSE(contents.empty());
+
+        CHECK(contents.find("Error Log") != std::string::npos);
+    }
+
+#if defined(FLY_LINUX) || defined(FLY_MACOS)
+    SECTION("Validate style of console logs")
+    {
+        // Get the substring of a log point that should be styled.
+        auto styled_contents = [](const std::string &contents, std::string &&log) {
+            auto pos = contents.find(": " + log);
+            REQUIRE(pos != std::string::npos);
+
+            return contents.substr(0, pos);
+        };
+
+        SECTION("Validate style of debug console logs")
+        {
+            fly::test::CaptureStream capture(fly::test::CaptureStream::Stream::Stdout);
+            logger->debug("Debug Log");
+
+            const std::string contents = capture();
+            REQUIRE_FALSE(contents.empty());
+
+            const std::string styled = styled_contents(contents, "Debug Log");
+            CHECK(fly::String::starts_with(styled, "\x1b[0m"));
+            CHECK(fly::String::ends_with(styled, "\x1b[0m"));
+        }
+
+        SECTION("Validate style of informational console logs")
+        {
+            fly::test::CaptureStream capture(fly::test::CaptureStream::Stream::Stdout);
+            logger->info("Info Log");
+
+            const std::string contents = capture();
+            REQUIRE_FALSE(contents.empty());
+
+            const std::string styled = styled_contents(contents, "Info Log");
+            CHECK(fly::String::starts_with(styled, "\x1b[0;32m"));
+            CHECK(fly::String::ends_with(styled, "\x1b[0m"));
+        }
+
+        SECTION("Validate style of warning console logs")
+        {
+            fly::test::CaptureStream capture(fly::test::CaptureStream::Stream::Stderr);
+            logger->warn("Warning Log");
+
+            const std::string contents = capture();
+            REQUIRE_FALSE(contents.empty());
+
+            const std::string styled = styled_contents(contents, "Warning Log");
+            CHECK(fly::String::starts_with(styled, "\x1b[0;33m"));
+            CHECK(fly::String::ends_with(styled, "\x1b[0m"));
+        }
+
+        SECTION("Validate style of error console logs")
+        {
+            fly::test::CaptureStream capture(fly::test::CaptureStream::Stream::Stderr);
+            logger->error("Error Log");
+
+            const std::string contents = capture();
+            REQUIRE_FALSE(contents.empty());
+
+            const std::string styled = styled_contents(contents, "Error Log");
+            CHECK(fly::String::starts_with(styled, "\x1b[1;31m"));
+            CHECK(fly::String::ends_with(styled, "\x1b[0m"));
+        }
+    }
+#endif
+}

--- a/test/mock/nix/mock_calls.cpp
+++ b/test/mock/nix/mock_calls.cpp
@@ -446,6 +446,20 @@ extern "C"
         return __real_times(buf);
     }
 
+    //==============================================================================================
+    ssize_t __real_write(int fd, const void *buf, size_t count);
+
+    ssize_t __wrap_write(int fd, const void *buf, size_t count)
+    {
+        if (fly::test::MockSystem::mock_enabled(fly::test::MockCall::Write))
+        {
+            errno = 0;
+            return -1;
+        }
+
+        return __real_write(fd, buf, count);
+    }
+
 #ifdef __cplusplus
 }
 #endif

--- a/test/mock/nix/mock_calls.hpp
+++ b/test/mock/nix/mock_calls.hpp
@@ -36,6 +36,7 @@ enum class MockCall : std::uint8_t
     Socket,
     Sysinfo,
     Times,
+    Write,
 };
 
 } // namespace fly::test


### PR DESCRIPTION
Previously, it was only valid to create a single logger, and that logger
could only log to a file. Or, for console logging, not creating a logger
at all would log to the console.

Any number of loggers may now be created, though there is still a notion
of a default logger for the LOG* macros. There are also now log sinks to
receive log points and stream them however they wish. There are built-in
sinks for console and file logging.

Lastly, there is now a logger registry whose job is (will be) to manage
all created loggers. This will allow creating named loggers, and then
retrieving those loggers by name at will. For now, it only manages the
default logger.