### PR TITLE
Logger registry to store weak references to all loggers

### DIFF
--- a/fly/logger/logger.cpp
+++ b/fly/logger/logger.cpp
@@ -4,6 +4,7 @@
 #include "fly/logger/detail/console_sink.hpp"
 #include "fly/logger/detail/file_sink.hpp"
 #include "fly/logger/detail/registry.hpp"
+#include "fly/logger/log.hpp"
 #include "fly/logger/log_sink.hpp"
 #include "fly/logger/logger_config.hpp"
 #include "fly/task/task_runner.hpp"
@@ -12,9 +13,11 @@ namespace fly {
 
 //==================================================================================================
 Logger::Logger(
+    const std::string &name,
     const std::shared_ptr<SequencedTaskRunner> &task_runner,
     const std::shared_ptr<LoggerConfig> &config,
     std::unique_ptr<LogSink> &&sink) noexcept :
+    m_name(name),
     m_config(config),
     m_sink(std::move(sink)),
     m_task_runner(task_runner),
@@ -23,22 +26,31 @@ Logger::Logger(
 }
 
 //==================================================================================================
-std::shared_ptr<Logger> Logger::create_logger(
-    const std::shared_ptr<LoggerConfig> &logger_config,
-    std::unique_ptr<LogSink> &&sink)
+Logger::~Logger()
 {
-    return create_logger(nullptr, logger_config, std::move(sink));
+    detail::Registry::instance().unregister_logger(m_name);
 }
 
 //==================================================================================================
 std::shared_ptr<Logger> Logger::create_logger(
+    const std::string &name,
+    const std::shared_ptr<LoggerConfig> &logger_config,
+    std::unique_ptr<LogSink> &&sink)
+{
+    return create_logger(name, nullptr, logger_config, std::move(sink));
+}
+
+//==================================================================================================
+std::shared_ptr<Logger> Logger::create_logger(
+    const std::string &name,
     const std::shared_ptr<SequencedTaskRunner> &task_runner,
     const std::shared_ptr<LoggerConfig> &logger_config,
     std::unique_ptr<LogSink> &&sink)
 {
-    auto logger = std::shared_ptr<Logger>(new Logger(task_runner, logger_config, std::move(sink)));
+    auto logger =
+        std::shared_ptr<Logger>(new Logger(name, task_runner, logger_config, std::move(sink)));
 
-    if (logger->initialize())
+    if (detail::Registry::instance().register_logger(logger) && logger->initialize())
     {
         return logger;
     }
@@ -48,38 +60,42 @@ std::shared_ptr<Logger> Logger::create_logger(
 
 //==================================================================================================
 std::shared_ptr<Logger> Logger::create_file_logger(
+    const std::string &name,
     const std::shared_ptr<LoggerConfig> &logger_config,
     const std::shared_ptr<CoderConfig> &coder_config,
     const std::filesystem::path &logger_directory)
 {
-    return create_file_logger(nullptr, logger_config, coder_config, logger_directory);
+    return create_file_logger(name, nullptr, logger_config, coder_config, logger_directory);
 }
 
 //==================================================================================================
 std::shared_ptr<Logger> Logger::create_file_logger(
+    const std::string &name,
     const std::shared_ptr<SequencedTaskRunner> &task_runner,
     const std::shared_ptr<LoggerConfig> &logger_config,
     const std::shared_ptr<CoderConfig> &coder_config,
     const std::filesystem::path &logger_directory)
 {
     auto sink = std::make_unique<detail::FileSink>(logger_config, coder_config, logger_directory);
-    return create_logger(task_runner, logger_config, std::move(sink));
-}
-
-//==================================================================================================
-std::shared_ptr<Logger>
-Logger::create_console_logger(const std::shared_ptr<LoggerConfig> &logger_config)
-{
-    return create_console_logger(nullptr, logger_config);
+    return create_logger(name, task_runner, logger_config, std::move(sink));
 }
 
 //==================================================================================================
 std::shared_ptr<Logger> Logger::create_console_logger(
+    const std::string &name,
+    const std::shared_ptr<LoggerConfig> &logger_config)
+{
+    return create_console_logger(name, nullptr, logger_config);
+}
+
+//==================================================================================================
+std::shared_ptr<Logger> Logger::create_console_logger(
+    const std::string &name,
     const std::shared_ptr<SequencedTaskRunner> &task_runner,
     const std::shared_ptr<LoggerConfig> &logger_config)
 {
     auto sink = std::make_unique<detail::ConsoleSink>();
-    return create_logger(task_runner, logger_config, std::move(sink));
+    return create_logger(name, task_runner, logger_config, std::move(sink));
 }
 
 //==================================================================================================
@@ -92,6 +108,18 @@ void Logger::set_default_logger(const std::shared_ptr<Logger> &default_logger)
 Logger *Logger::get_default_logger()
 {
     return detail::Registry::instance().get_default_logger();
+}
+
+//==================================================================================================
+std::shared_ptr<Logger> Logger::get(const std::string &name)
+{
+    return detail::Registry::instance().get_logger(name);
+}
+
+//==================================================================================================
+const std::string &Logger::name() const
+{
+    return m_name;
 }
 
 //==================================================================================================

--- a/test/logger/console_logger.cpp
+++ b/test/logger/console_logger.cpp
@@ -10,7 +10,7 @@
 
 TEST_CASE("ConsoleLogger", "[logger]")
 {
-    auto logger = fly::Logger::create_console_logger(std::make_shared<fly::LoggerConfig>());
+    auto logger = fly::Logger::create_console_logger("test", std::make_shared<fly::LoggerConfig>());
 
     SECTION("Debug log points")
     {

--- a/test/logger/file_logger.cpp
+++ b/test/logger/file_logger.cpp
@@ -104,7 +104,7 @@ TEST_CASE("FileLogger", "[logger]")
     auto coder_config = std::make_shared<MutableCoderConfig>();
     fly::test::PathUtil::ScopedTempDirectory path;
 
-    auto logger = fly::Logger::create_file_logger(logger_config, coder_config, path());
+    auto logger = fly::Logger::create_file_logger("test", logger_config, coder_config, path());
 
     SECTION("Valid logger file paths should be created after creating logger")
     {
@@ -116,7 +116,7 @@ TEST_CASE("FileLogger", "[logger]")
 
     SECTION("Cannot start logger with a bad file path")
     {
-        logger = fly::Logger::create_file_logger(logger_config, coder_config, __FILE__);
+        logger = fly::Logger::create_file_logger("test", logger_config, coder_config, __FILE__);
         CHECK(logger == nullptr);
     }
 


### PR DESCRIPTION
Loggers must now be created by name, and all loggers are now actually
registered with the logger registry. This also allows for retrieving
loggers by name.