### PR TITLE
Support clangd language server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,12 @@ profile/
 *.a
 *.lib
 
+# Language servers
+.cache
+.clangd
+compile_commands.json
+compile_flags.txt
+
 # Gtags files
 GPATH
 GRTAGS


### PR DESCRIPTION
Add $(make commands) to generate a compilation database for clangd.
Add typical clangd output paths to .gitignore.