### PR TITLE
First-class API for posting weak tasks

### DIFF
--- a/fly/config/config_manager.cpp
+++ b/fly/config/config_manager.cpp
@@ -58,14 +58,14 @@ bool ConfigManager::start()
             auto callback = [weak_self](const std::filesystem::path &, PathMonitor::PathEvent) {
                 if (auto self = weak_self.lock(); self)
                 {
-                    auto task = [weak_self]() {
-                        if (auto nested_self = weak_self.lock(); nested_self)
-                        {
-                            nested_self->update_config();
-                        }
+                    auto task = [](std::shared_ptr<ConfigManager> nested_self) {
+                        nested_self->update_config();
                     };
 
-                    self->m_task_runner->post_task(FROM_HERE, std::move(task));
+                    self->m_task_runner->post_task(
+                        FROM_HERE,
+                        std::move(task),
+                        std::move(weak_self));
                 }
             };
 

--- a/fly/path/path_monitor.cpp
+++ b/fly/path/path_monitor.cpp
@@ -185,17 +185,13 @@ bool PathMonitor::poll_paths_later()
         return false;
     }
 
-    std::weak_ptr<PathMonitor> weak_self = shared_from_this();
-
-    auto task = [weak_self]() {
-        if (auto self = weak_self.lock(); self && self->is_valid())
-        {
-            self->poll(self->m_config->poll_interval());
-            self->poll_paths_later();
-        }
+    auto task = [](std::shared_ptr<PathMonitor> self) {
+        self->poll(self->m_config->poll_interval());
+        self->poll_paths_later();
     };
 
-    return m_task_runner->post_task(FROM_HERE, std::move(task));
+    std::weak_ptr<PathMonitor> weak_self = shared_from_this();
+    return m_task_runner->post_task(FROM_HERE, std::move(task), std::move(weak_self));
 }
 
 //==================================================================================================

--- a/fly/socket/socket_manager.cpp
+++ b/fly/socket/socket_manager.cpp
@@ -135,17 +135,13 @@ void SocketManager::trigger_callbacks(
 //==================================================================================================
 void SocketManager::poll_sockets_later()
 {
-    std::weak_ptr<SocketManager> weak_self = shared_from_this();
-
-    auto task = [weak_self]() {
-        if (auto self = weak_self.lock(); self)
-        {
-            self->poll(self->m_config->io_wait_time());
-            self->poll_sockets_later();
-        }
+    auto task = [](std::shared_ptr<SocketManager> self) {
+        self->poll(self->m_config->io_wait_time());
+        self->poll_sockets_later();
     };
 
-    m_task_runner->post_task(FROM_HERE, std::move(task));
+    std::weak_ptr<SocketManager> weak_self = shared_from_this();
+    m_task_runner->post_task(FROM_HERE, std::move(task), std::move(weak_self));
 }
 
 } // namespace fly

--- a/fly/task/task_manager.cpp
+++ b/fly/task/task_manager.cpp
@@ -74,8 +74,11 @@ void TaskManager::post_task(
     Task &&task,
     std::weak_ptr<TaskRunner> weak_task_runner)
 {
-    const auto now = std::chrono::steady_clock::now();
-    TaskHolder wrapped_task {std::move(location), std::move(task), weak_task_runner, now};
+    TaskHolder wrapped_task {
+        std::move(location),
+        std::move(task),
+        std::move(weak_task_runner),
+        std::chrono::steady_clock::now()};
 
     m_tasks.push(std::move(wrapped_task));
 }
@@ -87,8 +90,11 @@ void TaskManager::post_task_with_delay(
     std::weak_ptr<TaskRunner> weak_task_runner,
     std::chrono::milliseconds delay)
 {
-    const auto schedule = std::chrono::steady_clock::now() + delay;
-    TaskHolder wrapped_task {std::move(location), std::move(task), weak_task_runner, schedule};
+    TaskHolder wrapped_task {
+        std::move(location),
+        std::move(task),
+        std::move(weak_task_runner),
+        std::chrono::steady_clock::now() + delay};
 
     std::unique_lock<std::mutex> lock(m_delayed_tasks_mutex);
     m_delayed_tasks.push_back(std::move(wrapped_task));

--- a/fly/task/task_runner.cpp
+++ b/fly/task/task_runner.cpp
@@ -6,7 +6,7 @@ namespace fly {
 
 //==================================================================================================
 TaskRunner::TaskRunner(std::weak_ptr<TaskManager> weak_task_manager) noexcept :
-    m_weak_task_manager(weak_task_manager)
+    m_weak_task_manager(std::move(weak_task_manager))
 {
 }
 
@@ -19,8 +19,8 @@ bool TaskRunner::post_task_to_task_manager(TaskLocation &&location, Task &&task)
         return false;
     }
 
-    std::shared_ptr<TaskRunner> task_runner = shared_from_this();
-    task_manager->post_task(std::move(location), std::move(task), task_runner);
+    std::weak_ptr<TaskRunner> task_runner = shared_from_this();
+    task_manager->post_task(std::move(location), std::move(task), std::move(task_runner));
 
     return true;
 }
@@ -37,15 +37,16 @@ bool TaskRunner::post_task_to_task_manager_with_delay(
         return false;
     }
 
-    std::shared_ptr<TaskRunner> task_runner = shared_from_this();
-    task_manager->post_task_with_delay(std::move(location), std::move(task), task_runner, delay);
+    std::weak_ptr<TaskRunner> task_runner = shared_from_this();
+    task_manager
+        ->post_task_with_delay(std::move(location), std::move(task), std::move(task_runner), delay);
 
     return true;
 }
 
 //==================================================================================================
 ParallelTaskRunner::ParallelTaskRunner(std::weak_ptr<TaskManager> weak_task_manager) noexcept :
-    TaskRunner(weak_task_manager)
+    TaskRunner(std::move(weak_task_manager))
 {
 }
 
@@ -62,7 +63,7 @@ void ParallelTaskRunner::task_complete(TaskLocation &&)
 
 //==================================================================================================
 SequencedTaskRunner::SequencedTaskRunner(std::weak_ptr<TaskManager> weak_task_manager) noexcept :
-    TaskRunner(weak_task_manager)
+    TaskRunner(std::move(weak_task_manager))
 {
 }
 


### PR DESCRIPTION
A common use case of the task runner is to pass a task that wraps a
smart pointer to the owner of the task. The task checks if it should
run by checking if the smart pointer is valid. Provide an API to do
this check automatically.