### PR TITLE
Task runner API for receiving task results

### DIFF
--- a/fly/task/task_manager.cpp
+++ b/fly/task/task_manager.cpp
@@ -111,8 +111,10 @@ void TaskManager::worker_thread()
         {
             if (auto task_runner = task_holder.m_weak_task_runner.lock(); task_runner)
             {
-                std::move(task_holder.m_task)();
-                task_runner->task_complete(std::move(task_holder.m_location));
+                TaskLocation location = std::move(task_holder.m_location);
+                Task task = std::move(task_holder.m_task);
+
+                task_runner->execute(std::move(location), std::move(task));
             }
         }
     }

--- a/fly/task/task_runner.cpp
+++ b/fly/task/task_runner.cpp
@@ -45,6 +45,13 @@ bool TaskRunner::post_task_to_task_manager_with_delay(
 }
 
 //==================================================================================================
+void TaskRunner::execute(TaskLocation &&location, Task &&task)
+{
+    std::move(task)(this, location);
+    task_complete(std::move(location));
+}
+
+//==================================================================================================
 ParallelTaskRunner::ParallelTaskRunner(std::weak_ptr<TaskManager> weak_task_manager) noexcept :
     TaskRunner(std::move(weak_task_manager))
 {

--- a/fly/task/task_types.hpp
+++ b/fly/task/task_types.hpp
@@ -5,10 +5,7 @@
 
 namespace fly {
 
-/**
- * Tasks posted to a task runner are wrapped in a generic lambda to be agnostic to return types.
- */
-using Task = std::function<void()>;
+class TaskRunner;
 
 /**
  * Structure to store basic information about from where a task was posted.
@@ -19,5 +16,10 @@ struct TaskLocation
     const char *m_function {nullptr};
     std::uint32_t m_line {0};
 };
+
+/**
+ * Tasks posted to a task runner are wrapped in a generic lambda to be agnostic to return types.
+ */
+using Task = std::function<void(TaskRunner *, TaskLocation)>;
 
 } // namespace fly


### PR DESCRIPTION
Add methods to receive the result of a task in a reply task. Currently
the reply task is posted on the same task runner on which the original
task was posted. I think it'd be nicer if the reply was posted on the
task runner (if any) on which the caller that posted the task was
currently on.