### PR TITLE
Allow void tasks to indicate completion to a reply task

### DIFF
--- a/fly/path/path_monitor.cpp
+++ b/fly/path/path_monitor.cpp
@@ -81,8 +81,6 @@ bool PathMonitor::remove_path(const std::filesystem::path &path)
 void PathMonitor::remove_all_paths()
 {
     std::lock_guard<std::mutex> lock(m_mutex);
-
-    LOGI("Removed all monitors");
     m_path_info.clear();
 }
 

--- a/fly/task/task_manager.cpp
+++ b/fly/task/task_manager.cpp
@@ -27,7 +27,6 @@ bool TaskManager::start()
 
     if (m_keep_running.compare_exchange_strong(expected, true))
     {
-        LOGI("Starting %d workers", m_num_workers);
         std::shared_ptr<TaskManager> task_manager = shared_from_this();
 
         for (std::uint32_t i = 0; i < m_num_workers; ++i)
@@ -52,8 +51,6 @@ bool TaskManager::stop()
 
     if (m_keep_running.compare_exchange_strong(expected, false))
     {
-        LOGI("Stopping %d workers", m_num_workers);
-
         for (auto &future : m_futures)
         {
             if (future.valid())


### PR DESCRIPTION
Previously, to use the post_task_with_reply methods, the task had to
return a non-void result, and the reply had to accept that result. Now
the tasks may be void, but the reply task must be invocable without
arguments.