### PR TITLE
Extend fly::Parser to support std::u8string

### DIFF
--- a/fly/parser/parser.hpp
+++ b/fly/parser/parser.hpp
@@ -35,8 +35,9 @@ public:
      *
      *     1. std::string - UTF-8
      *     2. std::wstring - UTF-16 on Windows, UTF-32 on Linux
-     *     3. std::u16string - UTF-16
-     *     4. std::u32string - UTF-32
+     *     3. std::u8string - UTF-8
+     *     4. std::u16string - UTF-16
+     *     5. std::u32string - UTF-32
      *
      * Further, all string types will be checked for the presence of a byte order mark. If a BOM is
      * not present, the parser will assume UTF-8 encoding. If a BOM is present, the following BOM
@@ -147,7 +148,7 @@ private:
 template <typename StringType>
 std::optional<Json> Parser::parse_string(const StringType &contents)
 {
-    if constexpr (sizeof(typename StringType::value_type) == 1)
+    if constexpr (std::is_same_v<StringType, std::string>)
     {
         std::istringstream stream(contents);
         return parse_stream(stream);

--- a/test/parser/json_parser.cpp
+++ b/test/parser/json_parser.cpp
@@ -180,7 +180,7 @@ CATCH_TEST_CASE("JsonParser", "[parser]")
         CATCH_CHECK(values.size() == 1112064);
     }
 
-    CATCH_SECTION("String with UTF-8 encoding is parsed as-is")
+    CATCH_SECTION("String with UTF-8 encoding (std::string)")
     {
         const std::string contents("{\"encoding\": \"UTF-8\"}");
 
@@ -194,7 +194,21 @@ CATCH_TEST_CASE("JsonParser", "[parser]")
         CATCH_CHECK(encoded_encoding == "UTF-8");
     }
 
-    CATCH_SECTION("File with UTF-8 byte order mark is parsed as-is")
+    CATCH_SECTION("String with UTF-8 encoding (std::u8string)")
+    {
+        const std::u8string contents(u8"{\"encoding\": \"UTF-8\"}");
+
+        auto parsed = parser.parse_string(contents);
+        CATCH_REQUIRE(parsed.has_value());
+
+        fly::Json values = std::move(parsed.value());
+        CATCH_REQUIRE(values.size() == 1);
+
+        fly::Json encoded_encoding = values["encoding"];
+        CATCH_CHECK(encoded_encoding == "UTF-8");
+    }
+
+    CATCH_SECTION("File with UTF-8 byte order mark")
     {
         const auto here = std::filesystem::path(__FILE__);
         const auto path = here.parent_path() / "json" / "unicode";
@@ -209,7 +223,7 @@ CATCH_TEST_CASE("JsonParser", "[parser]")
         CATCH_CHECK(encoded_encoding == "UTF-8");
     }
 
-    CATCH_SECTION("String with UTF-16 encoding is converted to UTF-8")
+    CATCH_SECTION("String with UTF-16 encoding")
     {
         const std::u16string contents(u"{\"encoding\": \"UTF-16\"}");
 
@@ -226,7 +240,7 @@ CATCH_TEST_CASE("JsonParser", "[parser]")
         CATCH_CHECK_FALSE(parsed.has_value());
     }
 
-    CATCH_SECTION("File with UTF-16 big endian byte order mark is converted to UTF-8")
+    CATCH_SECTION("File with UTF-16 big endian byte order mark")
     {
         const auto here = std::filesystem::path(__FILE__);
         const auto path = here.parent_path() / "json" / "unicode";
@@ -244,7 +258,7 @@ CATCH_TEST_CASE("JsonParser", "[parser]")
         CATCH_CHECK_FALSE(parsed.has_value());
     }
 
-    CATCH_SECTION("File with UTF-16 little endian byte order mark is converted to UTF-8")
+    CATCH_SECTION("File with UTF-16 little endian byte order mark")
     {
         const auto here = std::filesystem::path(__FILE__);
         const auto path = here.parent_path() / "json" / "unicode";
@@ -262,7 +276,7 @@ CATCH_TEST_CASE("JsonParser", "[parser]")
         CATCH_CHECK_FALSE(parsed.has_value());
     }
 
-    CATCH_SECTION("String with UTF-32 encoding is converted to UTF-8")
+    CATCH_SECTION("String with UTF-32 encoding")
     {
         const std::u32string contents(U"{\"encoding\": \"UTF-32\"}");
 
@@ -279,7 +293,7 @@ CATCH_TEST_CASE("JsonParser", "[parser]")
         CATCH_CHECK_FALSE(parsed.has_value());
     }
 
-    CATCH_SECTION("File with UTF-32 big endian byte order mark is converted to UTF-8")
+    CATCH_SECTION("File with UTF-32 big endian byte order mark")
     {
         const auto here = std::filesystem::path(__FILE__);
         const auto path = here.parent_path() / "json" / "unicode";
@@ -297,7 +311,7 @@ CATCH_TEST_CASE("JsonParser", "[parser]")
         CATCH_CHECK_FALSE(parsed.has_value());
     }
 
-    CATCH_SECTION("File with UTF-32 little endian byte order mark is converted to UTF-8")
+    CATCH_SECTION("File with UTF-32 little endian byte order mark")
     {
         const auto here = std::filesystem::path(__FILE__);
         const auto path = here.parent_path() / "json" / "unicode";


### PR DESCRIPTION
Parsing std::u8string isn't particularly efficient. The parsing interface
is centered around std::istream. So any std::u8string is first converted
to std::string, even though both are assumed to have UTF-8 encoding.

Perhaps in C++20, only std::u8string should be assumed to have UTF-8
encoding. Of course, any std::basic_string type can be made to hold any
binary data, even invalid Unicode. And STL support outside of
std::(w)string is awful.