### PR TITLE
Only parse BOM from file streams

### DIFF
--- a/fly/fly.hpp
+++ b/fly/fly.hpp
@@ -8,7 +8,7 @@
 #elif defined(_WIN32)
 #    define FLY_WINDOWS
 #else
-#    error Unsupported operating system. Only Windows and Linux are supported.
+#    error Unsupported operating system. Only Linux, macOS, and Windows are supported.
 #endif
 
 // Define macro to convert a macro parameter to a string.

--- a/fly/logger/styler.hpp
+++ b/fly/logger/styler.hpp
@@ -38,9 +38,11 @@ struct Color
     /**
      * Constants for standard colors.
      *
-     * On Linux, a color may be any value in the range [0, 255]. While only the 8 standard colors
-     * are listed here, any 8-bit integer value may be cast to a color. The color values correspond
-     * to the ANSI 256-color lookup table: https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit.
+     * On Linux and macOS, a color may be any value in the range [0, 255]. While only the 8 standard
+     * colors are listed here, any 8-bit integer value may be cast to a color. The color values
+     * correspond to the ANSI 256-color lookup table:
+     *
+     *     https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit.
      *
      * On Windows, the color may only be one of the 8 standard colors listed here.
      */

--- a/fly/parser/parser.hpp
+++ b/fly/parser/parser.hpp
@@ -34,20 +34,10 @@ public:
      * The encoding of the string is inferred from the templated string type:
      *
      *     1. std::string - UTF-8
-     *     2. std::wstring - UTF-16 on Windows, UTF-32 on Linux
+     *     2. std::wstring - UTF-16 on Windows, UTF-32 on Linux and macOS
      *     3. std::u8string - UTF-8
      *     4. std::u16string - UTF-16
      *     5. std::u32string - UTF-32
-     *
-     * Further, all string types will be checked for the presence of a byte order mark. If a BOM is
-     * not present, the parser will assume UTF-8 encoding. If a BOM is present, the following BOM
-     * representations are supported:
-     *
-     *     1. UTF-8 (0xef 0xbb 0xbf)
-     *     2. UTF-16 big endian (0xfe 0xff)
-     *     3. UTF-16 little endian (0xff 0xfe)
-     *     4. UTF-32 big endian (0x00 0x00 0xfe 0xff)
-     *     5. UTF-32 little endian (0xff 0xfe 0x00 0x00)
      *
      * Any string which is not encoded with UTF-8 will first be converted to a UTF-8 encoded string
      * before being passed to concrete parsers.

--- a/fly/types/string/detail/string_unicode.hpp
+++ b/fly/types/string/detail/string_unicode.hpp
@@ -12,11 +12,11 @@
 namespace fly::detail {
 
 /**
- * Helper class for decoding and encoding Unicode codepoints in a std::basic_string. The exact
- * encoding depends on the template type StringType:
+ * Helper class for decoding and encoding Unicode codepoints in a std::basic_string. The assumed
+ * Unicode encoding depends on the template type StringType:
  *
  *     1. std::string - UTF-8
- *     2. std::wstring - UTF-16 on Windows, UTF-32 on Linux
+ *     2. std::wstring - UTF-16 on Windows, UTF-32 on Linux and macOS
  *     3. std::u8string - UTF-8
  *     4. std::u16string - UTF-16
  *     5. std::u32string - UTF-32

--- a/test/types/string_formatter.cpp
+++ b/test/types/string_formatter.cpp
@@ -126,7 +126,7 @@ CATCH_TEMPLATE_TEST_CASE(
         format = FLY_STR(char_type, "%a");
         CATCH_CHECK(FLY_STR(streamed_char, "%a") == BasicString::format(format));
 #if defined(FLY_WINDOWS)
-        // Windows 0-pads std::hexfloat to match the stream precision, Linux does not.
+        // Windows 0-pads std::hexfloat to match the stream precision, Linux and macOS do not.
         CATCH_CHECK(FLY_STR(streamed_char, "0x1.600000p+2") == BasicString::format(format, 5.5));
 #else
         CATCH_CHECK(FLY_STR(streamed_char, "0x1.6p+2") == BasicString::format(format, 5.5));
@@ -135,7 +135,7 @@ CATCH_TEMPLATE_TEST_CASE(
         format = FLY_STR(char_type, "%A");
         CATCH_CHECK(FLY_STR(streamed_char, "%A") == BasicString::format(format));
 #if defined(FLY_WINDOWS)
-        // Windows 0-pads std::hexfloat to match the stream precision, Linux does not.
+        // Windows 0-pads std::hexfloat to match the stream precision, Linux and macOS do not.
         CATCH_CHECK(FLY_STR(streamed_char, "0X1.600000P+2") == BasicString::format(format, 5.5));
 #else
         CATCH_CHECK(FLY_STR(streamed_char, "0X1.6P+2") == BasicString::format(format, 5.5));


### PR DESCRIPTION
Don't parse from strings. We explicitly assume encoding based on string
types.