### PR TITLE
Allow parsing char8_t streams without converting to char

### DIFF
--- a/build/win/libfly/libfly.vcxproj
+++ b/build/win/libfly/libfly.vcxproj
@@ -182,6 +182,7 @@
     <ClInclude Include="..\..\..\fly\parser\ini_parser.hpp" />
     <ClInclude Include="..\..\..\fly\parser\json_parser.hpp" />
     <ClInclude Include="..\..\..\fly\parser\parser.hpp" />
+    <ClInclude Include="..\..\..\fly\parser\utf8_stream.hpp" />
     <ClInclude Include="..\..\..\fly\path\path_config.hpp" />
     <ClInclude Include="..\..\..\fly\path\path_monitor.hpp" />
     <ClInclude Include="..\..\..\fly\path\win\path_monitor_impl.hpp" />
@@ -248,6 +249,7 @@
     <ClCompile Include="..\..\..\fly\parser\ini_parser.cpp" />
     <ClCompile Include="..\..\..\fly\parser\json_parser.cpp" />
     <ClCompile Include="..\..\..\fly\parser\parser.cpp" />
+    <ClCompile Include="..\..\..\fly\parser\utf8_stream.cpp" />
     <ClCompile Include="..\..\..\fly\path\path_config.cpp" />
     <ClCompile Include="..\..\..\fly\path\path_monitor.cpp" />
     <ClCompile Include="..\..\..\fly\path\win\path_monitor_impl.cpp" />

--- a/build/win/libfly/libfly.vcxproj.filters
+++ b/build/win/libfly/libfly.vcxproj.filters
@@ -151,6 +151,9 @@
     <ClInclude Include="..\..\..\fly\parser\parser.hpp">
       <Filter>parser</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\fly\parser\utf8_stream.hpp">
+      <Filter>parser</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\..\fly\path\path_config.hpp">
       <Filter>path</Filter>
     </ClInclude>
@@ -343,6 +346,9 @@
       <Filter>parser</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\fly\parser\parser.cpp">
+      <Filter>parser</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\fly\parser\utf8_stream.cpp">
       <Filter>parser</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\fly\path\path_config.cpp">

--- a/build/win/libfly_unit_tests/libfly_unit_tests.vcxproj
+++ b/build/win/libfly_unit_tests/libfly_unit_tests.vcxproj
@@ -213,6 +213,7 @@
     <ClCompile Include="..\..\..\test\parser\ini_parser.cpp" />
     <ClCompile Include="..\..\..\test\parser\json_parser.cpp" />
     <ClCompile Include="..\..\..\test\parser\parser.cpp" />
+    <ClCompile Include="..\..\..\test\parser\utf8_stream.cpp" />
     <ClCompile Include="..\..\..\test\path\path_monitor.cpp" />
     <ClCompile Include="..\..\..\test\socket\socket.cpp" />
     <ClCompile Include="..\..\..\test\system\system.cpp" />

--- a/build/win/libfly_unit_tests/libfly_unit_tests.vcxproj.filters
+++ b/build/win/libfly_unit_tests/libfly_unit_tests.vcxproj.filters
@@ -70,6 +70,9 @@
     <ClCompile Include="..\..\..\test\parser\parser.cpp">
       <Filter>parser</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\test\parser\utf8_stream.cpp">
+      <Filter>parser</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\test\path\path_monitor.cpp">
       <Filter>path</Filter>
     </ClCompile>

--- a/fly/fly.hpp
+++ b/fly/fly.hpp
@@ -32,3 +32,49 @@
 
 // Mark an expression or value as unused.
 #define FLY_UNUSED(expr) (void)(expr)
+
+namespace fly {
+
+/**
+ * Compile-time helper function to determine if the operating system is Linux.
+ *
+ * @return True if the operating system is Linux.
+ */
+inline constexpr bool is_linux()
+{
+#if defined(FLY_LINUX)
+    return true;
+#else
+    return false;
+#endif
+}
+
+/**
+ * Compile-time helper function to determine if the operating system is macOS.
+ *
+ * @return True if the operating system is macOS.
+ */
+inline constexpr bool is_macos()
+{
+#if defined(FLY_MACOS)
+    return true;
+#else
+    return false;
+#endif
+}
+
+/**
+ * Compile-time helper function to determine if the operating system is Windows.
+ *
+ * @return True if the operating system is Windows.
+ */
+inline constexpr bool is_windows()
+{
+#if defined(FLY_WINDOWS)
+    return true;
+#else
+    return false;
+#endif
+}
+
+} // namespace fly

--- a/fly/parser/ini_parser.cpp
+++ b/fly/parser/ini_parser.cpp
@@ -8,12 +8,12 @@
 namespace fly {
 
 //==================================================================================================
-std::optional<Json> IniParser::parse_internal(std::istream &stream)
+std::optional<Json> IniParser::parse_internal()
 {
     std::string line, section;
     Json values;
 
-    while (stream && std::getline(stream, line))
+    while (m_stream->getline(line))
     {
         String::trim(line);
         ++m_line;

--- a/fly/parser/ini_parser.hpp
+++ b/fly/parser/ini_parser.hpp
@@ -21,11 +21,9 @@ protected:
     /**
      * Parse a stream and retrieve the parsed values.
      *
-     * @param stream Stream holding the contents to parse.
-     *
      * @return If successful, the parsed values. Otherwise, an unitialized value.
      */
-    std::optional<Json> parse_internal(std::istream &stream) override;
+    std::optional<Json> parse_internal() override;
 
 private:
     /**

--- a/fly/parser/json_parser.hpp
+++ b/fly/parser/json_parser.hpp
@@ -57,13 +57,11 @@ public:
 
 protected:
     /**
-     * Parse a single complete JSON value from a stream.
-     *
-     * @param stream Stream holding the contents to parse.
+     * Parse a single complete JSON value from the stream.
      *
      * @return If successful, the parsed JSON value. Otherwise, an unitialized value.
      */
-    std::optional<Json> parse_internal(std::istream &stream) override;
+    std::optional<Json> parse_internal() override;
 
 private:
     /**
@@ -125,136 +123,104 @@ private:
     using ParseStateGetter = std::function<ParseState()>;
 
     /**
-     * Parse a complete JSON value from a stream. May be called recursively for nested values.
-     *
-     * @param stream Stream holding the contents to parse.
+     * Parse a complete JSON value from the stream. May be called recursively for nested values.
      *
      * @return If successful, the parsed JSON value. Otherwise, an unitialized value.
      */
-    std::optional<Json> parse_json(std::istream &stream);
+    std::optional<Json> parse_json();
 
     /**
-     * Parse a JSON object from a stream.
-     *
-     * @param stream Stream holding the contents to parse.
+     * Parse a JSON object from the stream.
      *
      * @return If successful, the parsed JSON object. Otherwise, an unitialized value.
      */
-    std::optional<Json> parse_object(std::istream &stream);
+    std::optional<Json> parse_object();
 
     /**
-     * Parse a JSON array from a stream.
-     *
-     * @param stream Stream holding the contents to parse.
+     * Parse a JSON array from the stream.
      *
      * @return If successful, the parsed JSON array. Otherwise, an unitialized value.
      */
-    std::optional<Json> parse_array(std::istream &stream);
+    std::optional<Json> parse_array();
 
     /**
      * Determine whether parsing a JSON object or array is complete.
      *
-     * @param stream Stream holding the contents to parse.
      * @param token Token indicating the end of the JSON object (}) or array (]).
      *
      * @return The new parsing state.
      */
-    ParseState done_parsing_object_or_array(std::istream &stream, const Token &end_token);
+    ParseState done_parsing_object_or_array(const Token &end_token);
 
     /**
-     * Parse a JSON string, number, boolean, or null value from a stream.
-     *
-     * @param stream Stream holding the contents to parse.
+     * Parse a JSON string, number, boolean, or null value from the stream.
      *
      * @return If successful, the parsed JSON value. Otherwise, an unitialized value.
      */
-    std::optional<Json> parse_value(std::istream &stream);
+    std::optional<Json> parse_value();
 
     /**
-     * Extract a single symbol from a stream. Ensure that symbol is equal to an expected token.
-     *
-     * @param stream Stream holding the contents to parse.
+     * Extract a single symbol from the stream. Ensure that symbol is equal to an expected token.
      *
      * @return The new parsing state.
      */
-    ParseState consume_token(std::istream &stream, const Token &token);
+    ParseState consume_token(const Token &token);
 
     /**
-     * Extract a comma from a stream. Handles any trailing commas, allowing a single trailing comma
-     * if enabled in the feature set.
+     * Extract a comma from the stream. Handles any trailing commas, allowing a single trailing
+     * comma if enabled in the feature set.
      *
-     * @param stream Stream holding the contents to parse.
      * @param parse_state Callback to indicate whether the calling parser should stop parsing.
      *
      * @return The new parsing state.
      */
-    ParseState consume_comma(std::istream &stream, const ParseStateGetter &parse_state);
+    ParseState consume_comma(const ParseStateGetter &parse_state);
 
     /**
-     * Extract a string, number, boolean, or null value from a stream. If parsing a string, escaped
-     * symbols are preserved in that string, and the returned value does not contain its surrounding
-     * quotes.
+     * Extract a string, number, boolean, or null value from the stream. If parsing a string,
+     * escaped symbols are preserved in that string, and the returned value does not contain its
+     * surrounding quotes.
      *
-     * @param stream Stream holding the contents to parse.
      * @param type The JSON value type to consume.
      * @param value The location to store the parsed value.
      *
      * @return The JSON value type that was parsed. Will be either the type that was provided or
      *         JsonType::Invalid if an error occurred.
      */
-    JsonType consume_value(std::istream &stream, JsonType type, JsonTraits::string_type &value);
+    JsonType consume_value(JsonType type, JsonTraits::string_type &value);
 
     /**
      * Extract all consecutive whitespace symbols and comments (if enabled in the feature set) from
-     * a stream. The first non-whitespace, non-comment symbol is left on the stream.
-     *
-     * @param stream Stream holding the contents to parse.
+     * the stream. The first non-whitespace, non-comment symbol is left on the stream.
      *
      * @return The new parsing state.
      */
-    ParseState consume_whitespace_and_comments(std::istream &stream);
+    ParseState consume_whitespace_and_comments();
 
     /**
-     * Extract all consecutive whitespace symbols from a stream until a non- whitespace symbol is
+     * Extract all consecutive whitespace symbols from the stream until a non- whitespace symbol is
      * encountered. The non-whitespace symbol is left on the stream.
-     *
-     * @param stream Stream holding the contents to parse.
      */
-    void consume_whitespace(std::istream &stream);
+    void consume_whitespace();
 
     /**
-     * Extract a single- or multi-line comment from a stream, if enabled in the feature set.
-     *
-     * @param stream Stream holding the contents to parse.
+     * Extract a single- or multi-line comment from the stream, if enabled in the feature set.
      *
      * @return The new parsing state.
      */
-    ParseState consume_comment(std::istream &stream);
+    ParseState consume_comment();
 
     /**
-     * Read the next symbol in a stream without extracting it.
-     *
-     * @param stream Stream holding the contents to parse.
-     *
-     * @return The peeked symbol.
-     */
-    Token peek(std::istream &stream);
-
-    /**
-     * Extract the next symbol in a stream.
-     *
-     * @param stream Stream holding the contents to parse.
+     * Extract the next symbol in the stream.
      *
      * @return The extracted symbol.
      */
-    Token consume(std::istream &stream);
+    Token consume();
 
     /**
-     * Extract and discard the next symbol in a stream.
-     *
-     * @param stream Stream holding the contents to parse.
+     * Extract and discard the next symbol in the stream.
      */
-    void discard(std::istream &stream);
+    void discard();
 
     /**
      * Validate that a parsed number is valid and interpret its numeric JSON type.

--- a/fly/parser/parser.cpp
+++ b/fly/parser/parser.cpp
@@ -2,7 +2,6 @@
 
 #include <cstring>
 #include <fstream>
-#include <sstream>
 
 namespace fly {
 
@@ -61,7 +60,7 @@ std::optional<Json> Parser::parse_file(const std::filesystem::path &path)
     switch (encoding)
     {
         case Encoding::UTF8:
-            return parse_stream(stream);
+            return parse_stream(std::move(stream));
 
         case Encoding::UTF16BigEndian:
             utf8_contents = ensure_utf8<std::u16string, std::endian::big>(stream);
@@ -82,20 +81,10 @@ std::optional<Json> Parser::parse_file(const std::filesystem::path &path)
 
     if (utf8_contents)
     {
-        std::istringstream utf8_stream(std::move(utf8_contents.value()));
-        return parse_stream(utf8_stream);
+        return parse_string(utf8_contents.value());
     }
 
     return std::nullopt;
-}
-
-//==================================================================================================
-std::optional<Json> Parser::parse_stream(std::istream &stream)
-{
-    m_line = 1;
-    m_column = 0;
-
-    return parse_internal(stream);
 }
 
 //==================================================================================================

--- a/fly/parser/utf8_stream.cpp
+++ b/fly/parser/utf8_stream.cpp
@@ -1,0 +1,81 @@
+#include "fly/parser/utf8_stream.hpp"
+
+namespace fly {
+
+//==================================================================================================
+UTF8CharStream::UTF8CharStream(std::basic_istream<char> &stream) : UTF8Stream(), m_stream(stream)
+{
+}
+
+//==================================================================================================
+bool UTF8CharStream::good()
+{
+    return m_stream.good();
+}
+
+//==================================================================================================
+bool UTF8CharStream::eof()
+{
+    return m_stream.eof();
+}
+
+//==================================================================================================
+int UTF8CharStream::peek_internal()
+{
+    return static_cast<int>(m_stream.peek());
+}
+
+//==================================================================================================
+int UTF8CharStream::get_internal()
+{
+    return static_cast<int>(m_stream.get());
+}
+
+//==================================================================================================
+bool UTF8CharStream::is_eof(int ch)
+{
+    return static_cast<std::char_traits<char>::int_type>(ch) == std::char_traits<char>::eof();
+}
+
+#if !defined(FLY_MACOS)
+
+//==================================================================================================
+UTF8Char8Stream::UTF8Char8Stream(std::basic_istream<char8_t> &stream) :
+    UTF8Stream(),
+    m_stream(stream)
+{
+}
+
+//==================================================================================================
+bool UTF8Char8Stream::good()
+{
+    return m_stream.good();
+}
+
+//==================================================================================================
+bool UTF8Char8Stream::eof()
+{
+    return m_stream.eof();
+}
+
+//==================================================================================================
+int UTF8Char8Stream::peek_internal()
+{
+    return static_cast<int>(m_stream.peek());
+}
+
+//==================================================================================================
+int UTF8Char8Stream::get_internal()
+{
+    return static_cast<int>(m_stream.get());
+}
+
+//==================================================================================================
+bool UTF8Char8Stream::is_eof(int ch)
+{
+    return static_cast<std::char_traits<char8_t>::int_type>(ch) == std::char_traits<char8_t>::eof();
+}
+
+#endif // FLY_MACOS
+
+} // namespace fly

--- a/fly/parser/utf8_stream.hpp
+++ b/fly/parser/utf8_stream.hpp
@@ -1,0 +1,228 @@
+#pragma once
+
+#include "fly/fly.hpp"
+#include "fly/traits/traits.hpp"
+
+#include <istream>
+#include <memory>
+#include <string>
+#include <type_traits>
+
+namespace fly {
+
+/**
+ * A wrapper around std::basic_istream to hide the templated stream character type. This mostly
+ * exists so that concrete parsers do not need to be templated based on that character type.
+ *
+ * @author Timothy Flynn (trflynn89@pm.me)
+ * @version October 29, 2020
+ */
+class UTF8Stream
+{
+public:
+    /**
+     * Determine if a character type is supported by the UTF8Stream class.
+     *
+     * @tparam CharType The character type to check.
+     *
+     * @return True if the character type is supported.
+     */
+    template <typename CharType>
+    inline static constexpr bool supports_utf8_stream()
+    {
+        if constexpr (is_macos())
+        {
+            // Apple Clang does not yet have standard library support for char8_t:
+            // https://en.cppreference.com/w/cpp/compiler_support
+            return std::is_same_v<CharType, char>;
+        }
+        else
+        {
+            return any_same_v<CharType, char, char8_t>;
+        }
+    }
+
+    /**
+     * Create a UTF8Stream wrapped around an existing std::basic_istream. It is expected that the
+     * existing stream outlive this wrapper instance.
+     *
+     * @tparam CharType The character type for the std::basic_istream. Must be char or char8_t.
+     *
+     * @param stream The underlying stream to wrap.
+     *
+     * @return The wrapper UTF8Stream instance.
+     */
+    template <typename CharType>
+    static std::unique_ptr<UTF8Stream> create(std::basic_istream<CharType> &stream);
+
+    /**
+     * Destructor.
+     */
+    virtual ~UTF8Stream() = default;
+
+    /**
+     * Read the next character from the stream without extracting it.
+     *
+     * @tparam IntType The type to cast the character to.
+     *
+     * @return The peeked character.
+     */
+    template <typename IntType = int>
+    IntType peek();
+
+    /**
+     * Read the next character from the stream by extracting it.
+     *
+     * @tparam IntType The type to cast the character to.
+     *
+     * @return The read character.
+     */
+    template <typename IntType = int>
+    IntType get();
+
+    /**
+     * Read characters from the stream until a newline or end-of-file is reached.
+     *
+     * @tparam CharType The character type of the resulting string.
+     *
+     * @param stream The string to insert extracted characters ito.
+     *
+     * @return True if any characters were read.
+     */
+    template <typename CharType>
+    bool getline(std::basic_string<CharType> &result);
+
+    /**
+     * @return True if the stream is healthy.
+     */
+    virtual bool good() = 0;
+
+    /**
+     * @return True if the stream has reached end-of-file.
+     */
+    virtual bool eof() = 0;
+
+protected:
+    /**
+     * Protected constructor.
+     */
+    UTF8Stream() = default;
+
+    /**
+     * Read the next character from the stream without extracting it.
+     *
+     * @return The peeked character.
+     */
+    virtual int peek_internal() = 0;
+
+    /**
+     * Read the next character from the stream by extracting it.
+     *
+     * @return The read character.
+     */
+    virtual int get_internal() = 0;
+
+    /**
+     * Check if a character represents end-of-file for the stream.
+     *
+     * @param ch The character to check.
+     *
+     * @return True if the character represents end-of-file.
+     */
+    virtual bool is_eof(int ch) = 0;
+};
+
+/**
+ * UTF8Stream implementation for character type "char".
+ *
+ * @author Timothy Flynn (trflynn89@pm.me)
+ * @version October 29, 2020
+ */
+class UTF8CharStream : public UTF8Stream
+{
+public:
+    explicit UTF8CharStream(std::basic_istream<char> &stream);
+
+    bool good() override;
+    bool eof() override;
+
+protected:
+    int peek_internal() override;
+    int get_internal() override;
+    bool is_eof(int ch) override;
+
+private:
+    std::basic_istream<char> &m_stream;
+};
+
+/**
+ * UTF8Stream implementation for character type "char8_t".
+ *
+ * @author Timothy Flynn (trflynn89@pm.me)
+ * @version October 29, 2020
+ */
+class UTF8Char8Stream : public UTF8Stream
+{
+public:
+    explicit UTF8Char8Stream(std::basic_istream<char8_t> &stream);
+
+    bool good() override;
+    bool eof() override;
+
+protected:
+    int peek_internal() override;
+    int get_internal() override;
+    bool is_eof(int ch) override;
+
+private:
+    std::basic_istream<char8_t> &m_stream;
+};
+
+//==================================================================================================
+template <typename CharType>
+std::unique_ptr<UTF8Stream> UTF8Stream::create(std::basic_istream<CharType> &stream)
+{
+    static_assert(supports_utf8_stream<CharType>());
+
+    if constexpr (std::is_same_v<CharType, char>)
+    {
+        return std::make_unique<UTF8CharStream>(stream);
+    }
+    else if constexpr (std::is_same_v<CharType, char8_t>)
+    {
+        return std::make_unique<UTF8Char8Stream>(stream);
+    }
+}
+
+//==================================================================================================
+template <typename TokenType>
+TokenType UTF8Stream::peek()
+{
+    return static_cast<TokenType>(peek_internal());
+}
+
+//==================================================================================================
+template <typename TokenType>
+TokenType UTF8Stream::get()
+{
+    return static_cast<TokenType>(get_internal());
+}
+
+//==================================================================================================
+template <typename CharType>
+bool UTF8Stream::getline(std::basic_string<CharType> &result)
+{
+    static constexpr const int s_new_line = 0x0a;
+
+    result.clear();
+    int ch;
+
+    while (good() && ((ch = get_internal()) != s_new_line) && !is_eof(ch))
+    {
+        result += ch;
+    }
+
+    return good() || !result.empty();
+}
+
+} // namespace fly

--- a/test/files.mk
+++ b/test/files.mk
@@ -34,6 +34,7 @@ SRC_DIRS_$(d) += \
     test/types
 
 SRC_$(d) := \
+    $(d)/fly.cpp \
     $(d)/main.cpp
 
 # All unit tests should have Catch2 on the include path.

--- a/test/fly.cpp
+++ b/test/fly.cpp
@@ -1,0 +1,55 @@
+#include "fly/fly.hpp"
+
+#include <catch2/catch.hpp>
+
+#include <string>
+
+CATCH_TEST_CASE("Fly", "[fly]")
+{
+    CATCH_SECTION("Stringize helper")
+    {
+        const std::string s1 = FLY_STRINGIZE();
+        CATCH_CHECK(s1.empty());
+
+        const std::string s2 = FLY_STRINGIZE(libfly);
+        CATCH_CHECK(s2 == "libfly");
+    }
+
+    CATCH_SECTION("Operating system-dependent headers")
+    {
+        static_assert(fly::is_linux() || fly::is_macos() || fly::is_windows());
+        const std::string header = FLY_OS_IMPL_PATH(libfly, fly);
+
+        if constexpr (fly::is_linux())
+        {
+            CATCH_CHECK(header == "fly/libfly/nix/fly_impl.hpp");
+        }
+        else if constexpr (fly::is_macos())
+        {
+            CATCH_CHECK(header == "fly/libfly/mac/fly_impl.hpp");
+        }
+        else if constexpr (fly::is_windows())
+        {
+            CATCH_CHECK(header == "fly/libfly/win/fly_impl.hpp");
+        }
+    }
+
+    CATCH_SECTION("Operating system helpers")
+    {
+#if defined(__linux__)
+        CATCH_CHECK(fly::is_linux());
+        CATCH_CHECK_FALSE(fly::is_macos());
+        CATCH_CHECK_FALSE(fly::is_windows());
+#elif defined(__APPLE__)
+        CATCH_CHECK_FALSE(fly::is_linux());
+        CATCH_CHECK(fly::is_macos());
+        CATCH_CHECK_FALSE(fly::is_windows());
+#elif defined(_WIN32)
+        CATCH_CHECK_FALSE(fly::is_linux());
+        CATCH_CHECK_FALSE(fly::is_macos());
+        CATCH_CHECK(fly::is_windows());
+#else
+        static_assert(false, "Unknown operating system");
+#endif
+    }
+}

--- a/test/parser/parser.cpp
+++ b/test/parser/parser.cpp
@@ -25,12 +25,12 @@ protected:
     /**
      * Dummy parser to fail if the given stream contains any characters.
      */
-    std::optional<fly::Json> parse_internal(std::istream &stream) override
+    std::optional<fly::Json> parse_internal() override
     {
         m_chars.clear();
         int c = 0;
 
-        while ((c = stream.get()) != EOF)
+        while ((c = m_stream->get()) != EOF)
         {
             m_chars.push_back(c);
         }

--- a/test/parser/utf8_stream.cpp
+++ b/test/parser/utf8_stream.cpp
@@ -1,0 +1,155 @@
+#include "fly/parser/utf8_stream.hpp"
+
+#include "fly/fly.hpp"
+#include "fly/types/string/string.hpp"
+#include "fly/types/string/string_literal.hpp"
+
+#include <catch2/catch.hpp>
+
+#include <sstream>
+#include <vector>
+
+CATCH_TEST_CASE("UTF8StreamSupport", "[parser]")
+{
+    CATCH_CHECK(fly::UTF8Stream::supports_utf8_stream<char>());
+    CATCH_CHECK_FALSE(fly::UTF8Stream::supports_utf8_stream<wchar_t>());
+
+    if constexpr (fly::is_macos())
+    {
+        CATCH_CHECK_FALSE(fly::UTF8Stream::supports_utf8_stream<char8_t>());
+    }
+    else
+    {
+        CATCH_CHECK(fly::UTF8Stream::supports_utf8_stream<char8_t>());
+    }
+
+    CATCH_CHECK_FALSE(fly::UTF8Stream::supports_utf8_stream<char16_t>());
+    CATCH_CHECK_FALSE(fly::UTF8Stream::supports_utf8_stream<char32_t>());
+}
+
+CATCH_TEMPLATE_TEST_CASE("UTF8Stream", "[parser]", char, char8_t)
+{
+    using char_type = TestType;
+
+    if constexpr (fly::UTF8Stream::supports_utf8_stream<char_type>())
+    {
+        using string_type = std::basic_string<char_type>;
+        using int_type = typename std::char_traits<char_type>::int_type;
+        constexpr const int_type eof = std::char_traits<char_type>::eof();
+
+        std::basic_stringstream<char_type> stream;
+
+        auto utf8_stream = fly::UTF8Stream::create(stream);
+        CATCH_REQUIRE(utf8_stream);
+
+        CATCH_SECTION("Operations on an empty stream")
+        {
+            CATCH_CHECK(utf8_stream->template peek<int_type>() == eof);
+            CATCH_CHECK(utf8_stream->template get<int_type>() == eof);
+
+            string_type value;
+            CATCH_CHECK_FALSE(utf8_stream->getline(value));
+            CATCH_CHECK(value.empty());
+        }
+
+        CATCH_SECTION("Operations on a single-line stream")
+        {
+            static string_type s_test = FLY_STR(char_type, "test");
+            stream << s_test;
+
+            CATCH_SECTION("Peek and get")
+            {
+                for (std::size_t i = 0; i < s_test.size(); ++i)
+                {
+                    CATCH_CHECK(utf8_stream->template peek<char_type>() == s_test[i]);
+                    CATCH_CHECK(utf8_stream->template get<char_type>() == s_test[i]);
+                }
+
+                CATCH_CHECK(utf8_stream->template peek<int_type>() == eof);
+                CATCH_CHECK(utf8_stream->template get<int_type>() == eof);
+            }
+
+            CATCH_SECTION("Get line")
+            {
+                string_type value;
+                CATCH_CHECK(utf8_stream->getline(value));
+                CATCH_CHECK(value == s_test);
+
+                CATCH_CHECK_FALSE(utf8_stream->getline(value));
+                CATCH_CHECK(value.empty());
+            }
+        }
+
+        CATCH_SECTION("Operations on a multi-line stream")
+        {
+            static string_type s_test = FLY_STR(char_type, "test\nmultiple\nlines");
+            stream << s_test;
+
+            CATCH_SECTION("Peek and get")
+            {
+                for (std::size_t i = 0; i < s_test.size(); ++i)
+                {
+                    CATCH_CHECK(utf8_stream->template peek<char_type>() == s_test[i]);
+                    CATCH_CHECK(utf8_stream->template get<char_type>() == s_test[i]);
+                }
+
+                CATCH_CHECK(utf8_stream->template peek<int_type>() == eof);
+                CATCH_CHECK(utf8_stream->template get<int_type>() == eof);
+            }
+
+            CATCH_SECTION("Get line")
+            {
+                auto lines = fly::BasicString<string_type>::split(s_test, FLY_CHR(char_type, '\n'));
+                string_type value;
+
+                for (const auto &line : lines)
+                {
+                    CATCH_CHECK(utf8_stream->getline(value));
+                    CATCH_CHECK(value == line);
+                }
+
+                CATCH_CHECK_FALSE(utf8_stream->getline(value));
+                CATCH_CHECK(value.empty());
+            }
+        }
+
+        CATCH_SECTION("Operations on a multi-line stream with beginning newline")
+        {
+            static string_type s_test = FLY_STR(char_type, "\ntest\nmultiple\nlines");
+            stream << s_test;
+
+            auto lines = fly::BasicString<string_type>::split(s_test, FLY_CHR(char_type, '\n'));
+            string_type value;
+
+            CATCH_CHECK(utf8_stream->getline(value));
+            CATCH_CHECK(value.empty());
+
+            for (const auto &line : lines)
+            {
+                CATCH_CHECK(utf8_stream->getline(value));
+                CATCH_CHECK(value == line);
+            }
+
+            CATCH_CHECK_FALSE(utf8_stream->getline(value));
+            CATCH_CHECK(value.empty());
+        }
+
+        CATCH_SECTION("Operations on a multi-line stream with ending newline")
+        {
+            static string_type s_test = FLY_STR(char_type, "test\nmultiple\nlines\n");
+            stream << s_test;
+
+            auto lines = fly::BasicString<string_type>::split(s_test, FLY_CHR(char_type, '\n'));
+            string_type value;
+
+            for (const auto &line : lines)
+            {
+                CATCH_CHECK(utf8_stream->getline(value));
+                CATCH_CHECK(value == line);
+            }
+
+            CATCH_CHECK_FALSE(utf8_stream->getline(value));
+            CATCH_CHECK(value.empty());
+        }
+    }
+}


### PR DESCRIPTION
Previously, to parse a std::u8string, the parser would first convert to
std::string through BasicStringUnicode. To prevent the wasted effort of
converting a UTF-8 string to another UTF-8 string, create a wrapper
around std::basic_istream to support both char and char8_t.

This is really only needed because virtual methods and member variables
cannot be templated. So neither parse_internal() nor m_stream can be
templated on character type.