### PR TITLE
Allow  more JSON operations with any string-like type

### DIFF
--- a/build/win/libfly_unit_tests/libfly_unit_tests.vcxproj
+++ b/build/win/libfly_unit_tests/libfly_unit_tests.vcxproj
@@ -242,6 +242,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\test\config\test_config.hpp" />
+    <ClInclude Include="..\..\..\test\types\json_macros.hpp" />
     <ClInclude Include="..\..\..\test\util\capture_stream.hpp" />
     <ClInclude Include="..\..\..\test\util\path_util.hpp" />
     <ClInclude Include="..\..\..\test\util\task_manager.hpp" />

--- a/build/win/libfly_unit_tests/libfly_unit_tests.vcxproj.filters
+++ b/build/win/libfly_unit_tests/libfly_unit_tests.vcxproj.filters
@@ -153,6 +153,9 @@
     <ClInclude Include="..\..\..\test\config\test_config.hpp">
       <Filter>config</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\test\types\json_macros.hpp">
+      <Filter>types</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\..\test\util\capture_stream.hpp">
       <Filter>util</Filter>
     </ClInclude>

--- a/fly/parser/json_parser.hpp
+++ b/fly/parser/json_parser.hpp
@@ -67,9 +67,9 @@ private:
     /**
      * ASCII codes for special JSON tokens.
      */
-    enum class Token : std::int16_t
+    enum class Token : std::char_traits<JsonTraits::char_type>::int_type
     {
-        EndOfFile = std::char_traits<JsonTraits::string_type::value_type>::eof(),
+        EndOfFile = std::char_traits<JsonTraits::char_type>::eof(),
 
         Tab = 0x09, // \t
         NewLine = 0x0a, // \n

--- a/fly/types/json/json.cpp
+++ b/fly/types/json/json.cpp
@@ -363,20 +363,6 @@ Json::const_iterator Json::cend() const
 }
 
 //==================================================================================================
-void Json::swap(JsonTraits::string_type &other)
-{
-    if (is_string())
-    {
-        auto &value = std::get<JsonTraits::string_type>(m_value);
-        std::swap(value, other);
-    }
-    else
-    {
-        throw JsonException(*this, "JSON type invalid for swap(string)");
-    }
-}
-
-//==================================================================================================
 bool operator==(Json::const_reference json1, Json::const_reference json2)
 {
     auto visitor = [](const auto &value1, const auto &value2) -> bool

--- a/fly/types/json/json.cpp
+++ b/fly/types/json/json.cpp
@@ -482,7 +482,7 @@ std::ostream &operator<<(std::ostream &stream, Json::const_reference json)
 //==================================================================================================
 JsonTraits::string_type Json::validate_string(const JsonTraits::string_type &str)
 {
-    stream_type stream;
+    stringstream_type stream;
 
     const auto end = str.cend();
 
@@ -503,7 +503,7 @@ JsonTraits::string_type Json::validate_string(const JsonTraits::string_type &str
 
 //==================================================================================================
 void Json::read_escaped_character(
-    stream_type &stream,
+    stringstream_type &stream,
     JsonTraits::string_type::const_iterator &it,
     const JsonTraits::string_type::const_iterator &end)
 {
@@ -542,7 +542,7 @@ void Json::read_escaped_character(
 
         case 'u':
             // The input sequence is expected to begin with the reverse solidus character.
-            if (auto value = String::unescape_codepoint(--it, end); value)
+            if (auto value = JsonTraits::StringType::unescape_codepoint(--it, end); value)
             {
                 stream << std::move(value.value());
             }
@@ -555,7 +555,8 @@ void Json::read_escaped_character(
             return;
 
         default:
-            throw JsonException(String::format("Invalid escape character '%c'", *it));
+            throw JsonException(
+                String::format("Invalid escape character '%c'", static_cast<char>(*it)));
     }
 
     ++it;
@@ -598,7 +599,7 @@ void Json::write_escaped_charater(
             break;
 
         default:
-            stream << String::escape_codepoint<'u'>(it, end).value();
+            stream << JsonTraits::StringType::escape_codepoint<'u'>(it, end).value();
             return;
     }
 
@@ -607,14 +608,15 @@ void Json::write_escaped_charater(
 
 //==================================================================================================
 void Json::validate_character(
-    stream_type &stream,
+    stringstream_type &stream,
     const JsonTraits::string_type::const_iterator &it)
 {
     const std::uint8_t ch = static_cast<std::uint8_t>(*it);
 
     if ((ch <= 0x1f) || (ch == 0x22) || (ch == 0x5c))
     {
-        throw JsonException(String::format("Character '%c' must be escaped", *it));
+        throw JsonException(
+            String::format("Character '%c' must be escaped", static_cast<char>(*it)));
     }
 
     stream << *it;

--- a/fly/types/json/json.cpp
+++ b/fly/types/json/json.cpp
@@ -175,32 +175,6 @@ Json::operator JsonTraits::null_type() const noexcept(false)
 }
 
 //==================================================================================================
-Json::reference Json::operator[](const typename JsonTraits::object_type::key_type &key)
-{
-    if (is_null())
-    {
-        m_value = JsonTraits::object_type();
-    }
-
-    if (is_object())
-    {
-        const Json json(key);
-        auto &value = std::get<JsonTraits::object_type>(m_value);
-
-        return value[JsonTraits::object_type::key_type(json)];
-    }
-
-    throw JsonException(*this, "JSON type invalid for operator[key]");
-}
-
-//==================================================================================================
-Json::const_reference Json::operator[](const typename JsonTraits::object_type::key_type &key) const
-
-{
-    return at(key);
-}
-
-//==================================================================================================
 Json::reference Json::operator[](size_type index)
 {
     if (is_null())
@@ -227,49 +201,6 @@ Json::reference Json::operator[](size_type index)
 Json::const_reference Json::operator[](size_type index) const
 {
     return at(index);
-}
-
-//==================================================================================================
-Json::reference Json::at(const typename JsonTraits::object_type::key_type &key)
-{
-    if (is_object())
-    {
-        const Json json(key);
-        auto &value = std::get<JsonTraits::object_type>(m_value);
-
-        auto it = value.find(JsonTraits::object_type::key_type(json));
-
-        if (it == value.end())
-        {
-            throw JsonException(*this, String::format("Given key (%s) not found", key));
-        }
-
-        return it->second;
-    }
-
-    throw JsonException(*this, "JSON type invalid for operator[key]");
-}
-
-//==================================================================================================
-Json::const_reference Json::at(const typename JsonTraits::object_type::key_type &key) const
-
-{
-    if (is_object())
-    {
-        const Json json(key);
-        const auto &value = std::get<JsonTraits::object_type>(m_value);
-
-        const auto it = value.find(JsonTraits::object_type::key_type(json));
-
-        if (it == value.end())
-        {
-            throw JsonException(*this, String::format("Given key (%s) not found", key));
-        }
-
-        return it->second;
-    }
-
-    throw JsonException(*this, "JSON type invalid for operator[key]");
 }
 
 //==================================================================================================

--- a/fly/types/json/json.hpp
+++ b/fly/types/json/json.hpp
@@ -113,7 +113,7 @@ public:
      *
      * @throws JsonException If the string-like value is not valid.
      */
-    template <typename T, enable_if_all<JsonTraits::is_string<T>> = 0>
+    template <typename T, enable_if_all<JsonTraits::is_string_like<T>> = 0>
     Json(const T &value) noexcept(false);
 
     /**
@@ -301,7 +301,7 @@ public:
      *
      * @return The Json instance as a string.
      */
-    template <typename T, enable_if_all<detail::is_supported_string<T>> = 0>
+    template <typename T, enable_if_all<JsonTraits::is_string<T>> = 0>
     explicit operator T() const noexcept;
 
     /**
@@ -404,7 +404,7 @@ public:
      * @throws JsonException If the Json instance is neither an object nor null, or the key value is
      *         invalid.
      */
-    template <typename T, enable_if_all<JsonTraits::is_string<T>> = 0>
+    template <typename T, enable_if_all<JsonTraits::is_string_like<T>> = 0>
     reference operator[](const T &key);
 
     /**
@@ -421,7 +421,7 @@ public:
      * @throws JsonException If the Json instance is not an object, or the key value does not exist,
      *         or the key value is invalid.
      */
-    template <typename T, enable_if_all<JsonTraits::is_string<T>> = 0>
+    template <typename T, enable_if_all<JsonTraits::is_string_like<T>> = 0>
     const_reference operator[](const T &key) const;
 
     /**
@@ -469,7 +469,7 @@ public:
      * @throws JsonException If the Json instance is not an object, or the key value does not exist,
      *         or the key value is invalid.
      */
-    template <typename T, enable_if_all<JsonTraits::is_string<T>> = 0>
+    template <typename T, enable_if_all<JsonTraits::is_string_like<T>> = 0>
     reference at(const T &key);
 
     /**
@@ -488,7 +488,7 @@ public:
      * @throws JsonException If the Json instance is not an object, or the key value does not exist,
      *         or the key value is invalid.
      */
-    template <typename T, enable_if_all<JsonTraits::is_string<T>> = 0>
+    template <typename T, enable_if_all<JsonTraits::is_string_like<T>> = 0>
     const_reference at(const T &key) const;
 
     /**
@@ -575,7 +575,7 @@ public:
      *
      * @throws JsonException If the Json instance is not a string.
      */
-    template <typename T, enable_if_all<detail::is_supported_string<T>> = 0>
+    template <typename T, enable_if_all<JsonTraits::is_string<T>> = 0>
     void swap(T &other);
 
     /**
@@ -707,7 +707,7 @@ private:
      *
      * @throws JsonException If the string-like value is not valid.
      */
-    template <typename T, enable_if_all<JsonTraits::is_string<T>> = 0>
+    template <typename T, enable_if_all<JsonTraits::is_string_like<T>> = 0>
     static JsonTraits::string_type convert_to_string(const T &value);
 
     /**
@@ -767,7 +767,7 @@ private:
 };
 
 //==================================================================================================
-template <typename T, enable_if_all<JsonTraits::is_string<T>>>
+template <typename T, enable_if_all<JsonTraits::is_string_like<T>>>
 Json::Json(const T &value) noexcept(false) : m_value(convert_to_string(value))
 {
 }
@@ -822,7 +822,7 @@ Json::Json(const T &value) noexcept : m_value(static_cast<JsonTraits::float_type
 }
 
 //==================================================================================================
-template <typename T, enable_if_all<detail::is_supported_string<T>>>
+template <typename T, enable_if_all<JsonTraits::is_string<T>>>
 Json::operator T() const noexcept
 {
     JsonTraits::string_type value;
@@ -975,7 +975,7 @@ Json::operator T() const noexcept(false)
 }
 
 //==================================================================================================
-template <typename T, enable_if_all<JsonTraits::is_string<T>>>
+template <typename T, enable_if_all<JsonTraits::is_string_like<T>>>
 Json::reference Json::operator[](const T &key)
 {
     if (is_null())
@@ -993,14 +993,14 @@ Json::reference Json::operator[](const T &key)
 }
 
 //==================================================================================================
-template <typename T, enable_if_all<JsonTraits::is_string<T>>>
+template <typename T, enable_if_all<JsonTraits::is_string_like<T>>>
 Json::const_reference Json::operator[](const T &key) const
 {
     return at(key);
 }
 
 //==================================================================================================
-template <typename T, enable_if_all<JsonTraits::is_string<T>>>
+template <typename T, enable_if_all<JsonTraits::is_string_like<T>>>
 Json::reference Json::at(const T &key)
 {
     if (is_object())
@@ -1020,7 +1020,7 @@ Json::reference Json::at(const T &key)
 }
 
 //==================================================================================================
-template <typename T, enable_if_all<JsonTraits::is_string<T>>>
+template <typename T, enable_if_all<JsonTraits::is_string_like<T>>>
 Json::const_reference Json::at(const T &key) const
 {
     if (is_object())
@@ -1040,7 +1040,7 @@ Json::const_reference Json::at(const T &key) const
 }
 
 //==================================================================================================
-template <typename T, enable_if_all<detail::is_supported_string<T>>>
+template <typename T, enable_if_all<JsonTraits::is_string<T>>>
 void Json::swap(T &other)
 {
     if (is_string())
@@ -1091,10 +1091,10 @@ void Json::swap(T &other)
 }
 
 //==================================================================================================
-template <typename T, enable_if_all<JsonTraits::is_string<T>>>
+template <typename T, enable_if_all<JsonTraits::is_string_like<T>>>
 JsonTraits::string_type Json::convert_to_string(const T &value)
 {
-    using StringType = BasicString<JsonTraits::is_string_t<T>>;
+    using StringType = BasicString<JsonTraits::is_string_like_t<T>>;
 
     if (auto converted = StringType::template convert<JsonTraits::string_type>(value); converted)
     {

--- a/fly/types/json/json.hpp
+++ b/fly/types/json/json.hpp
@@ -569,15 +569,20 @@ public:
      * Exchange the contents of the Json instance with another string. Only valid if the Json
      * instance is a string.
      *
+     * @tparam T The string type to swap with.
+     *
      * @param json The string to swap with.
      *
      * @throws JsonException If the Json instance is not a string.
      */
-    void swap(JsonTraits::string_type &other);
+    template <typename T, enable_if_all<detail::is_supported_string<T>> = 0>
+    void swap(T &other);
 
     /**
      * Exchange the contents of the Json instance with another object. Only valid if the Json
      * instance is an object.
+     *
+     * @tparam T The object type to swap with.
      *
      * @param json The object to swap with.
      *
@@ -589,6 +594,8 @@ public:
     /**
      * Exchange the contents of the Json instance with another array. Only valid if the Json
      * instance is an array.
+     *
+     * @tparam T The array type to swap with.
      *
      * @param json The array to swap with.
      *
@@ -1030,6 +1037,23 @@ Json::const_reference Json::at(const T &key) const
     }
 
     throw JsonException(*this, "JSON type invalid for operator[key]");
+}
+
+//==================================================================================================
+template <typename T, enable_if_all<detail::is_supported_string<T>>>
+void Json::swap(T &other)
+{
+    if (is_string())
+    {
+        T string = static_cast<T>(*this);
+
+        *this = std::move(other);
+        other = std::move(string);
+    }
+    else
+    {
+        throw JsonException(*this, "JSON type invalid for swap(string)");
+    }
 }
 
 //==================================================================================================

--- a/fly/types/json/json_traits.hpp
+++ b/fly/types/json/json_traits.hpp
@@ -43,6 +43,17 @@ struct JsonTraits
     using array_type = std::vector<Json>;
 
     /**
+     * Alias for the fly::BasicString specialization for the JSON string type.
+     */
+    using StringType = BasicString<string_type>;
+
+    /**
+     * Alias for the JSON string character type. Though it is not a valid JSON type itself, knowing
+     * its type is often useful.
+     */
+    using char_type = typename string_type::value_type;
+
+    /**
      * Define a trait for testing if type T could be a JSON string.
      */
     template <typename T>

--- a/fly/types/json/json_traits.hpp
+++ b/fly/types/json/json_traits.hpp
@@ -43,16 +43,25 @@ struct JsonTraits
     using array_type = std::vector<Json>;
 
     /**
-     * Define a trait for testing if type T is a JSON string.
+     * Define a trait for testing if type T could be a JSON string.
      */
     template <typename T>
-    using is_string = detail::is_like_supported_string<T>;
-
-    template <typename T>
-    using is_string_t = typename is_string<T>::type;
+    using is_string = detail::is_supported_string<T>;
 
     template <typename T>
     inline static constexpr bool is_string_v = is_string<T>::value;
+
+    /**
+     * Define a trait for testing if type T is like a JSON string.
+     */
+    template <typename T>
+    using is_string_like = detail::is_like_supported_string<T>;
+
+    template <typename T>
+    using is_string_like_t = typename is_string_like<T>::type;
+
+    template <typename T>
+    inline static constexpr bool is_string_like_v = is_string_like<T>::value;
 
     /**
      * Define a trait for testing if type T is a JSON boolean.
@@ -114,7 +123,7 @@ struct JsonTraits
     struct ObjectTraits
     {
         template <typename Key>
-        using is_string_key = std::bool_constant<is_string_v<Key>>;
+        using is_string_key = std::bool_constant<is_string_like_v<Key>>;
 
         template <typename>
         struct IsObject : std::false_type

--- a/fly/types/string/string_literal.hpp
+++ b/fly/types/string/string_literal.hpp
@@ -3,8 +3,8 @@
 #include <filesystem>
 
 /**
- * Helper macros to choose the correct string literal to use for either a given type or the char
- * type used on the compiling system.
+ * Helper macros to choose the correct string literal prefix to use for either a given type or the
+ * character type used on the compiling system.
  *
  * @author Timothy Flynn (trflynn89@pm.me)
  * @version March 23, 2019

--- a/test/types/json.cpp
+++ b/test/types/json.cpp
@@ -54,155 +54,6 @@ CATCH_TEST_CASE("Json", "[json]")
         CATCH_CHECK(json == null);
     }
 
-    CATCH_SECTION("Access a JSON object's values via the access operator")
-    {
-        fly::Json string1 = "abc";
-        CATCH_CHECK_THROWS_JSON(string1["a"], "JSON type invalid for operator[key]: (%s)", string1);
-
-        const fly::Json string2 = "abc";
-        CATCH_CHECK_THROWS_JSON(string2["a"], "JSON type invalid for operator[key]: (%s)", string2);
-
-        fly::Json object1 = {{"a", 1}, {"b", 2}};
-        CATCH_CHECK(object1["a"] == 1);
-        CATCH_CHECK(object1["b"] == 2);
-        CATCH_CHECK_NOTHROW(object1["c"]);
-        CATCH_CHECK(object1["c"] == nullptr);
-
-        const fly::Json object2 = {{"a", 1}, {"b", 2}};
-        CATCH_CHECK(object2["a"] == 1);
-        CATCH_CHECK(object2["b"] == 2);
-        CATCH_CHECK_THROWS_JSON(object2["c"], "Given key (c) not found: (%s)", object2);
-
-        fly::Json array1 = {'7', 8};
-        CATCH_CHECK_THROWS_JSON(array1["a"], "JSON type invalid for operator[key]: (%s)", array1);
-
-        const fly::Json array2 = {'7', 8};
-        CATCH_CHECK_THROWS_JSON(array2["a"], "JSON type invalid for operator[key]: (%s)", array2);
-
-        fly::Json bool1 = true;
-        CATCH_CHECK_THROWS_JSON(bool1["a"], "JSON type invalid for operator[key]: (%s)", bool1);
-
-        const fly::Json bool2 = true;
-        CATCH_CHECK_THROWS_JSON(bool2["a"], "JSON type invalid for operator[key]: (%s)", bool2);
-
-        fly::Json signed1 = 1;
-        CATCH_CHECK_THROWS_JSON(signed1["a"], "JSON type invalid for operator[key]: (%s)", signed1);
-
-        const fly::Json signed2 = 1;
-        CATCH_CHECK_THROWS_JSON(signed2["a"], "JSON type invalid for operator[key]: (%s)", signed2);
-
-        fly::Json unsigned1 = static_cast<unsigned int>(1);
-        CATCH_CHECK_THROWS_JSON(
-            unsigned1["a"],
-            "JSON type invalid for operator[key]: (%s)",
-            unsigned1);
-
-        const fly::Json unsigned2 = static_cast<unsigned int>(1);
-        CATCH_CHECK_THROWS_JSON(
-            unsigned2["a"],
-            "JSON type invalid for operator[key]: (%s)",
-            unsigned2);
-
-        fly::Json float1 = 1.0f;
-        CATCH_CHECK_THROWS_JSON(float1["a"], "JSON type invalid for operator[key]: (%s)", float1);
-
-        const fly::Json float2 = 1.0f;
-        CATCH_CHECK_THROWS_JSON(float2["a"], "JSON type invalid for operator[key]: (%s)", float2);
-
-        fly::Json null1 = nullptr;
-        CATCH_CHECK_NOTHROW(null1["a"]);
-        CATCH_CHECK(null1.is_object());
-        CATCH_CHECK(null1["a"] == nullptr);
-
-        const fly::Json null2 = nullptr;
-        CATCH_CHECK_THROWS_JSON(null2["a"], "JSON type invalid for operator[key]: (%s)", null2);
-    }
-
-    CATCH_SECTION("Access a JSON object's values via the accessor 'at'")
-    {
-        fly::Json string1 = "abc";
-        CATCH_CHECK_THROWS_JSON(
-            string1.at("a"),
-            "JSON type invalid for operator[key]: (%s)",
-            string1);
-
-        const fly::Json string2 = "abc";
-        CATCH_CHECK_THROWS_JSON(
-            string2.at("a"),
-            "JSON type invalid for operator[key]: (%s)",
-            string2);
-
-        fly::Json object1 = {{"a", 1}, {"b", 2}};
-        CATCH_CHECK(object1.at("a") == 1);
-        CATCH_CHECK(object1.at("b") == 2);
-        CATCH_CHECK_THROWS_JSON(object1.at("c"), "Given key (c) not found: (%s)", object1);
-
-        const fly::Json object2 = {{"a", 1}, {"b", 2}};
-        CATCH_CHECK(object2.at("a") == 1);
-        CATCH_CHECK(object2.at("b") == 2);
-        CATCH_CHECK_THROWS_JSON(object2.at("c"), "Given key (c) not found: (%s)", object2);
-
-        fly::Json array1 = {'7', 8};
-        CATCH_CHECK_THROWS_JSON(
-            array1.at("a"),
-            "JSON type invalid for operator[key]: (%s)",
-            array1);
-
-        const fly::Json array2 = {'7', 8};
-        CATCH_CHECK_THROWS_JSON(
-            array2.at("a"),
-            "JSON type invalid for operator[key]: (%s)",
-            array2);
-
-        fly::Json bool1 = true;
-        CATCH_CHECK_THROWS_JSON(bool1.at("a"), "JSON type invalid for operator[key]: (%s)", bool1);
-
-        const fly::Json bool2 = true;
-        CATCH_CHECK_THROWS_JSON(bool2.at("a"), "JSON type invalid for operator[key]: (%s)", bool2);
-
-        fly::Json signed1 = 1;
-        CATCH_CHECK_THROWS_JSON(
-            signed1.at("a"),
-            "JSON type invalid for operator[key]: (%s)",
-            signed1);
-
-        const fly::Json signed2 = 1;
-        CATCH_CHECK_THROWS_JSON(
-            signed2.at("a"),
-            "JSON type invalid for operator[key]: (%s)",
-            signed2);
-
-        fly::Json unsigned1 = static_cast<unsigned int>(1);
-        CATCH_CHECK_THROWS_JSON(
-            unsigned1.at("a"),
-            "JSON type invalid for operator[key]: (%s)",
-            unsigned1);
-
-        const fly::Json unsigned2 = static_cast<unsigned int>(1);
-        CATCH_CHECK_THROWS_JSON(
-            unsigned2.at("a"),
-            "JSON type invalid for operator[key]: (%s)",
-            unsigned2);
-
-        fly::Json float1 = 1.0f;
-        CATCH_CHECK_THROWS_JSON(
-            float1.at("a"),
-            "JSON type invalid for operator[key]: (%s)",
-            float1);
-
-        const fly::Json float2 = 1.0f;
-        CATCH_CHECK_THROWS_JSON(
-            float2.at("a"),
-            "JSON type invalid for operator[key]: (%s)",
-            float2);
-
-        fly::Json null1 = nullptr;
-        CATCH_CHECK_THROWS_JSON(null1.at("a"), "JSON type invalid for operator[key]: (%s)", null1);
-
-        const fly::Json null2 = nullptr;
-        CATCH_CHECK_THROWS_JSON(null2.at("a"), "JSON type invalid for operator[key]: (%s)", null2);
-    }
-
     CATCH_SECTION("Access a JSON array's values via the access operator")
     {
         fly::Json string1 = "abc";
@@ -1157,5 +1008,212 @@ CATCH_TEST_CASE("Json", "[json]")
             const std::string str = stream.str();
             CATCH_CHECK(str == "\"abc\\ud83c\\udf55zef\"");
         }
+    }
+}
+
+CATCH_TEMPLATE_TEST_CASE(
+    "JsonObjectAccess",
+    "[json]",
+    std::string,
+    std::wstring,
+    std::u8string,
+    std::u16string,
+    std::u32string)
+{
+    using string_type = TestType;
+    using char_type = typename string_type::value_type;
+
+    CATCH_SECTION("Access a JSON object's values via the access operator")
+    {
+        fly::Json string1 = "abc";
+        CATCH_CHECK_THROWS_JSON(
+            string1[J_STR("a")],
+            "JSON type invalid for operator[key]: (%s)",
+            string1);
+
+        const fly::Json string2 = "abc";
+        CATCH_CHECK_THROWS_JSON(
+            string2[J_STR("a")],
+            "JSON type invalid for operator[key]: (%s)",
+            string2);
+
+        fly::Json object1 = {{"a", 1}, {"b", 2}};
+        CATCH_CHECK(object1[J_STR("a")] == 1);
+        CATCH_CHECK(object1[J_STR("b")] == 2);
+        CATCH_CHECK_NOTHROW(object1[J_STR("c")]);
+        CATCH_CHECK(object1[J_STR("c")] == nullptr);
+
+        const fly::Json object2 = {{"a", 1}, {"b", 2}};
+        CATCH_CHECK(object2[J_STR("a")] == 1);
+        CATCH_CHECK(object2[J_STR("b")] == 2);
+        CATCH_CHECK_THROWS_JSON(object2[J_STR("c")], "Given key (c) not found: (%s)", object2);
+
+        fly::Json array1 = {'7', 8};
+        CATCH_CHECK_THROWS_JSON(
+            array1[J_STR("a")],
+            "JSON type invalid for operator[key]: (%s)",
+            array1);
+
+        const fly::Json array2 = {'7', 8};
+        CATCH_CHECK_THROWS_JSON(
+            array2[J_STR("a")],
+            "JSON type invalid for operator[key]: (%s)",
+            array2);
+
+        fly::Json bool1 = true;
+        CATCH_CHECK_THROWS_JSON(
+            bool1[J_STR("a")],
+            "JSON type invalid for operator[key]: (%s)",
+            bool1);
+
+        const fly::Json bool2 = true;
+        CATCH_CHECK_THROWS_JSON(
+            bool2[J_STR("a")],
+            "JSON type invalid for operator[key]: (%s)",
+            bool2);
+
+        fly::Json signed1 = 1;
+        CATCH_CHECK_THROWS_JSON(
+            signed1[J_STR("a")],
+            "JSON type invalid for operator[key]: (%s)",
+            signed1);
+
+        const fly::Json signed2 = 1;
+        CATCH_CHECK_THROWS_JSON(
+            signed2[J_STR("a")],
+            "JSON type invalid for operator[key]: (%s)",
+            signed2);
+
+        fly::Json unsigned1 = static_cast<unsigned int>(1);
+        CATCH_CHECK_THROWS_JSON(
+            unsigned1[J_STR("a")],
+            "JSON type invalid for operator[key]: (%s)",
+            unsigned1);
+
+        const fly::Json unsigned2 = static_cast<unsigned int>(1);
+        CATCH_CHECK_THROWS_JSON(
+            unsigned2[J_STR("a")],
+            "JSON type invalid for operator[key]: (%s)",
+            unsigned2);
+
+        fly::Json float1 = 1.0f;
+        CATCH_CHECK_THROWS_JSON(
+            float1[J_STR("a")],
+            "JSON type invalid for operator[key]: (%s)",
+            float1);
+
+        const fly::Json float2 = 1.0f;
+        CATCH_CHECK_THROWS_JSON(
+            float2[J_STR("a")],
+            "JSON type invalid for operator[key]: (%s)",
+            float2);
+
+        fly::Json null1 = nullptr;
+        CATCH_CHECK_NOTHROW(null1[J_STR("a")]);
+        CATCH_CHECK(null1.is_object());
+        CATCH_CHECK(null1[J_STR("a")] == nullptr);
+
+        const fly::Json null2 = nullptr;
+        CATCH_CHECK_THROWS_JSON(
+            null2[J_STR("a")],
+            "JSON type invalid for operator[key]: (%s)",
+            null2);
+    }
+
+    CATCH_SECTION("Access a JSON object's values via the accessor 'at'")
+    {
+        fly::Json string1 = "abc";
+        CATCH_CHECK_THROWS_JSON(
+            string1.at(J_STR("a")),
+            "JSON type invalid for operator[key]: (%s)",
+            string1);
+
+        const fly::Json string2 = "abc";
+        CATCH_CHECK_THROWS_JSON(
+            string2.at(J_STR("a")),
+            "JSON type invalid for operator[key]: (%s)",
+            string2);
+
+        fly::Json object1 = {{"a", 1}, {"b", 2}};
+        CATCH_CHECK(object1.at(J_STR("a")) == 1);
+        CATCH_CHECK(object1.at(J_STR("b")) == 2);
+        CATCH_CHECK_THROWS_JSON(object1.at(J_STR("c")), "Given key (c) not found: (%s)", object1);
+
+        const fly::Json object2 = {{"a", 1}, {"b", 2}};
+        CATCH_CHECK(object2.at(J_STR("a")) == 1);
+        CATCH_CHECK(object2.at(J_STR("b")) == 2);
+        CATCH_CHECK_THROWS_JSON(object2.at(J_STR("c")), "Given key (c) not found: (%s)", object2);
+
+        fly::Json array1 = {'7', 8};
+        CATCH_CHECK_THROWS_JSON(
+            array1.at(J_STR("a")),
+            "JSON type invalid for operator[key]: (%s)",
+            array1);
+
+        const fly::Json array2 = {'7', 8};
+        CATCH_CHECK_THROWS_JSON(
+            array2.at(J_STR("a")),
+            "JSON type invalid for operator[key]: (%s)",
+            array2);
+
+        fly::Json bool1 = true;
+        CATCH_CHECK_THROWS_JSON(
+            bool1.at(J_STR("a")),
+            "JSON type invalid for operator[key]: (%s)",
+            bool1);
+
+        const fly::Json bool2 = true;
+        CATCH_CHECK_THROWS_JSON(
+            bool2.at(J_STR("a")),
+            "JSON type invalid for operator[key]: (%s)",
+            bool2);
+
+        fly::Json signed1 = 1;
+        CATCH_CHECK_THROWS_JSON(
+            signed1.at(J_STR("a")),
+            "JSON type invalid for operator[key]: (%s)",
+            signed1);
+
+        const fly::Json signed2 = 1;
+        CATCH_CHECK_THROWS_JSON(
+            signed2.at(J_STR("a")),
+            "JSON type invalid for operator[key]: (%s)",
+            signed2);
+
+        fly::Json unsigned1 = static_cast<unsigned int>(1);
+        CATCH_CHECK_THROWS_JSON(
+            unsigned1.at(J_STR("a")),
+            "JSON type invalid for operator[key]: (%s)",
+            unsigned1);
+
+        const fly::Json unsigned2 = static_cast<unsigned int>(1);
+        CATCH_CHECK_THROWS_JSON(
+            unsigned2.at(J_STR("a")),
+            "JSON type invalid for operator[key]: (%s)",
+            unsigned2);
+
+        fly::Json float1 = 1.0f;
+        CATCH_CHECK_THROWS_JSON(
+            float1.at(J_STR("a")),
+            "JSON type invalid for operator[key]: (%s)",
+            float1);
+
+        const fly::Json float2 = 1.0f;
+        CATCH_CHECK_THROWS_JSON(
+            float2.at(J_STR("a")),
+            "JSON type invalid for operator[key]: (%s)",
+            float2);
+
+        fly::Json null1 = nullptr;
+        CATCH_CHECK_THROWS_JSON(
+            null1.at(J_STR("a")),
+            "JSON type invalid for operator[key]: (%s)",
+            null1);
+
+        const fly::Json null2 = nullptr;
+        CATCH_CHECK_THROWS_JSON(
+            null2.at(J_STR("a")),
+            "JSON type invalid for operator[key]: (%s)",
+            null2);
     }
 }

--- a/test/types/json.cpp
+++ b/test/types/json.cpp
@@ -334,39 +334,6 @@ CATCH_TEST_CASE("Json", "[json]")
         CATCH_CHECK(json3 == "string");
     }
 
-    CATCH_SECTION("Swap a JSON instance with a string-like type")
-    {
-        fly::Json json;
-        std::string str;
-
-        json = "abcdef";
-        str = "ghijkl";
-        CATCH_CHECK_NOTHROW(json.swap(str));
-        CATCH_CHECK(json == "ghijkl");
-        CATCH_CHECK(str == "abcdef");
-
-        json = {{"a", 1}, {"b", 2}};
-        CATCH_CHECK_THROWS_JSON(json.swap(str), "JSON type invalid for swap(string): (%s)", json);
-
-        json = {'7', 8, 9, 10};
-        CATCH_CHECK_THROWS_JSON(json.swap(str), "JSON type invalid for swap(string): (%s)", json);
-
-        json = true;
-        CATCH_CHECK_THROWS_JSON(json.swap(str), "JSON type invalid for swap(string): (%s)", json);
-
-        json = 1;
-        CATCH_CHECK_THROWS_JSON(json.swap(str), "JSON type invalid for swap(string): (%s)", json);
-
-        json = static_cast<unsigned int>(1);
-        CATCH_CHECK_THROWS_JSON(json.swap(str), "JSON type invalid for swap(string): (%s)", json);
-
-        json = 1.0f;
-        CATCH_CHECK_THROWS_JSON(json.swap(str), "JSON type invalid for swap(string): (%s)", json);
-
-        json = nullptr;
-        CATCH_CHECK_THROWS_JSON(json.swap(str), "JSON type invalid for swap(string): (%s)", json);
-    }
-
     CATCH_SECTION("Swap a JSON instance with an object-like type")
     {
         auto validate = [](auto *name, auto &test1, auto &test2, auto &test3)
@@ -1012,7 +979,7 @@ CATCH_TEST_CASE("Json", "[json]")
 }
 
 CATCH_TEMPLATE_TEST_CASE(
-    "JsonObjectAccess",
+    "JsonStringOperations",
     "[json]",
     std::string,
     std::wstring,
@@ -1215,5 +1182,36 @@ CATCH_TEMPLATE_TEST_CASE(
             null2.at(J_STR("a")),
             "JSON type invalid for operator[key]: (%s)",
             null2);
+    }
+
+    CATCH_SECTION("Swap a JSON instance with a string-like type")
+    {
+        fly::Json json = "abcdef";
+        string_type str = J_STR("ghijkl");
+
+        CATCH_CHECK_NOTHROW(json.swap(str));
+        CATCH_CHECK(json == "ghijkl");
+        CATCH_CHECK(str == J_STR("abcdef"));
+
+        json = {{"a", 1}, {"b", 2}};
+        CATCH_CHECK_THROWS_JSON(json.swap(str), "JSON type invalid for swap(string): (%s)", json);
+
+        json = {'7', 8, 9, 10};
+        CATCH_CHECK_THROWS_JSON(json.swap(str), "JSON type invalid for swap(string): (%s)", json);
+
+        json = true;
+        CATCH_CHECK_THROWS_JSON(json.swap(str), "JSON type invalid for swap(string): (%s)", json);
+
+        json = 1;
+        CATCH_CHECK_THROWS_JSON(json.swap(str), "JSON type invalid for swap(string): (%s)", json);
+
+        json = static_cast<unsigned int>(1);
+        CATCH_CHECK_THROWS_JSON(json.swap(str), "JSON type invalid for swap(string): (%s)", json);
+
+        json = 1.0f;
+        CATCH_CHECK_THROWS_JSON(json.swap(str), "JSON type invalid for swap(string): (%s)", json);
+
+        json = nullptr;
+        CATCH_CHECK_THROWS_JSON(json.swap(str), "JSON type invalid for swap(string): (%s)", json);
     }
 }

--- a/test/types/json.cpp
+++ b/test/types/json.cpp
@@ -642,7 +642,7 @@ CATCH_TEST_CASE("Json", "[json]")
             for (auto it = json.begin(); it != json.end(); ++it, ++size)
             {
                 CATCH_CHECK(*it == (size == 0 ? 1 : 2));
-                CATCH_CHECK(it.key() == (size == 0 ? "a" : "b"));
+                CATCH_CHECK(it.key() == (size == 0 ? FLY_JSON_STR("a") : FLY_JSON_STR("b")));
                 CATCH_CHECK(it.value() == (size == 0 ? 1 : 2));
             }
 
@@ -654,7 +654,7 @@ CATCH_TEST_CASE("Json", "[json]")
             for (auto it = json.cbegin(); it != json.cend(); ++it, ++size)
             {
                 CATCH_CHECK(*it == (size == 0 ? 1 : 2));
-                CATCH_CHECK(it.key() == (size == 0 ? "a" : "b"));
+                CATCH_CHECK(it.key() == (size == 0 ? FLY_JSON_STR("a") : FLY_JSON_STR("b")));
                 CATCH_CHECK(it.value() == (size == 0 ? 1 : 2));
             }
 

--- a/test/types/json.cpp
+++ b/test/types/json.cpp
@@ -1,5 +1,7 @@
 #include "fly/types/json/json.hpp"
 
+#include "test/types/json_macros.hpp"
+
 #include <catch2/catch.hpp>
 
 #include <array>
@@ -12,13 +14,6 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
-
-#define CATCH_CHECK_THROWS_JSON(expression, ...)                                                   \
-    CATCH_CHECK_THROWS_MATCHES(                                                                    \
-        expression,                                                                                \
-        fly::JsonException,                                                                        \
-        Catch::Matchers::Exception::ExceptionMessageMatcher(                                       \
-            fly::String::format("JsonException: " __VA_ARGS__)))
 
 CATCH_TEST_CASE("Json", "[json]")
 {

--- a/test/types/json_construction.cpp
+++ b/test/types/json_construction.cpp
@@ -1,5 +1,5 @@
 #include "fly/types/json/json.hpp"
-#include "fly/types/string/string_literal.hpp"
+#include "test/types/json_macros.hpp"
 
 #include <catch2/catch.hpp>
 
@@ -12,16 +12,6 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
-
-#define CATCH_CHECK_THROWS_JSON(expression, ...)                                                   \
-    CATCH_CHECK_THROWS_MATCHES(                                                                    \
-        expression,                                                                                \
-        fly::JsonException,                                                                        \
-        Catch::Matchers::Exception::ExceptionMessageMatcher(                                       \
-            fly::String::format("JsonException: " __VA_ARGS__)))
-
-#define J_CHR(ch) FLY_CHR(char_type, ch)
-#define J_STR(str) FLY_STR(char_type, str)
 
 CATCH_TEMPLATE_TEST_CASE(
     "JsonConstruction",

--- a/test/types/json_conversion.cpp
+++ b/test/types/json_conversion.cpp
@@ -1,5 +1,6 @@
 #include "fly/fly.hpp"
 #include "fly/types/json/json.hpp"
+#include "test/types/json_macros.hpp"
 
 #include <catch2/catch.hpp>
 
@@ -13,16 +14,6 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
-
-#define CATCH_CHECK_THROWS_JSON(expression, ...)                                                   \
-    CATCH_CHECK_THROWS_MATCHES(                                                                    \
-        expression,                                                                                \
-        fly::JsonException,                                                                        \
-        Catch::Matchers::Exception::ExceptionMessageMatcher(                                       \
-            fly::String::format("JsonException: " __VA_ARGS__)))
-
-#define J_CHR(ch) FLY_CHR(char_type, ch)
-#define J_STR(str) FLY_STR(char_type, str)
 
 CATCH_TEMPLATE_TEST_CASE(
     "JsonConversion",

--- a/test/types/json_iterator.cpp
+++ b/test/types/json_iterator.cpp
@@ -499,8 +499,8 @@ CATCH_TEST_CASE("JsonIterator", "[json]")
         iterator it2 = json.begin();
         iterator it1 = it2++;
 
-        CATCH_CHECK(it1.key() == "a");
-        CATCH_CHECK(it2.key() == "b");
+        CATCH_CHECK(it1.key() == FLY_JSON_STR("a"));
+        CATCH_CHECK(it2.key() == FLY_JSON_STR("b"));
 
         CATCH_CHECK_THROWS_NULL_WITH(json.end().key(), json);
         CATCH_CHECK_THROWS_NULL_WITH(json.cend().key(), json);

--- a/test/types/json_macros.hpp
+++ b/test/types/json_macros.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "fly/types/json/json_exception.hpp"
+#include "fly/types/string/string.hpp"
+
+#include <catch2/catch.hpp>
+
+#define CATCH_CHECK_THROWS_JSON(expression, ...)                                                   \
+    CATCH_CHECK_THROWS_MATCHES(                                                                    \
+        expression,                                                                                \
+        fly::JsonException,                                                                        \
+        Catch::Matchers::Exception::ExceptionMessageMatcher(                                       \
+            fly::String::format("JsonException: " __VA_ARGS__)))
+
+#define CATCH_CHECK_THROWS_ITERATOR(expression, ...)                                               \
+    CATCH_CHECK_THROWS_MATCHES(                                                                    \
+        expression,                                                                                \
+        fly::JsonIteratorException,                                                                \
+        Catch::Matchers::Exception::ExceptionMessageMatcher(                                       \
+            fly::String::format("JsonIteratorException: " __VA_ARGS__)))
+
+#define CATCH_CHECK_THROWS_BAD_COMPARISON(expression, json1, json2)                                \
+    CATCH_CHECK_THROWS_MATCHES(                                                                    \
+        expression,                                                                                \
+        fly::BadJsonComparisonException,                                                           \
+        Catch::Matchers::Exception::ExceptionMessageMatcher(fly::String::format(                   \
+            "BadJsonComparisonException: Cannot compare iterators of different JSON instances: "   \
+            "(%s) (%s)",                                                                           \
+            json1,                                                                                 \
+            json2)))
+
+#define CATCH_CHECK_THROWS_NULL(expression)                                                        \
+    CATCH_CHECK_THROWS_MATCHES(                                                                    \
+        expression,                                                                                \
+        fly::NullJsonException,                                                                    \
+        Catch::Matchers::Exception::ExceptionMessageMatcher(                                       \
+            fly::String::format("NullJsonException: Cannot dereference an empty or past-the-end "  \
+                                "iterator")))
+
+#define CATCH_CHECK_THROWS_NULL_WITH(expression, json)                                             \
+    CATCH_CHECK_THROWS_MATCHES(                                                                    \
+        expression,                                                                                \
+        fly::NullJsonException,                                                                    \
+        Catch::Matchers::Exception::ExceptionMessageMatcher(fly::String::format(                   \
+            "NullJsonException: Cannot dereference an empty or past-the-end "                      \
+            "iterator: (%s)",                                                                      \
+            json)))
+
+#define CATCH_CHECK_THROWS_OUT_OF_RANGE(expression, offset, json)                                  \
+    CATCH_CHECK_THROWS_MATCHES(                                                                    \
+        expression,                                                                                \
+        fly::OutOfRangeJsonException,                                                              \
+        Catch::Matchers::Exception::ExceptionMessageMatcher(fly::String::format(                   \
+            "OutOfRangeJsonException: Offset %d is out-of-range: (%s)",                            \
+            offset,                                                                                \
+            json)))
+
+#define J_CHR(ch) FLY_CHR(char_type, ch)
+#define J_STR(str) FLY_STR(char_type, str)

--- a/test/types/json_macros.hpp
+++ b/test/types/json_macros.hpp
@@ -55,5 +55,6 @@
             offset,                                                                                \
             json)))
 
+// These macros depend on the test defining a type named char_type for the string literals.
 #define J_CHR(ch) FLY_CHR(char_type, ch)
 #define J_STR(str) FLY_STR(char_type, str)

--- a/test/types/json_traits.cpp
+++ b/test/types/json_traits.cpp
@@ -43,45 +43,87 @@ CATCH_TEST_CASE("JsonTraits", "[json]")
     {
         CATCH_CHECK(fly::JsonTraits::is_string_v<const string_type>);
         CATCH_CHECK(fly::JsonTraits::is_string_v<string_type>);
-        CATCH_CHECK(fly::JsonTraits::is_string_v<const char_type *>);
-        CATCH_CHECK(fly::JsonTraits::is_string_v<char_type *>);
-        CATCH_CHECK(fly::JsonTraits::is_string_v<const char_type[]>);
-        CATCH_CHECK(fly::JsonTraits::is_string_v<char_type[]>);
+        CATCH_CHECK_FALSE(fly::JsonTraits::is_string_v<const char_type *>);
+        CATCH_CHECK_FALSE(fly::JsonTraits::is_string_v<char_type *>);
+        CATCH_CHECK_FALSE(fly::JsonTraits::is_string_v<const char_type[]>);
+        CATCH_CHECK_FALSE(fly::JsonTraits::is_string_v<char_type[]>);
+
+        CATCH_CHECK(fly::JsonTraits::is_string_like_v<const string_type>);
+        CATCH_CHECK(fly::JsonTraits::is_string_like_v<string_type>);
+        CATCH_CHECK(fly::JsonTraits::is_string_like_v<const char_type *>);
+        CATCH_CHECK(fly::JsonTraits::is_string_like_v<char_type *>);
+        CATCH_CHECK(fly::JsonTraits::is_string_like_v<const char_type[]>);
+        CATCH_CHECK(fly::JsonTraits::is_string_like_v<char_type[]>);
 
         CATCH_CHECK(fly::JsonTraits::is_string_v<const std::string>);
         CATCH_CHECK(fly::JsonTraits::is_string_v<std::string>);
-        CATCH_CHECK(fly::JsonTraits::is_string_v<const char *>);
-        CATCH_CHECK(fly::JsonTraits::is_string_v<char *>);
-        CATCH_CHECK(fly::JsonTraits::is_string_v<const char[]>);
-        CATCH_CHECK(fly::JsonTraits::is_string_v<char[]>);
+        CATCH_CHECK_FALSE(fly::JsonTraits::is_string_v<const char *>);
+        CATCH_CHECK_FALSE(fly::JsonTraits::is_string_v<char *>);
+        CATCH_CHECK_FALSE(fly::JsonTraits::is_string_v<const char[]>);
+        CATCH_CHECK_FALSE(fly::JsonTraits::is_string_v<char[]>);
+
+        CATCH_CHECK(fly::JsonTraits::is_string_like_v<const std::string>);
+        CATCH_CHECK(fly::JsonTraits::is_string_like_v<std::string>);
+        CATCH_CHECK(fly::JsonTraits::is_string_like_v<const char *>);
+        CATCH_CHECK(fly::JsonTraits::is_string_like_v<char *>);
+        CATCH_CHECK(fly::JsonTraits::is_string_like_v<const char[]>);
+        CATCH_CHECK(fly::JsonTraits::is_string_like_v<char[]>);
 
         CATCH_CHECK(fly::JsonTraits::is_string_v<const std::wstring>);
         CATCH_CHECK(fly::JsonTraits::is_string_v<std::wstring>);
-        CATCH_CHECK(fly::JsonTraits::is_string_v<const wchar_t *>);
-        CATCH_CHECK(fly::JsonTraits::is_string_v<wchar_t *>);
-        CATCH_CHECK(fly::JsonTraits::is_string_v<const wchar_t[]>);
-        CATCH_CHECK(fly::JsonTraits::is_string_v<wchar_t[]>);
+        CATCH_CHECK_FALSE(fly::JsonTraits::is_string_v<const wchar_t *>);
+        CATCH_CHECK_FALSE(fly::JsonTraits::is_string_v<wchar_t *>);
+        CATCH_CHECK_FALSE(fly::JsonTraits::is_string_v<const wchar_t[]>);
+        CATCH_CHECK_FALSE(fly::JsonTraits::is_string_v<wchar_t[]>);
+
+        CATCH_CHECK(fly::JsonTraits::is_string_like_v<const std::wstring>);
+        CATCH_CHECK(fly::JsonTraits::is_string_like_v<std::wstring>);
+        CATCH_CHECK(fly::JsonTraits::is_string_like_v<const wchar_t *>);
+        CATCH_CHECK(fly::JsonTraits::is_string_like_v<wchar_t *>);
+        CATCH_CHECK(fly::JsonTraits::is_string_like_v<const wchar_t[]>);
+        CATCH_CHECK(fly::JsonTraits::is_string_like_v<wchar_t[]>);
 
         CATCH_CHECK(fly::JsonTraits::is_string_v<const std::u8string>);
         CATCH_CHECK(fly::JsonTraits::is_string_v<std::u8string>);
-        CATCH_CHECK(fly::JsonTraits::is_string_v<const char8_t *>);
-        CATCH_CHECK(fly::JsonTraits::is_string_v<char8_t *>);
-        CATCH_CHECK(fly::JsonTraits::is_string_v<const char8_t[]>);
-        CATCH_CHECK(fly::JsonTraits::is_string_v<char8_t[]>);
+        CATCH_CHECK_FALSE(fly::JsonTraits::is_string_v<const char8_t *>);
+        CATCH_CHECK_FALSE(fly::JsonTraits::is_string_v<char8_t *>);
+        CATCH_CHECK_FALSE(fly::JsonTraits::is_string_v<const char8_t[]>);
+        CATCH_CHECK_FALSE(fly::JsonTraits::is_string_v<char8_t[]>);
+
+        CATCH_CHECK(fly::JsonTraits::is_string_like_v<const std::u8string>);
+        CATCH_CHECK(fly::JsonTraits::is_string_like_v<std::u8string>);
+        CATCH_CHECK(fly::JsonTraits::is_string_like_v<const char8_t *>);
+        CATCH_CHECK(fly::JsonTraits::is_string_like_v<char8_t *>);
+        CATCH_CHECK(fly::JsonTraits::is_string_like_v<const char8_t[]>);
+        CATCH_CHECK(fly::JsonTraits::is_string_like_v<char8_t[]>);
 
         CATCH_CHECK(fly::JsonTraits::is_string_v<const std::u16string>);
         CATCH_CHECK(fly::JsonTraits::is_string_v<std::u16string>);
-        CATCH_CHECK(fly::JsonTraits::is_string_v<const char16_t *>);
-        CATCH_CHECK(fly::JsonTraits::is_string_v<char16_t *>);
-        CATCH_CHECK(fly::JsonTraits::is_string_v<const char16_t[]>);
-        CATCH_CHECK(fly::JsonTraits::is_string_v<char16_t[]>);
+        CATCH_CHECK_FALSE(fly::JsonTraits::is_string_v<const char16_t *>);
+        CATCH_CHECK_FALSE(fly::JsonTraits::is_string_v<char16_t *>);
+        CATCH_CHECK_FALSE(fly::JsonTraits::is_string_v<const char16_t[]>);
+        CATCH_CHECK_FALSE(fly::JsonTraits::is_string_v<char16_t[]>);
+
+        CATCH_CHECK(fly::JsonTraits::is_string_like_v<const std::u16string>);
+        CATCH_CHECK(fly::JsonTraits::is_string_like_v<std::u16string>);
+        CATCH_CHECK(fly::JsonTraits::is_string_like_v<const char16_t *>);
+        CATCH_CHECK(fly::JsonTraits::is_string_like_v<char16_t *>);
+        CATCH_CHECK(fly::JsonTraits::is_string_like_v<const char16_t[]>);
+        CATCH_CHECK(fly::JsonTraits::is_string_like_v<char16_t[]>);
 
         CATCH_CHECK(fly::JsonTraits::is_string_v<const std::u32string>);
         CATCH_CHECK(fly::JsonTraits::is_string_v<std::u32string>);
-        CATCH_CHECK(fly::JsonTraits::is_string_v<const char32_t *>);
-        CATCH_CHECK(fly::JsonTraits::is_string_v<char32_t *>);
-        CATCH_CHECK(fly::JsonTraits::is_string_v<const char32_t[]>);
-        CATCH_CHECK(fly::JsonTraits::is_string_v<char32_t[]>);
+        CATCH_CHECK_FALSE(fly::JsonTraits::is_string_v<const char32_t *>);
+        CATCH_CHECK_FALSE(fly::JsonTraits::is_string_v<char32_t *>);
+        CATCH_CHECK_FALSE(fly::JsonTraits::is_string_v<const char32_t[]>);
+        CATCH_CHECK_FALSE(fly::JsonTraits::is_string_v<char32_t[]>);
+
+        CATCH_CHECK(fly::JsonTraits::is_string_like_v<const std::u32string>);
+        CATCH_CHECK(fly::JsonTraits::is_string_like_v<std::u32string>);
+        CATCH_CHECK(fly::JsonTraits::is_string_like_v<const char32_t *>);
+        CATCH_CHECK(fly::JsonTraits::is_string_like_v<char32_t *>);
+        CATCH_CHECK(fly::JsonTraits::is_string_like_v<const char32_t[]>);
+        CATCH_CHECK(fly::JsonTraits::is_string_like_v<char32_t[]>);
 
         CATCH_CHECK_FALSE(fly::JsonTraits::is_string_v<array_type>);
         CATCH_CHECK_FALSE(fly::JsonTraits::is_string_v<deque_type>);
@@ -97,12 +139,33 @@ CATCH_TEST_CASE("JsonTraits", "[json]")
         CATCH_CHECK_FALSE(fly::JsonTraits::is_string_v<unordered_set_type>);
         CATCH_CHECK_FALSE(fly::JsonTraits::is_string_v<vector_type>);
 
+        CATCH_CHECK_FALSE(fly::JsonTraits::is_string_like_v<array_type>);
+        CATCH_CHECK_FALSE(fly::JsonTraits::is_string_like_v<deque_type>);
+        CATCH_CHECK_FALSE(fly::JsonTraits::is_string_like_v<forward_list_type>);
+        CATCH_CHECK_FALSE(fly::JsonTraits::is_string_like_v<list_type>);
+        CATCH_CHECK_FALSE(fly::JsonTraits::is_string_like_v<map_type>);
+        CATCH_CHECK_FALSE(fly::JsonTraits::is_string_like_v<multimap_type>);
+        CATCH_CHECK_FALSE(fly::JsonTraits::is_string_like_v<multiset_type>);
+        CATCH_CHECK_FALSE(fly::JsonTraits::is_string_like_v<set_type>);
+        CATCH_CHECK_FALSE(fly::JsonTraits::is_string_like_v<unordered_map_type>);
+        CATCH_CHECK_FALSE(fly::JsonTraits::is_string_like_v<unordered_multimap_type>);
+        CATCH_CHECK_FALSE(fly::JsonTraits::is_string_like_v<unordered_multiset_type>);
+        CATCH_CHECK_FALSE(fly::JsonTraits::is_string_like_v<unordered_set_type>);
+        CATCH_CHECK_FALSE(fly::JsonTraits::is_string_like_v<vector_type>);
+
         CATCH_CHECK_FALSE(fly::JsonTraits::is_string_v<signed_integer_type>);
         CATCH_CHECK_FALSE(fly::JsonTraits::is_string_v<boolean_type>);
         CATCH_CHECK_FALSE(fly::JsonTraits::is_string_v<float_type>);
         CATCH_CHECK_FALSE(fly::JsonTraits::is_string_v<double_type>);
         CATCH_CHECK_FALSE(fly::JsonTraits::is_string_v<const char_type>);
         CATCH_CHECK_FALSE(fly::JsonTraits::is_string_v<char_type>);
+
+        CATCH_CHECK_FALSE(fly::JsonTraits::is_string_like_v<signed_integer_type>);
+        CATCH_CHECK_FALSE(fly::JsonTraits::is_string_like_v<boolean_type>);
+        CATCH_CHECK_FALSE(fly::JsonTraits::is_string_like_v<float_type>);
+        CATCH_CHECK_FALSE(fly::JsonTraits::is_string_like_v<double_type>);
+        CATCH_CHECK_FALSE(fly::JsonTraits::is_string_like_v<const char_type>);
+        CATCH_CHECK_FALSE(fly::JsonTraits::is_string_like_v<char_type>);
     }
 
     CATCH_SECTION("Traits for boolean-like JSON types")

--- a/test/types/json_traits.cpp
+++ b/test/types/json_traits.cpp
@@ -15,7 +15,7 @@
 CATCH_TEST_CASE("JsonTraits", "[json]")
 {
     using string_type = typename fly::JsonTraits::string_type;
-    using char_type = typename string_type::value_type;
+    using char_type = typename fly::JsonTraits::char_type;
 
     using array_type = std::array<int, 4>;
     using deque_type = std::deque<int>;


### PR DESCRIPTION
Allow `operator[]`, `at`, and `swap` with any string type.