### PR TITLE
Fix Windows builds with Visual Studio 16.8

### DIFF
--- a/build/win/libfly_unit_tests/libfly_unit_tests.vcxproj
+++ b/build/win/libfly_unit_tests/libfly_unit_tests.vcxproj
@@ -117,7 +117,7 @@
       <UseFullPaths>true</UseFullPaths>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpplatest</LanguageStandard>
-      <AdditionalOptions>/utf-8 /bigobj %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/utf-8 /bigobj /permissive %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -137,7 +137,7 @@
       <UseFullPaths>true</UseFullPaths>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpplatest</LanguageStandard>
-      <AdditionalOptions>/utf-8 /bigobj %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/utf-8 /bigobj /permissive %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -159,7 +159,7 @@
       <UseFullPaths>true</UseFullPaths>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpplatest</LanguageStandard>
-      <AdditionalOptions>/utf-8 /bigobj %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/utf-8 /bigobj /permissive %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -183,7 +183,7 @@
       <UseFullPaths>true</UseFullPaths>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpplatest</LanguageStandard>
-      <AdditionalOptions>/utf-8 /bigobj %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/utf-8 /bigobj /permissive %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/test/types/string_formatter.cpp
+++ b/test/types/string_formatter.cpp
@@ -178,8 +178,10 @@ CATCH_TEMPLATE_TEST_CASE(
         format = FLY_STR(char_type, "%a");
         CATCH_CHECK(FLY_STR(streamed_char, "%a") == BasicString::format(format));
 #if defined(FLY_WINDOWS)
-        // Windows 0-pads std::hexfloat to match the stream precision, Linux and macOS do not.
-        CATCH_CHECK(FLY_STR(streamed_char, "0x1.600000p+2") == BasicString::format(format, 5.5));
+        // MSVC will always 0-pad std::hexfloat formatted strings. Clang and GCC do not.
+        // https://github.com/microsoft/STL/blob/0b81475cc8087a7b615911d65b52b6a1fad87d7d/stl/inc/xlocnum#L1156
+        CATCH_CHECK(
+            FLY_STR(streamed_char, "0x1.6000000000000p+2") == BasicString::format(format, 5.5));
 #else
         CATCH_CHECK(FLY_STR(streamed_char, "0x1.6p+2") == BasicString::format(format, 5.5));
 #endif
@@ -187,8 +189,10 @@ CATCH_TEMPLATE_TEST_CASE(
         format = FLY_STR(char_type, "%A");
         CATCH_CHECK(FLY_STR(streamed_char, "%A") == BasicString::format(format));
 #if defined(FLY_WINDOWS)
-        // Windows 0-pads std::hexfloat to match the stream precision, Linux and macOS do not.
-        CATCH_CHECK(FLY_STR(streamed_char, "0X1.600000P+2") == BasicString::format(format, 5.5));
+        // MSVC will always 0-pad std::hexfloat formatted strings. Clang and GCC do not.
+        // https://github.com/microsoft/STL/blob/0b81475cc8087a7b615911d65b52b6a1fad87d7d/stl/inc/xlocnum#L1156
+        CATCH_CHECK(
+            FLY_STR(streamed_char, "0X1.6000000000000P+2") == BasicString::format(format, 5.5));
 #else
         CATCH_CHECK(FLY_STR(streamed_char, "0X1.6P+2") == BasicString::format(format, 5.5));
 #endif


### PR DESCRIPTION
1. Add /permissive flag to MSVC unit test compilation. As of 16.8, MSVC
   implicitly adds /permissive- when using /std:c++latest. See:

   https://docs.microsoft.com/en-us/cpp/build/reference/permissive-standards-conformance?view=msvc-160

   It seems that with this flag, MSVC fails to compile user-defined
   literals when prefixed with a negative sign, e.g. "-100_u8".

2. MSVC previously respected a stream's precision using std::hexfloat,
   which is non-compliant with the spec (std::hexfloat is meant to
   ignore precision). Unfortunately it does not behave the same as Clang
   and GCC still; MSVC will always zero-pad a fixed amount. See:

   https://github.com/microsoft/STL/pull/1173