### PR TITLE
Reduce string overhead of Json and JsonParser

### DIFF
--- a/fly/parser/json_parser.cpp
+++ b/fly/parser/json_parser.cpp
@@ -189,7 +189,7 @@ std::optional<JsonTraits::string_type> JsonParser::parse_quoted_string()
         return (token == Token::Quote) || (token == Token::EndOfFile);
     };
 
-    Json::stringstream_type parsing;
+    JsonTraits::string_type value;
     Token token;
 
     if (consume_token(Token::Quote) == ParseState::Invalid)
@@ -199,7 +199,7 @@ std::optional<JsonTraits::string_type> JsonParser::parse_quoted_string()
 
     while (!stop_parsing(token = m_stream->peek<Token>()))
     {
-        parsing << static_cast<JsonTraits::char_type>(token);
+        value.push_back(static_cast<JsonTraits::char_type>(token));
         discard();
 
         // Blindly ignore escaped symbols, the Json class will check whether they are valid. Just
@@ -213,7 +213,7 @@ std::optional<JsonTraits::string_type> JsonParser::parse_quoted_string()
                 return std::nullopt;
             }
 
-            parsing << static_cast<JsonTraits::char_type>(token);
+            value.push_back(static_cast<JsonTraits::char_type>(token));
         }
     }
 
@@ -222,7 +222,7 @@ std::optional<JsonTraits::string_type> JsonParser::parse_quoted_string()
         return std::nullopt;
     }
 
-    return parsing.str();
+    return value;
 }
 
 //==================================================================================================
@@ -325,16 +325,16 @@ JsonTraits::string_type JsonParser::consume_value()
             (token == Token::EndOfFile);
     };
 
-    Json::stringstream_type parsing;
+    JsonTraits::string_type value;
     Token token;
 
     while (!stop_parsing(token = m_stream->peek<Token>()))
     {
-        parsing << static_cast<JsonTraits::char_type>(token);
+        value.push_back(static_cast<JsonTraits::char_type>(token));
         discard();
     }
 
-    return parsing.str();
+    return value;
 }
 
 //==================================================================================================

--- a/fly/parser/json_parser.hpp
+++ b/fly/parser/json_parser.hpp
@@ -93,16 +93,14 @@ private:
     };
 
     /**
-     * Enumeration to indicate the type of a JSON value to parse.
+     * Enumeration to indicate the type of a JSON number to parse.
      */
-    enum class JsonType : std::uint8_t
+    enum class NumberType : std::uint8_t
     {
         Invalid,
-        JsonString,
         SignedInteger,
         UnsignedInteger,
         FloatingPoint,
-        Other,
     };
 
     /**
@@ -110,13 +108,8 @@ private:
      */
     enum class ParseState : std::uint8_t
     {
-        // A parsing error has occurred and all parsing should stop.
         Invalid,
-
-        // Parsing is complete.
         StopParsing,
-
-        // Parsing is ongoing.
         KeepParsing,
     };
 
@@ -153,7 +146,18 @@ private:
     ParseState done_parsing_object_or_array(const Token &end_token);
 
     /**
-     * Parse a JSON string, number, boolean, or null value from the stream.
+     * Parse a JSON string from the stream. Escaped symbols are preserved in the string, and the
+     * returned value does not contain its surrounding quotes.
+     *
+     * This returns an actual string rather than a JSON value because some callers prefer the string
+     * type (e.g. to pass the string as the key of a JSON object).
+     *
+     * @return If successful, the parsed JSON string. Otherwise, an unitialized value.
+     */
+    std::optional<JsonTraits::string_type> parse_quoted_string();
+
+    /**
+     * Parse a JSON number, boolean, or null value from the stream.
      *
      * @return If successful, the parsed JSON value. Otherwise, an unitialized value.
      */
@@ -177,17 +181,11 @@ private:
     ParseState consume_comma(const ParseStateGetter &parse_state);
 
     /**
-     * Extract a string, number, boolean, or null value from the stream. If parsing a string,
-     * escaped symbols are preserved in that string, and the returned value does not contain its
-     * surrounding quotes.
+     * Extract a number, boolean, or null value from the stream.
      *
-     * @param type The JSON value type to consume.
-     * @param value The location to store the parsed value.
-     *
-     * @return The JSON value type that was parsed. Will be either the type that was provided or
-     *         JsonType::Invalid if an error occurred.
+     * @return The JSON value that was parsed as a string.
      */
-    JsonType consume_value(JsonType type, JsonTraits::string_type &value);
+    JsonTraits::string_type consume_value();
 
     /**
      * Extract all consecutive whitespace symbols and comments (if enabled in the feature set) from
@@ -229,7 +227,7 @@ private:
      *
      * @return The interpreted JSON value type.
      */
-    JsonType validate_number(const JsonTraits::string_type &value) const;
+    NumberType validate_number(const JsonTraits::string_type &value) const;
 
     /**
      * Check if a symbol is a whitespace symbol.

--- a/fly/types/json/json.cpp
+++ b/fly/types/json/json.cpp
@@ -10,7 +10,7 @@
 namespace fly {
 
 //==================================================================================================
-Json::Json(const JsonTraits::null_type &value) noexcept : m_value(value)
+Json::Json(JsonTraits::null_type value) noexcept : m_value(value)
 {
 }
 
@@ -169,50 +169,48 @@ bool Json::is_float() const
 //==================================================================================================
 Json::operator JsonTraits::null_type() const noexcept(false)
 {
-    if (is_null())
-    {
-        return std::get<JsonTraits::null_type>(m_value);
-    }
-    else
+    if (!is_null())
     {
         throw JsonException(*this, "JSON type is not null");
     }
+
+    return std::get<JsonTraits::null_type>(m_value);
 }
 
 //==================================================================================================
 Json::reference Json::at(size_type index)
 {
-    if (is_array())
+    if (!is_array())
     {
-        auto &value = std::get<JsonTraits::array_type>(m_value);
-
-        if (index >= value.size())
-        {
-            throw JsonException(*this, String::format("Given index (%d) not found", index));
-        }
-
-        return value.at(index);
+        throw JsonException(*this, "JSON type invalid for operator[index]");
     }
 
-    throw JsonException(*this, "JSON type invalid for operator[index]");
+    auto &value = std::get<JsonTraits::array_type>(m_value);
+
+    if (index >= value.size())
+    {
+        throw JsonException(*this, String::format("Given index (%d) not found", index));
+    }
+
+    return value.at(index);
 }
 
 //==================================================================================================
 Json::const_reference Json::at(size_type index) const
 {
-    if (is_array())
+    if (!is_array())
     {
-        const auto &value = std::get<JsonTraits::array_type>(m_value);
-
-        if (index >= value.size())
-        {
-            throw JsonException(*this, String::format("Given index (%d) not found", index));
-        }
-
-        return value.at(index);
+        throw JsonException(*this, "JSON type invalid for operator[index]");
     }
 
-    throw JsonException(*this, "JSON type invalid for operator[index]");
+    const auto &value = std::get<JsonTraits::array_type>(m_value);
+
+    if (index >= value.size())
+    {
+        throw JsonException(*this, String::format("Given index (%d) not found", index));
+    }
+
+    return value.at(index);
 }
 
 //==================================================================================================
@@ -222,20 +220,19 @@ Json::reference Json::operator[](size_type index)
     {
         m_value = JsonTraits::array_type();
     }
-
-    if (is_array())
+    else if (!is_array())
     {
-        auto &value = std::get<JsonTraits::array_type>(m_value);
-
-        if (index >= value.size())
-        {
-            value.resize(index + 1);
-        }
-
-        return value.at(index);
+        throw JsonException(*this, "JSON type invalid for operator[index]");
     }
 
-    throw JsonException(*this, "JSON type invalid for operator[index]");
+    auto &value = std::get<JsonTraits::array_type>(m_value);
+
+    if (index >= value.size())
+    {
+        value.resize(index + 1);
+    }
+
+    return value.at(index);
 }
 
 //==================================================================================================

--- a/fly/types/json/json.hpp
+++ b/fly/types/json/json.hpp
@@ -201,7 +201,7 @@ public:
      *
      * @param value The null value.
      */
-    Json(const JsonTraits::null_type &value) noexcept;
+    Json(JsonTraits::null_type value) noexcept;
 
     /**
      * String constructor. Intializes the Json instance to a string value. The SFINAE declaration
@@ -215,7 +215,7 @@ public:
      * @throws JsonException If the string-like value is not valid.
      */
     template <typename T, enable_if_all<JsonTraits::is_string_like<T>> = 0>
-    Json(const T &value) noexcept(false);
+    Json(T value) noexcept(false);
 
     /**
      * Object constructor. Intializes the Json instance to an object's values. The SFINAE
@@ -229,7 +229,7 @@ public:
      * @throws JsonException If an object key is not a valid string.
      */
     template <typename T, enable_if_all<JsonTraits::is_object<T>> = 0>
-    Json(const T &value) noexcept(false);
+    Json(T value) noexcept(false);
 
     /**
      * Array constructor. Intializes the Json instance to an array's values. The SFINAE declaration
@@ -242,7 +242,7 @@ public:
      * @throws JsonException If an string-like value in the array is not valid.
      */
     template <typename T, enable_if_all<JsonTraits::is_array<T>> = 0>
-    Json(const T &value) noexcept(false);
+    Json(T value) noexcept(false);
 
     /**
      * Boolean constructor. Intializes the Json instance to a boolean value. The SFINAE declaration
@@ -254,7 +254,7 @@ public:
      * @param value The boolean value.
      */
     template <typename T, enable_if_all<JsonTraits::is_boolean<T>> = 0>
-    Json(const T &value) noexcept;
+    Json(T value) noexcept;
 
     /**
      * Signed integer constructor. Intializes the Json instance to a signed integer value. The
@@ -266,7 +266,7 @@ public:
      * @param value The signed value.
      */
     template <typename T, enable_if_all<JsonTraits::is_signed_integer<T>> = 0>
-    Json(const T &value) noexcept;
+    Json(T value) noexcept;
 
     /**
      * Unsigned integer constructor. Intializes the Json instance to an unsigned integer value. The
@@ -278,7 +278,7 @@ public:
      * @param value The unsigned value.
      */
     template <typename T, enable_if_all<JsonTraits::is_unsigned_integer<T>> = 0>
-    Json(const T &value) noexcept;
+    Json(T value) noexcept;
 
     /**
      * Floating point constructor. Intializes the Json instance to a floating point value. The
@@ -290,7 +290,7 @@ public:
      * @param value The floating point value.
      */
     template <typename T, enable_if_all<JsonTraits::is_floating_point<T>> = 0>
-    Json(const T &value) noexcept;
+    Json(T value) noexcept;
 
     /**
      * Copy constructor. Intializes the Json instance with the type and value of another Json
@@ -515,7 +515,7 @@ public:
      *         or the key value is invalid.
      */
     template <typename T, enable_if_all<JsonTraits::is_string_like<T>> = 0>
-    reference at(const T &key);
+    reference at(T key);
 
     /**
      * Object read-only accessor. The SFINAE declaration allows lookups with any string-like type
@@ -533,7 +533,7 @@ public:
      *         or the key value is invalid.
      */
     template <typename T, enable_if_all<JsonTraits::is_string_like<T>> = 0>
-    const_reference at(const T &key) const;
+    const_reference at(T key) const;
 
     /**
      * Array read-only accessor.
@@ -580,7 +580,7 @@ public:
      *         invalid.
      */
     template <typename T, enable_if_all<JsonTraits::is_string_like<T>> = 0>
-    reference operator[](const T &key);
+    reference operator[](T key);
 
     /**
      * Object read-only access operator. The SFINAE declaration allows lookups with any string-like
@@ -596,7 +596,7 @@ public:
      *         or the key value is invalid.
      */
     template <typename T, enable_if_all<JsonTraits::is_string_like<T>> = 0>
-    const_reference operator[](const T &key) const;
+    const_reference operator[](T key) const;
 
     /**
      * Array access operator.
@@ -867,7 +867,7 @@ public:
      * @throws JsonException If the Json instance is not an object or the key value is invalid.
      */
     template <typename Key, enable_if_all<JsonTraits::is_string_like<Key>> = 0>
-    std::pair<iterator, bool> insert(const Key &key, const Json &value);
+    std::pair<iterator, bool> insert(Key key, const Json &value);
 
     /**
      * Insert a moved key-value pair into the Json instance. Only valid if the Json instance is an
@@ -886,7 +886,7 @@ public:
      * @throws JsonException If the Json instance is not an object or the key value is invalid.
      */
     template <typename Key, enable_if_all<JsonTraits::is_string_like<Key>> = 0>
-    std::pair<iterator, bool> insert(const Key &key, Json &&value);
+    std::pair<iterator, bool> insert(Key key, Json &&value);
 
     /**
      * Insert all values into the Json instance in the range [first, last). Only valid if the Json
@@ -994,7 +994,7 @@ public:
      * @throws JsonException If the Json instance is not an object or the key value is invalid.
      */
     template <typename Key, enable_if_all<JsonTraits::is_string_like<Key>> = 0>
-    std::pair<iterator, bool> insert_or_assign(const Key &key, Json &&value);
+    std::pair<iterator, bool> insert_or_assign(Key key, Json &&value);
 
     /**
      * Construct an element in-place within the Json instance. Only valid if the Json instance is an
@@ -1015,7 +1015,7 @@ public:
      * @throws JsonException If the Json instance is neither an object nor null.
      */
     template <typename Key, typename Value, enable_if_all<JsonTraits::is_string_like<Key>> = 0>
-    std::pair<iterator, bool> emplace(const Key &key, Value &&arg);
+    std::pair<iterator, bool> emplace(Key key, Value &&arg);
 
     /**
      * Construct an element in-place at the end of the Json instance. Only valid if the Json
@@ -1075,7 +1075,7 @@ public:
      * @throws JsonException If the Json instance is not an object or the key value is invalid.
      */
     template <typename T, enable_if_all<JsonTraits::is_string_like<T>> = 0>
-    size_type erase(const T &key);
+    size_type erase(T key);
 
     /**
      * Remove a value from the Json instance at the provided index. Only valid if the Json instance
@@ -1252,7 +1252,7 @@ public:
      * @throws JsonException If the Json instance is not an object or the key value is invalid.
      */
     template <typename T, enable_if_all<JsonTraits::is_string_like<T>> = 0>
-    size_type count(const T &key) const;
+    size_type count(T key) const;
 
     /**
      * Search for an element in the Json instance with a given key. Only valid if the Json instance
@@ -1269,7 +1269,7 @@ public:
      * @throws JsonException If the Json instance is not an object or the key value is invalid.
      */
     template <typename T, enable_if_all<JsonTraits::is_string_like<T>> = 0>
-    iterator find(const T &key);
+    iterator find(T key);
 
     /**
      * Search for an element in the Json instance with a given key. Only valid if the Json instance
@@ -1286,7 +1286,7 @@ public:
      * @throws JsonException If the Json instance is not an object or the key value is invalid.
      */
     template <typename T, enable_if_all<JsonTraits::is_string_like<T>> = 0>
-    const_iterator find(const T &key) const;
+    const_iterator find(T key) const;
 
     /**
      * Check if there is an element in the Json instance with a given key. Only valid if the Json
@@ -1302,7 +1302,7 @@ public:
      * @throws JsonException If the Json instance is not an object or the key value is invalid.
      */
     template <typename T, enable_if_all<JsonTraits::is_string_like<T>> = 0>
-    bool contains(const T &key) const;
+    bool contains(T key) const;
 
     //==============================================================================================
     //
@@ -1365,7 +1365,7 @@ private:
      * @throws JsonException If the string-like value is not valid.
      */
     template <typename T, enable_if_all<JsonTraits::is_string_like<T>> = 0>
-    static JsonTraits::string_type convert_to_string(const T &value);
+    static JsonTraits::string_type convert_to_string(T value);
 
     /**
      * Validate the string for compliance according to https://www.json.org. Validation includes
@@ -1457,56 +1457,52 @@ private:
 
 //==================================================================================================
 template <typename T, enable_if_all<JsonTraits::is_string_like<T>>>
-Json::Json(const T &value) noexcept(false) : m_value(convert_to_string(value))
+Json::Json(T value) noexcept(false) : m_value(convert_to_string(std::move(value)))
 {
 }
 
 //==================================================================================================
 template <typename T, enable_if_all<JsonTraits::is_object<T>>>
-Json::Json(const T &value) noexcept(false) : m_value(JsonTraits::object_type())
+Json::Json(T value) noexcept(false) : m_value(JsonTraits::object_type())
 {
-    auto &storage = std::get<JsonTraits::object_type>(m_value);
-
-    for (const auto &it : value)
-    {
-        storage[convert_to_string(it.first)] = Json(it.second);
-    }
+    merge(std::move(value));
 }
 
 //==================================================================================================
 template <typename T, enable_if_all<JsonTraits::is_array<T>>>
-Json::Json(const T &value) noexcept(false) : m_value(JsonTraits::array_type())
+Json::Json(T value) noexcept(false) : m_value(JsonTraits::array_type())
 {
-    auto &storage = std::get<JsonTraits::array_type>(m_value);
+    using move_iterator_type = std::move_iterator<typename T::iterator>;
 
-    for (const auto &it : value)
+    std::get<JsonTraits::array_type>(m_value).reserve(JsonTraits::ArrayTraits::size(value));
+
+    for (auto it = move_iterator_type(value.begin()); it != move_iterator_type(value.end()); ++it)
     {
-        auto copy = static_cast<typename T::value_type>(it);
-        JsonTraits::ArrayTraits::append(storage, std::move(copy));
+        push_back(*it);
     }
 }
 
 //==================================================================================================
 template <typename T, enable_if_all<JsonTraits::is_boolean<T>>>
-Json::Json(const T &value) noexcept : m_value(static_cast<JsonTraits::boolean_type>(value))
+Json::Json(T value) noexcept : m_value(static_cast<JsonTraits::boolean_type>(value))
 {
 }
 
 //==================================================================================================
 template <typename T, enable_if_all<JsonTraits::is_signed_integer<T>>>
-Json::Json(const T &value) noexcept : m_value(static_cast<JsonTraits::signed_type>(value))
+Json::Json(T value) noexcept : m_value(static_cast<JsonTraits::signed_type>(value))
 {
 }
 
 //==================================================================================================
 template <typename T, enable_if_all<JsonTraits::is_unsigned_integer<T>>>
-Json::Json(const T &value) noexcept : m_value(static_cast<JsonTraits::unsigned_type>(value))
+Json::Json(T value) noexcept : m_value(static_cast<JsonTraits::unsigned_type>(value))
 {
 }
 
 //==================================================================================================
 template <typename T, enable_if_all<JsonTraits::is_floating_point<T>>>
-Json::Json(const T &value) noexcept : m_value(static_cast<JsonTraits::float_type>(value))
+Json::Json(T value) noexcept : m_value(static_cast<JsonTraits::float_type>(value))
 {
 }
 
@@ -1665,86 +1661,85 @@ Json::operator T() const noexcept(false)
 
 //==================================================================================================
 template <typename T, enable_if_all<JsonTraits::is_string_like<T>>>
-Json::reference Json::at(const T &key)
+Json::reference Json::at(T key)
 {
-    if (is_object())
+    if (!is_object())
     {
-        auto &value = std::get<JsonTraits::object_type>(m_value);
-        auto it = value.find(convert_to_string(key));
-
-        if (it == value.end())
-        {
-            throw JsonException(*this, String::format("Given key (%s) not found", key));
-        }
-
-        return it->second;
+        throw JsonException(*this, "JSON type invalid for operator[key]");
     }
 
-    throw JsonException(*this, "JSON type invalid for operator[key]");
+    auto &value = std::get<JsonTraits::object_type>(m_value);
+    auto it = value.find(convert_to_string(std::move(key)));
+
+    if (it == value.end())
+    {
+        throw JsonException(*this, String::format("Given key (%s) not found", key));
+    }
+
+    return it->second;
 }
 
 //==================================================================================================
 template <typename T, enable_if_all<JsonTraits::is_string_like<T>>>
-Json::const_reference Json::at(const T &key) const
+Json::const_reference Json::at(T key) const
 {
-    if (is_object())
+    if (!is_object())
     {
-        const auto &value = std::get<JsonTraits::object_type>(m_value);
-        const auto it = value.find(convert_to_string(key));
-
-        if (it == value.end())
-        {
-            throw JsonException(*this, String::format("Given key (%s) not found", key));
-        }
-
-        return it->second;
+        throw JsonException(*this, "JSON type invalid for operator[key]");
     }
 
-    throw JsonException(*this, "JSON type invalid for operator[key]");
+    const auto &value = std::get<JsonTraits::object_type>(m_value);
+    const auto it = value.find(convert_to_string(std::move(key)));
+
+    if (it == value.end())
+    {
+        throw JsonException(*this, String::format("Given key (%s) not found", key));
+    }
+
+    return it->second;
 }
 
 //==================================================================================================
 template <typename T, enable_if_all<JsonTraits::is_string_like<T>>>
-Json::reference Json::operator[](const T &key)
+Json::reference Json::operator[](T key)
 {
     if (is_null())
     {
         m_value = JsonTraits::object_type();
     }
-
-    if (is_object())
+    else if (!is_object())
     {
-        auto &value = std::get<JsonTraits::object_type>(m_value);
-        return value[convert_to_string(key)];
+        throw JsonException(*this, "JSON type invalid for operator[key]");
     }
 
-    throw JsonException(*this, "JSON type invalid for operator[key]");
+    auto &value = std::get<JsonTraits::object_type>(m_value);
+    return value[convert_to_string(std::move(key))];
 }
 
 //==================================================================================================
 template <typename T, enable_if_all<JsonTraits::is_string_like<T>>>
-Json::const_reference Json::operator[](const T &key) const
+Json::const_reference Json::operator[](T key) const
 {
     return at(key);
 }
 
 //==================================================================================================
 template <typename Key, enable_if_all<JsonTraits::is_string_like<Key>>>
-std::pair<Json::iterator, bool> Json::insert(const Key &key, const Json &value)
+std::pair<Json::iterator, bool> Json::insert(Key key, const Json &value)
 {
-    return object_inserter(std::make_pair(convert_to_string(key), value));
+    return object_inserter(std::make_pair(convert_to_string(std::move(key)), value));
 }
 
 //==================================================================================================
 template <typename Key, enable_if_all<JsonTraits::is_string_like<Key>>>
-std::pair<Json::iterator, bool> Json::insert(const Key &key, Json &&value)
+std::pair<Json::iterator, bool> Json::insert(Key key, Json &&value)
 {
-    return object_inserter(std::make_pair(convert_to_string(key), std::move(value)));
+    return object_inserter(std::make_pair(convert_to_string(std::move(key)), std::move(value)));
 }
 
 //==================================================================================================
 template <typename Key, enable_if_all<JsonTraits::is_string_like<Key>>>
-std::pair<Json::iterator, bool> Json::insert_or_assign(const Key &key, Json &&value)
+std::pair<Json::iterator, bool> Json::insert_or_assign(Key key, Json &&value)
 {
     auto result = insert(key, value);
 
@@ -1759,14 +1754,13 @@ std::pair<Json::iterator, bool> Json::insert_or_assign(const Key &key, Json &&va
 
 //==================================================================================================
 template <typename Key, typename Value, enable_if_all<JsonTraits::is_string_like<Key>>>
-std::pair<Json::iterator, bool> Json::emplace(const Key &key, Value &&value)
+std::pair<Json::iterator, bool> Json::emplace(Key key, Value &&value)
 {
     if (is_null())
     {
         m_value = JsonTraits::object_type();
     }
-
-    if (!is_object())
+    else if (!is_object())
     {
         throw JsonException(*this, "JSON type invalid for object emplacement");
     }
@@ -1774,7 +1768,7 @@ std::pair<Json::iterator, bool> Json::emplace(const Key &key, Value &&value)
     auto &storage = std::get<JsonTraits::object_type>(m_value);
     auto it = end();
 
-    auto result = storage.emplace(convert_to_string(key), std::forward<Value>(value));
+    auto result = storage.emplace(convert_to_string(std::move(key)), std::forward<Value>(value));
     it.m_iterator = result.first;
 
     return {it, result.second};
@@ -1788,8 +1782,7 @@ Json::reference Json::emplace_back(Args &&...args)
     {
         m_value = JsonTraits::array_type();
     }
-
-    if (!is_array())
+    else if (!is_array())
     {
         throw JsonException(*this, "JSON type invalid for array emplacement");
     }
@@ -1800,7 +1793,7 @@ Json::reference Json::emplace_back(Args &&...args)
 
 //==================================================================================================
 template <typename T, enable_if_all<JsonTraits::is_string_like<T>>>
-Json::size_type Json::erase(const T &key)
+Json::size_type Json::erase(T key)
 {
     if (!is_object())
     {
@@ -1808,58 +1801,52 @@ Json::size_type Json::erase(const T &key)
     }
 
     auto &value = std::get<JsonTraits::object_type>(m_value);
-    return value.erase(convert_to_string(key));
+    return value.erase(convert_to_string(std::move(key)));
 }
 
 //==================================================================================================
 template <typename T, enable_if_all<JsonTraits::is_string<T>>>
 void Json::swap(T &other)
 {
-    if (is_string())
-    {
-        T string = static_cast<T>(*this);
-
-        *this = std::move(other);
-        other = std::move(string);
-    }
-    else
+    if (!is_string())
     {
         throw JsonException(*this, "JSON type invalid for swap(string)");
     }
+
+    T string = static_cast<T>(*this);
+
+    *this = std::move(other);
+    other = std::move(string);
 }
 
 //==================================================================================================
 template <typename T, enable_if_all<JsonTraits::is_object<T>>>
 void Json::swap(T &other)
 {
-    if (is_object())
-    {
-        T object = static_cast<T>(*this);
-
-        *this = std::move(other);
-        other = std::move(object);
-    }
-    else
+    if (!is_object())
     {
         throw JsonException(*this, "JSON type invalid for swap(object)");
     }
+
+    T object = static_cast<T>(*this);
+
+    *this = std::move(other);
+    other = std::move(object);
 }
 
 //==================================================================================================
 template <typename T, enable_if_all<JsonTraits::is_array<T>>>
 void Json::swap(T &other)
 {
-    if (is_array())
-    {
-        T array = static_cast<T>(*this);
-
-        *this = std::move(other);
-        other = std::move(array);
-    }
-    else
+    if (!is_array())
     {
         throw JsonException(*this, "JSON type invalid for swap(array)");
     }
+
+    T array = static_cast<T>(*this);
+
+    *this = std::move(other);
+    other = std::move(array);
 }
 
 //==================================================================================================
@@ -1870,8 +1857,7 @@ void Json::merge(T &other)
     {
         m_value = JsonTraits::object_type();
     }
-
-    if (!is_object())
+    else if (!is_object())
     {
         throw JsonException(*this, "JSON type invalid for merging");
     }
@@ -1885,7 +1871,7 @@ void Json::merge(T &other)
         }
         else
         {
-            emplace(it->first, std::move(it->second));
+            insert(std::move(it->first), std::move(it->second));
             it = other.erase(it);
         }
     }
@@ -1899,8 +1885,7 @@ void Json::merge(T &&other)
     {
         m_value = JsonTraits::object_type();
     }
-
-    if (!is_object())
+    else if (!is_object())
     {
         throw JsonException(*this, "JSON type invalid for merging");
     }
@@ -1910,74 +1895,74 @@ void Json::merge(T &&other)
     {
         if (!contains(it.first))
         {
-            emplace(it.first, std::move(it.second));
+            insert(std::move(it.first), std::move(it.second));
         }
     }
 }
 
 //==================================================================================================
 template <typename T, enable_if_all<JsonTraits::is_string_like<T>>>
-Json::size_type Json::count(const T &key) const
+Json::size_type Json::count(T key) const
 {
-    if (is_object())
+    if (!is_object())
     {
-        const auto &value = std::get<JsonTraits::object_type>(m_value);
-        return value.count(convert_to_string(key));
+        throw JsonException(*this, "JSON type invalid for count(key)");
     }
 
-    throw JsonException(*this, "JSON type invalid for count(key)");
+    const auto &value = std::get<JsonTraits::object_type>(m_value);
+    return value.count(convert_to_string(std::move(key)));
 }
 
 //==================================================================================================
 template <typename T, enable_if_all<JsonTraits::is_string_like<T>>>
-Json::iterator Json::find(const T &key)
+Json::iterator Json::find(T key)
 {
-    if (is_object())
+    if (!is_object())
     {
-        auto &value = std::get<JsonTraits::object_type>(m_value);
-
-        auto it = end();
-        it.m_iterator = value.find(convert_to_string(key));
-
-        return it;
+        throw JsonException(*this, "JSON type invalid for find(key)");
     }
 
-    throw JsonException(*this, "JSON type invalid for find(key)");
+    auto &value = std::get<JsonTraits::object_type>(m_value);
+
+    auto it = end();
+    it.m_iterator = value.find(convert_to_string(std::move(key)));
+
+    return it;
 }
 
 //==================================================================================================
 template <typename T, enable_if_all<JsonTraits::is_string_like<T>>>
-Json::const_iterator Json::find(const T &key) const
+Json::const_iterator Json::find(T key) const
 {
-    if (is_object())
+    if (!is_object())
     {
-        const auto &value = std::get<JsonTraits::object_type>(m_value);
-
-        auto it = cend();
-        it.m_iterator = value.find(convert_to_string(key));
-
-        return it;
+        throw JsonException(*this, "JSON type invalid for find(key)");
     }
 
-    throw JsonException(*this, "JSON type invalid for find(key)");
+    const auto &value = std::get<JsonTraits::object_type>(m_value);
+
+    auto it = cend();
+    it.m_iterator = value.find(convert_to_string(std::move(key)));
+
+    return it;
 }
 
 //==================================================================================================
 template <typename T, enable_if_all<JsonTraits::is_string_like<T>>>
-bool Json::contains(const T &key) const
+bool Json::contains(T key) const
 {
-    if (is_object())
+    if (!is_object())
     {
-        const auto &value = std::get<JsonTraits::object_type>(m_value);
-        return value.find(convert_to_string(key)) != value.end();
+        throw JsonException(*this, "JSON type invalid for contains(key)");
     }
 
-    throw JsonException(*this, "JSON type invalid for contains(key)");
+    const auto &value = std::get<JsonTraits::object_type>(m_value);
+    return value.find(convert_to_string(std::move(key))) != value.end();
 }
 
 //==================================================================================================
 template <typename T, enable_if_all<JsonTraits::is_string_like<T>>>
-JsonTraits::string_type Json::convert_to_string(const T &value)
+JsonTraits::string_type Json::convert_to_string(T value)
 {
     using StringType = BasicString<JsonTraits::is_string_like_t<T>>;
 

--- a/fly/types/json/json.hpp
+++ b/fly/types/json/json.hpp
@@ -187,11 +187,6 @@ public:
     using const_reverse_iterator = detail::JsonReverseIterator<const_iterator>;
 
     /**
-     * Alias for a basic_stringstream with the JSON string type.
-     */
-    using stringstream_type = std::basic_stringstream<JsonTraits::char_type>;
-
-    /**
      * Default constructor. Intializes the Json instance to a null value.
      */
     Json() = default;
@@ -1518,7 +1513,7 @@ Json::operator T() const noexcept
     }
     else
     {
-        stringstream_type stream;
+        std::basic_stringstream<JsonTraits::char_type> stream;
         stream << *this;
 
         value = stream.str();

--- a/fly/types/json/json.hpp
+++ b/fly/types/json/json.hpp
@@ -1966,9 +1966,19 @@ JsonTraits::string_type Json::convert_to_string(T value)
 {
     using StringType = BasicString<JsonTraits::is_string_like_t<T>>;
 
-    if (auto converted = StringType::template convert<JsonTraits::string_type>(value); converted)
+    if constexpr (std::is_same_v<typename StringType::string_type, JsonTraits::string_type>)
     {
-        return validate_string(std::move(converted.value()));
+        if (StringType::validate(value))
+        {
+            return validate_string(std::move(value));
+        }
+    }
+    else
+    {
+        if (auto result = StringType::template convert<JsonTraits::string_type>(value); result)
+        {
+            return validate_string(std::move(result.value()));
+        }
     }
 
     throw JsonException("Could not convert string-like type to a JSON string");

--- a/fly/types/json/json_traits.hpp
+++ b/fly/types/json/json_traits.hpp
@@ -120,10 +120,8 @@ struct JsonTraits
      * Define a trait for testing if type T is any JSON number type.
      */
     template <typename T>
-    using is_number = std::disjunction<
-        is_signed_integer<std::decay_t<T>>,
-        is_unsigned_integer<std::decay_t<T>>,
-        is_floating_point<std::decay_t<T>>>;
+    using is_number =
+        std::disjunction<is_signed_integer<T>, is_unsigned_integer<T>, is_floating_point<T>>;
 
     template <typename T>
     inline static constexpr bool is_number_v = is_number<T>::value;

--- a/fly/types/json/json_traits.hpp
+++ b/fly/types/json/json_traits.hpp
@@ -36,8 +36,8 @@ struct JsonTraits
     using null_type = std::nullptr_t;
     using string_type = std::string;
     using boolean_type = bool;
-    using signed_type = std::intmax_t;
-    using unsigned_type = std::uintmax_t;
+    using signed_type = std::int64_t;
+    using unsigned_type = std::uint64_t;
     using float_type = long double;
     using object_type = std::map<string_type, Json>;
     using array_type = std::vector<Json>;

--- a/fly/types/json/json_traits.hpp
+++ b/fly/types/json/json_traits.hpp
@@ -189,6 +189,12 @@ struct JsonTraits
         {
         };
 
+        template <typename T, std::size_t N>
+        static inline std::size_t size(const std::array<T, N> &array)
+        {
+            return array.size();
+        }
+
         // std::deque
 
         template <typename... Args>
@@ -197,10 +203,16 @@ struct JsonTraits
         };
 
         template <typename... Args>
-        static void
+        static inline void
         append(std::deque<Args...> &array, typename std::deque<Args...>::value_type &&value)
         {
             array.push_back(std::move(value));
+        }
+
+        template <typename... Args>
+        static inline std::size_t size(const std::deque<Args...> &array)
+        {
+            return array.size();
         }
 
         // std::forward_list
@@ -211,7 +223,7 @@ struct JsonTraits
         };
 
         template <typename... Args>
-        static void append(
+        static inline void append(
             std::forward_list<Args...> &array,
             typename std::forward_list<Args...>::value_type &&value)
         {
@@ -226,6 +238,20 @@ struct JsonTraits
             array.insert_after(before_end, std::move(value));
         }
 
+        template <typename... Args>
+        static inline std::size_t size(const std::forward_list<Args...> &array)
+        {
+            std::size_t elements = 0;
+
+            for (const auto &element : array)
+            {
+                FLY_UNUSED(element);
+                ++elements;
+            }
+
+            return elements;
+        }
+
         // std::list
 
         template <typename... Args>
@@ -234,10 +260,16 @@ struct JsonTraits
         };
 
         template <typename... Args>
-        static void
+        static inline void
         append(std::list<Args...> &array, typename std::list<Args...>::value_type &&value)
         {
             array.push_back(std::move(value));
+        }
+
+        template <typename... Args>
+        static inline std::size_t size(const std::list<Args...> &array)
+        {
+            return array.size();
         }
 
         // std::multiset
@@ -248,10 +280,16 @@ struct JsonTraits
         };
 
         template <typename... Args>
-        static void
+        static inline void
         append(std::multiset<Args...> &array, typename std::multiset<Args...>::value_type &&value)
         {
             array.insert(std::move(value));
+        }
+
+        template <typename... Args>
+        static inline std::size_t size(const std::multiset<Args...> &array)
+        {
+            return array.size();
         }
 
         // std::set
@@ -262,9 +300,16 @@ struct JsonTraits
         };
 
         template <typename... Args>
-        static void append(std::set<Args...> &array, typename std::set<Args...>::value_type &&value)
+        static inline void
+        append(std::set<Args...> &array, typename std::set<Args...>::value_type &&value)
         {
             array.insert(std::move(value));
+        }
+
+        template <typename... Args>
+        static inline std::size_t size(const std::set<Args...> &array)
+        {
+            return array.size();
         }
 
         // std::unordered_multiset
@@ -275,11 +320,17 @@ struct JsonTraits
         };
 
         template <typename... Args>
-        static void append(
+        static inline void append(
             std::unordered_multiset<Args...> &array,
             typename std::unordered_multiset<Args...>::value_type &&value)
         {
             array.insert(std::move(value));
+        }
+
+        template <typename... Args>
+        static inline std::size_t size(const std::unordered_multiset<Args...> &array)
+        {
+            return array.size();
         }
 
         // std::unordered_set
@@ -290,11 +341,17 @@ struct JsonTraits
         };
 
         template <typename... Args>
-        static void append(
+        static inline void append(
             std::unordered_set<Args...> &array,
             typename std::unordered_set<Args...>::value_type &&value)
         {
             array.insert(std::move(value));
+        }
+
+        template <typename... Args>
+        static inline std::size_t size(const std::unordered_set<Args...> &array)
+        {
+            return array.size();
         }
 
         // std::vector
@@ -305,10 +362,16 @@ struct JsonTraits
         };
 
         template <typename... Args>
-        static void
+        static inline void
         append(std::vector<Args...> &array, typename std::vector<Args...>::value_type &&value)
         {
             array.push_back(std::move(value));
+        }
+
+        template <typename... Args>
+        static inline std::size_t size(const std::vector<Args...> &array)
+        {
+            return array.size();
         }
     };
 

--- a/fly/types/string/detail/string_traits.hpp
+++ b/fly/types/string/detail/string_traits.hpp
@@ -101,9 +101,6 @@ struct BasicStringTraits
     using char_type = typename StringType::value_type;
     using view_type = std::basic_string_view<char_type>;
 
-    using iterator = typename StringType::iterator;
-    using const_iterator = typename StringType::const_iterator;
-
     using codepoint_type = std::uint32_t;
 
     using streamer_traits = BasicStringStreamerTraits<StringType>;

--- a/fly/types/string/detail/string_traits.hpp
+++ b/fly/types/string/detail/string_traits.hpp
@@ -97,6 +97,7 @@ struct BasicStringTraits
     /**
      * Aliases for STL types that use std::basic_string specializations as a template type.
      */
+    using string_type = StringType;
     using size_type = typename StringType::size_type;
     using char_type = typename StringType::value_type;
     using view_type = std::basic_string_view<char_type>;

--- a/fly/types/string/detail/string_unicode.hpp
+++ b/fly/types/string/detail/string_unicode.hpp
@@ -33,6 +33,19 @@ class BasicStringUnicode
 
 public:
     /**
+     * Validate that a string is strictly Unicode compliant.
+     *
+     * @tparam IteratorType The type of the encoded Unicode string's iterator.
+     *
+     * @param it Pointer to the beginning of the encoded Unicode string.
+     * @param end Pointer to the end of the encoded Unicode string.
+     *
+     * @return True if the string is Unicode compliant.
+     */
+    template <typename IteratorType>
+    static bool validate_encoding(IteratorType &it, const IteratorType &end);
+
+    /**
      * Convert the Unicode encoding of a string to another encoding.
      *
      * @tparam DesiredStringType The type of string to convert to.
@@ -298,6 +311,22 @@ private:
     static constexpr char_type s_lower_u = FLY_CHR(char_type, 'u');
     static constexpr char_type s_upper_u = FLY_CHR(char_type, 'U');
 };
+
+//==================================================================================================
+template <typename StringType>
+template <typename IteratorType>
+bool BasicStringUnicode<StringType>::validate_encoding(IteratorType &it, const IteratorType &end)
+{
+    while (it != end)
+    {
+        if (!decode_codepoint(it, end))
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
 
 //==================================================================================================
 template <typename StringType>

--- a/fly/types/string/string.hpp
+++ b/fly/types/string/string.hpp
@@ -60,8 +60,6 @@ public:
     using size_type = typename traits::size_type;
     using char_type = typename traits::char_type;
     using view_type = typename traits::view_type;
-    using iterator = typename traits::iterator;
-    using const_iterator = typename traits::const_iterator;
     using codepoint_type = typename traits::codepoint_type;
     using ostream_type = typename traits::ostream_type;
     using streamed_type = typename traits::streamed_type;
@@ -178,13 +176,16 @@ public:
      * iterator. If successful, after invoking this method, that iterator will point at the first
      * character after the Unicode codepoint in the source string.
      *
+     * @tparam IteratorType The type of the encoded Unicode codepoint's iterator.
+     *
      * @param it Pointer to the beginning of the encoded Unicode codepoint.
      * @param end Pointer to the end of the encoded Unicode codepoint.
      *
      * @return If successful, the decoded Unicode codepoint. Otherwise, an unitialized value.
      */
+    template <typename IteratorType>
     static std::optional<codepoint_type>
-    decode_codepoint(const_iterator &it, const const_iterator &end);
+    decode_codepoint(IteratorType &it, const IteratorType &end);
 
     /**
      * Encode a single Unicode codepoint.
@@ -243,6 +244,7 @@ public:
      *        the encoding will of the form \Unnnnnnnn.
      *
      * @tparam UnicodePrefix The Unicode prefix character ('u' or 'U').
+     * @tparam IteratorType The type of the encoded Unicode codepoint's iterator.
      *
      * @param it Pointer to the beginning of the encoded Unicode codepoint.
      * @param end Pointer to the end of the encoded Unicode codepoint.
@@ -250,9 +252,8 @@ public:
      * @return If successful, a string containing the escaped Unicode codepoint. Otherwise, an
      *         unitialized value.
      */
-    template <char UnicodePrefix = 'U'>
-    static std::optional<StringType>
-    escape_codepoint(const_iterator &it, const const_iterator &end);
+    template <char UnicodePrefix = 'U', typename IteratorType>
+    static std::optional<StringType> escape_codepoint(IteratorType &it, const IteratorType &end);
 
     /**
      * Unescape all Unicode codepoints in a string.
@@ -281,14 +282,16 @@ public:
      *     2. \unnnn\unnnn surrogate pairs for Unicode codepoints in the range [U+10000, U+10FFFF].
      *     3. \Unnnnnnnn for all Unicode codepoints.
      *
+     * @tparam IteratorType The type of the escaped Unicode string's iterator.
+     *
      * @param it Pointer to the beginning of the escaped character sequence.
      * @param end Pointer to the end of the escaped character sequence.
      *
      * @return If successful, a string containing the unescaped Unicode codepoint. Otherwise, an
      *         unitialized value.
      */
-    static std::optional<StringType>
-    unescape_codepoint(const_iterator &it, const const_iterator &end);
+    template <typename IteratorType>
+    static std::optional<StringType> unescape_codepoint(IteratorType &it, const IteratorType &end);
 
     /**
      * Format an integer as a hexadecimal string.
@@ -624,7 +627,8 @@ bool BasicString<StringType>::wildcard_match(const StringType &source, const Str
 
 //==================================================================================================
 template <typename StringType>
-auto BasicString<StringType>::decode_codepoint(const_iterator &it, const const_iterator &end)
+template <typename IteratorType>
+auto BasicString<StringType>::decode_codepoint(IteratorType &it, const IteratorType &end)
     -> std::optional<codepoint_type>
 {
     return unicode::decode_codepoint(it, end);
@@ -664,9 +668,9 @@ std::optional<StringType> BasicString<StringType>::escape_all_codepoints(const S
 
 //==================================================================================================
 template <typename StringType>
-template <char UnicodePrefix>
+template <char UnicodePrefix, typename IteratorType>
 std::optional<StringType>
-BasicString<StringType>::escape_codepoint(const_iterator &it, const const_iterator &end)
+BasicString<StringType>::escape_codepoint(IteratorType &it, const IteratorType &end)
 {
     return unicode::template escape_codepoint<UnicodePrefix>(it, end);
 }
@@ -717,8 +721,9 @@ std::optional<StringType> BasicString<StringType>::unescape_all_codepoints(const
 
 //==================================================================================================
 template <typename StringType>
+template <typename IteratorType>
 std::optional<StringType>
-BasicString<StringType>::unescape_codepoint(const_iterator &it, const const_iterator &end)
+BasicString<StringType>::unescape_codepoint(IteratorType &it, const IteratorType &end)
 {
     return unicode::unescape_codepoint(it, end);
 }

--- a/test/types/json_modifiers.cpp
+++ b/test/types/json_modifiers.cpp
@@ -272,28 +272,32 @@ CATCH_JSON_TEST_CASE("JsonModifiers")
 
     CATCH_SECTION("Push a value into a JSON array")
     {
-        const fly::Json value = 3;
+        const fly::Json value1 = 3;
+        const fly::Json value2 = 4;
 
         if constexpr (fly::test::is_null_or_other_type_v<json_type, fly::JsonTraits::array_type>)
         {
-            const auto size_before = json.size();
-            json.push_back(value);
-            const auto size_after = json.size();
+            const auto starting_size = json.size();
 
-            CATCH_CHECK((size_after - size_before) == 1);
-            CATCH_CHECK(json[size_after - 1] == value);
+            json.push_back(value1);
+            CATCH_CHECK(json.size() == (starting_size + 1));
+            CATCH_CHECK(json.back() == 3);
+
+            json.push_back(value2);
+            CATCH_CHECK(json.size() == (starting_size + 2));
+            CATCH_CHECK(json.back() == 4);
         }
         else if constexpr (std::is_same_v<json_type, fly::JsonTraits::object_type>)
         {
             CATCH_CHECK_THROWS_JSON(
-                json.push_back(value),
+                json.push_back(value1),
                 "JSON type invalid for array insertion: (%s)",
                 json);
         }
         else
         {
             CATCH_CHECK_THROWS_ITERATOR(
-                json.push_back(value),
+                json.push_back(value1),
                 "JSON type invalid for iteration: (%s)",
                 json);
         }
@@ -301,28 +305,32 @@ CATCH_JSON_TEST_CASE("JsonModifiers")
 
     CATCH_SECTION("Push a moved value into a JSON array")
     {
-        fly::Json value = 3;
+        fly::Json value1 = 3;
+        fly::Json value2 = 4;
 
         if constexpr (fly::test::is_null_or_other_type_v<json_type, fly::JsonTraits::array_type>)
         {
-            const auto size_before = json.size();
-            json.push_back(std::move(value));
-            const auto size_after = json.size();
+            const auto starting_size = json.size();
 
-            CATCH_CHECK((size_after - size_before) == 1);
-            CATCH_CHECK(json[size_after - 1] == 3);
+            json.push_back(std::move(value1));
+            CATCH_CHECK(json.size() == (starting_size + 1));
+            CATCH_CHECK(json.back() == 3);
+
+            json.push_back(std::move(value2));
+            CATCH_CHECK(json.size() == (starting_size + 2));
+            CATCH_CHECK(json.back() == 4);
         }
         else if constexpr (std::is_same_v<json_type, fly::JsonTraits::object_type>)
         {
             CATCH_CHECK_THROWS_JSON(
-                json.push_back(std::move(value)),
+                json.push_back(std::move(value1)),
                 "JSON type invalid for array insertion: (%s)",
                 json);
         }
         else
         {
             CATCH_CHECK_THROWS_ITERATOR(
-                json.push_back(std::move(value)),
+                json.push_back(std::move(value1)),
                 "JSON type invalid for iteration: (%s)",
                 json);
         }

--- a/test/types/string_unicode.cpp
+++ b/test/types/string_unicode.cpp
@@ -41,6 +41,7 @@ CATCH_TEMPLATE_TEST_CASE(
         auto begin = test.cbegin();
         const auto end = test.cend();
 
+        CATCH_CHECK_FALSE(BasicString::validate(test));
         CATCH_CHECK_FALSE(BasicString::escape_codepoint(begin, end));
         CATCH_CHECK_FALSE(BasicString::escape_all_codepoints(test));
     };
@@ -75,6 +76,7 @@ CATCH_TEMPLATE_TEST_CASE(
         auto begin = test.cbegin();
         const auto end = test.cend();
 
+        CATCH_CHECK(BasicString::validate(test));
         CATCH_CHECK_FALSE(BasicString::decode_codepoint(begin, end));
 
         actual = BasicString::escape_all_codepoints(test);
@@ -164,6 +166,7 @@ CATCH_TEMPLATE_TEST_CASE(
                 auto begin = test.cbegin();
                 const auto end = test.cend();
 
+                CATCH_CHECK_FALSE(BasicString::validate(test));
                 CATCH_CHECK_FALSE(BasicString::escape_codepoint(begin, end));
                 CATCH_CHECK_FALSE(BasicString::escape_all_codepoints(test));
             }
@@ -301,6 +304,8 @@ CATCH_TEMPLATE_TEST_CASE(
             const StringType test = make_string({ch});
             std::optional<StringType> actual;
 
+            CATCH_CHECK(BasicString::validate(test));
+
             actual = BasicString::encode_codepoint(ch);
             CATCH_CHECK(actual == test);
 
@@ -355,6 +360,9 @@ CATCH_TEMPLATE_TEST_CASE(
             [](StringType &&test, StringType &&expected, auto prefix, bool one_char = true)
         {
             CATCH_CAPTURE(test);
+
+            CATCH_CHECK(BasicString::validate(test));
+            CATCH_CHECK(BasicString::validate(expected));
 
             auto begin = test.cbegin();
             const auto end = test.cend();
@@ -485,6 +493,9 @@ CATCH_TEMPLATE_TEST_CASE(
         {
             CATCH_CAPTURE(test);
 
+            CATCH_CHECK(BasicString::validate(test));
+            CATCH_CHECK(BasicString::validate(expected));
+
             auto begin = test.cbegin();
             const auto end = test.cend();
 
@@ -567,6 +578,8 @@ CATCH_TEMPLATE_TEST_CASE(
                 CATCH_CAPTURE(test);
                 CATCH_CAPTURE(line);
 
+                CATCH_CHECK(BasicString::validate(test));
+
                 auto it = test.cbegin();
                 const auto end = test.cend();
 
@@ -579,6 +592,8 @@ CATCH_TEMPLATE_TEST_CASE(
             {
                 CATCH_CAPTURE(test);
                 CATCH_CAPTURE(line);
+
+                CATCH_CHECK(BasicString::validate(test));
 
                 std::size_t index = 0;
 
@@ -599,6 +614,8 @@ CATCH_TEMPLATE_TEST_CASE(
             {
                 CATCH_CAPTURE(test);
                 CATCH_CAPTURE(line);
+
+                CATCH_CHECK_FALSE(BasicString::validate(test));
 
                 const auto end = test.cend();
                 std::size_t actual = 0;


### PR DESCRIPTION
Heavily reduce the amount of string copying involved in these classes.
If the caller is able to std::move a string when creating a JSON object,
there will now be zero copies of that string created. All modifications
(e.g. escaped control or Unicode characters) are made in place.

Overall, since the beginning of improving JSON performance, release build
runtime of the all_unicode.json test decreased from ~2.3 seconds to ~0.4
seconds. Debug runtime decreased from ~29.6 seconds to ~12.7 seconds.