### PR TITLE
Improve Base64 decoder performance by error checking only when needed

### DIFF
--- a/bench/coders/README.md
+++ b/bench/coders/README.md
@@ -22,8 +22,8 @@ and 3/4 for decoding.
 
 | Direction | Duration (ms) | Speed (MB/s) | Ratio (%) |
 | :--       |           --: |          --: |       --: |
-| Encode    |       214.870 |      443.837 |   133.333 |
-| Decode    |       288.017 |      441.490 |    75.000 |
+| Encode    |       217.510 |      438.450 |   133.333 |
+| Decode    |       231.091 |      550.245 |    75.000 |
 
 ## Profile
 
@@ -79,11 +79,7 @@ Each sample counts as 0.01 seconds.
 A profile of the Base64 encoder:
 
 ```
-Each sample counts as 0.01 seconds.
-  %   cumulative   self              self     total
- time   seconds   seconds    calls  ms/call  ms/call  name
- 81.82      0.09     0.09 33333334     0.00     0.00  fly::Base64Coder::encode_chunk(char const*, char*) const
- 18.18      0.11     0.02        1    20.00   110.00  fly::Base64Coder::encode_internal(std::istream&, std::ostream&)
+100.00      0.11     0.11        1   110.00   110.00  fly::Base64Coder::encode_internal(std::istream&, std::ostream&)
   0.00      0.11     0.00     1194     0.00     0.00  std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release()
   0.00      0.11     0.00     1159     0.00     0.00  std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
   0.00      0.11     0.00     1009     0.00     0.00  std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >::vector(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&)
@@ -98,12 +94,11 @@ A profile of the Base64 decoder:
 Each sample counts as 0.01 seconds.
   %   cumulative   self              self     total
  time   seconds   seconds    calls  ms/call  ms/call  name
- 72.73      0.08     0.08 33333334     0.00     0.00  fly::Base64Coder::decode_chunk(char const*, char*) const
- 27.27      0.11     0.03        1    30.00   110.00  fly::Base64Coder::decode_internal(std::istream&, std::ostream&)
-  0.00      0.11     0.00     1194     0.00     0.00  std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release()
-  0.00      0.11     0.00     1159     0.00     0.00  std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
-  0.00      0.11     0.00     1009     0.00     0.00  std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >::vector(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&)
-  0.00      0.11     0.00      140     0.00     0.00  std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_dispose()
-  0.00      0.11     0.00      117     0.00     0.00  void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<char const*>(char const*, char const*, std::forward_iterator_tag)
-  0.00      0.11     0.00       83     0.00     0.00  void fly::detail::BasicStringStreamer<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::stream_char<char>(std::ostream&, char)
+100.00      0.15     0.15        1   150.00   150.00  fly::Base64Coder::decode_internal(std::istream&, std::ostream&)
+  0.00      0.15     0.00     1194     0.00     0.00  std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release()
+  0.00      0.15     0.00     1159     0.00     0.00  std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
+  0.00      0.15     0.00     1009     0.00     0.00  std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >::vector(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&)
+  0.00      0.15     0.00      140     0.00     0.00  std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_dispose()
+  0.00      0.15     0.00      117     0.00     0.00  void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<char const*>(char const*, char const*, std::forward_iterator_tag)
+  0.00      0.15     0.00       83     0.00     0.00  void fly::detail::BasicStringStreamer<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::stream_char<char>(std::ostream&, char)
 ```

--- a/fly/coders/base64/base64_coder.cpp
+++ b/fly/coders/base64/base64_coder.cpp
@@ -10,7 +10,7 @@ namespace fly {
 namespace {
 
     // The Base64 symbol table.
-    constexpr const std::array<std::ios::char_type, 64> s_base64_table = {
+    constexpr const std::array<std::ios::char_type, 64> s_base64_symbols = {
         'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
         'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
 
@@ -22,7 +22,8 @@ namespace {
         '+', '/',
     };
 
-    // A mapping of ASCII codes to their indices in the Base64 symbol table. Invalid values are -1.
+    // A mapping of ASCII codes to their indices in the Base64 symbol table. Invalid values are -1,
+    // and the padding symbol is -2.
     constexpr const std::array<std::ios::char_type, 256> s_base64_codes = {
         -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
         -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 62,
@@ -41,16 +42,84 @@ namespace {
     // The Base64 padding symbol for 4-byte encoding alignment.
     constexpr const std::ios::char_type *s_pad = "===";
 
-    template <typename T>
-    inline std::ios::char_type encoded_symbol(T index)
+    /**
+     * Encode a chunk of data into Base64 symbols.
+     *
+     * @param decoded Buffer holding the contents to encode.
+     * @param encoded Buffer to store the encoded contents.
+     */
+    void encode_chunk(const std::ios::char_type *decoded, std::ios::char_type *encoded)
     {
-        return s_base64_table[static_cast<std::size_t>(index)];
+        const auto &ch0 = decoded[0];
+        const auto &ch1 = decoded[1];
+        const auto &ch2 = decoded[2];
+
+        // First 6 bits of the first symbol.
+        encoded[0] = s_base64_symbols[static_cast<std::size_t>((ch0 & 0xfc) >> 2)];
+
+        // Last 2 bits of the first symbol, first 4 bits of the second symbol.
+        encoded[1] =
+            s_base64_symbols[static_cast<std::size_t>(((ch0 & 0x03) << 4) | ((ch1 & 0xf0) >> 4))];
+
+        // Last 4 bits of the second symbol, first 2 bits of the third symbol.
+        encoded[2] =
+            s_base64_symbols[static_cast<std::size_t>(((ch1 & 0x0f) << 2) | ((ch2 & 0xc0) >> 6))];
+
+        // Last 6 bits of the third symbol.
+        encoded[3] = s_base64_symbols[static_cast<std::size_t>(ch2 & 0x3f)];
     }
 
-    template <typename T>
-    inline std::ios::char_type decoded_symbol(T index)
+    /**
+     * Decode a chunk of Base64 symbols, conditionally allowing padding symbols.
+     *
+     * @tparam AllowPadding Provide std::true_type to allow padding symbols.
+     *
+     * @param encoded Buffer holding the contents to decode.
+     * @param decoded Buffer to store the decoded contents.
+     *
+     * @return If padding symbols are allowed, returns the number of non-padding symbols decoded. If
+     *         padding symbols are not allowed, returns true if all symbols were valid, non-padding
+     *         symbols.
+     */
+    template <typename AllowPadding>
+    std::conditional_t<AllowPadding::value, std::size_t, bool>
+    decode_chunk(const std::ios::char_type *encoded, std::ios::char_type *decoded)
     {
-        return s_base64_codes[static_cast<std::size_t>(index)];
+        const auto code0 = s_base64_codes[static_cast<std::size_t>(encoded[0])];
+        const auto code1 = s_base64_codes[static_cast<std::size_t>(encoded[1])];
+        const auto code2 = s_base64_codes[static_cast<std::size_t>(encoded[2])];
+        const auto code3 = s_base64_codes[static_cast<std::size_t>(encoded[3])];
+
+        // All 6 bits of the first code, first 2 bits of the second code.
+        decoded[0] = static_cast<std::ios::char_type>((code0 << 2) | ((code1 >> 4) & 0x03));
+
+        // Last 4 bits of the second code, first 4 bits of the third code.
+        decoded[1] =
+            static_cast<std::ios::char_type>(((code1 & 0x0f) << 4) | ((code2 & 0xfc) >> 2));
+
+        // Last 2 bits of the third code, all 6 bits of the fourth code.
+        decoded[2] = static_cast<std::ios::char_type>(((code2 & 0x03) << 6) | code3);
+
+        if constexpr (std::is_same_v<AllowPadding, std::true_type>)
+        {
+            if ((code0 == -1) || (code1 == -1) || (code2 == -1) || (code3 == -1))
+            {
+                // Fail if any of the codes were invalid.
+                return 0;
+            }
+            else if ((code0 == -2) || (code1 == -2) || ((code2 == -2) && (code3 != -2)))
+            {
+                // Fail if either of the first two coders were padding, or the third code was
+                // padding but the fourth was not.
+                return 0;
+            }
+
+            return (code2 == -2) ? 1 : ((code3 == -2) ? 2 : 3);
+        }
+        else
+        {
+            return !((code0 | code1 | code2 | code3) & 0x80);
+        }
     }
 
 } // namespace
@@ -61,30 +130,28 @@ bool Base64Coder::encode_internal(std::istream &decoded, std::ostream &encoded)
     do
     {
         decoded.read(m_decoded.data(), static_cast<std::streamsize>(m_decoded.size()));
-
         const auto bytes = static_cast<std::size_t>(decoded.gcount());
-        const auto chunks = bytes / s_decoded_chunk_size;
 
-        const std::ios::char_type *decoded_pos = m_decoded.data();
-        std::ios::char_type *encoded_pos = m_encoded.data();
+        const std::ios::char_type *decoding = m_decoded.data();
+        std::ios::char_type *encoding = m_encoded.data();
 
-        for (std::size_t i = 0; i < chunks; ++i)
+        for (std::size_t i = bytes / s_decoded_chunk_size; i > 0; --i)
         {
-            encode_chunk(decoded_pos, encoded_pos);
-            decoded_pos += s_decoded_chunk_size;
-            encoded_pos += s_encoded_chunk_size;
+            encode_chunk(decoding, encoding);
+            decoding += s_decoded_chunk_size;
+            encoding += s_encoded_chunk_size;
         }
 
-        encoded.write(m_encoded.data(), encoded_pos - m_encoded.data());
+        encoded.write(m_encoded.data(), encoding - m_encoded.data());
 
         // If the input stream was not evenly split into 3-byte chunks, add padding to the remaining
         // chunk.
         if (const auto remainder = bytes % s_decoded_chunk_size; remainder > 0)
         {
-            const auto end = static_cast<std::size_t>(decoded_pos - m_decoded.data()) + remainder;
+            const auto end = static_cast<std::size_t>(decoding - m_decoded.data()) + remainder;
             ::memset(m_decoded.data() + end, '\0', end);
 
-            encode_chunk(decoded_pos, m_encoded.data());
+            encode_chunk(decoding, m_encoded.data());
 
             encoded.write(m_encoded.data(), static_cast<std::streamsize>(remainder + 1));
             encoded.write(s_pad, static_cast<std::streamsize>(s_decoded_chunk_size - remainder));
@@ -100,81 +167,54 @@ bool Base64Coder::decode_internal(std::istream &encoded, std::ostream &decoded)
     do
     {
         encoded.read(m_encoded.data(), static_cast<std::streamsize>(m_encoded.size()));
-
         const auto bytes = static_cast<std::size_t>(encoded.gcount());
-        const auto chunks = bytes / s_encoded_chunk_size;
 
         if ((bytes % s_encoded_chunk_size) != 0)
         {
             decoded.setstate(std::ios::failbit);
             break;
         }
-
-        const std::ios::char_type *encoded_pos = m_encoded.data();
-        std::ios::char_type *decoded_pos = m_decoded.data();
-
-        for (std::size_t i = 0; i < chunks; ++i)
+        else if (bytes == 0)
         {
-            const std::size_t decoded_bytes = decode_chunk(encoded_pos, decoded_pos);
+            break;
+        }
 
-            if (decoded_bytes == 0)
+        const std::ios::char_type *encoding = m_encoded.data();
+        std::ios::char_type *decoding = m_decoded.data();
+
+        // For performance, the decoding loop is potentially broken up depending on whether this is
+        // the last read from the encoded stream. The goal is to keep the decoding loop as simple
+        // as possible; the decode_chunk method is specialized to disallow padding symbols within
+        // this loop. So on the last read from the encoded stream, break out of this loop one
+        // iteration early to then allow padding symbols.
+        for (std::size_t i = bytes / s_encoded_chunk_size - encoded.eof(); i > 0; --i)
+        {
+            if (!decode_chunk<std::false_type>(encoding, decoding))
             {
                 decoded.setstate(std::ios::failbit);
                 break;
             }
 
-            encoded_pos += s_encoded_chunk_size;
-            decoded_pos += decoded_bytes;
+            encoding += s_encoded_chunk_size;
+            decoding += s_decoded_chunk_size;
         }
 
-        decoded.write(m_decoded.data(), decoded_pos - m_decoded.data());
+        if (encoded.eof())
+        {
+            const std::size_t bytes_read = decode_chunk<std::true_type>(encoding, decoding);
+            decoding += bytes_read;
+
+            if (bytes_read == 0)
+            {
+                decoded.setstate(std::ios::failbit);
+                break;
+            }
+        }
+
+        decoded.write(m_decoded.data(), decoding - m_decoded.data());
     } while (encoded);
 
     return encoded.eof() && decoded.good();
-}
-
-//==================================================================================================
-void Base64Coder::encode_chunk(const std::ios::char_type *decoded, std::ios::char_type *encoded)
-    const
-{
-    // First 6 bits of the first symbol.
-    encoded[0] = encoded_symbol((decoded[0] & 0xfc) >> 2);
-
-    // Last 2 bits of the first symbol, first 4 bits of the second symbol.
-    encoded[1] = encoded_symbol(((decoded[0] & 0x03) << 4) | ((decoded[1] & 0xf0) >> 4));
-
-    // Last 4 bits of the second symbol, first 2 bits of the third symbol.
-    encoded[2] = encoded_symbol(((decoded[1] & 0x0f) << 2) | ((decoded[2] & 0xc0) >> 6));
-
-    // Last 6 bits of the third symbol.
-    encoded[3] = encoded_symbol(decoded[2] & 0x3f);
-}
-
-//==================================================================================================
-std::size_t
-Base64Coder::decode_chunk(const std::ios::char_type *encoded, std::ios::char_type *decoded) const
-{
-    const auto code0 = decoded_symbol(encoded[0]);
-    const auto code1 = decoded_symbol(encoded[1]);
-    const auto code2 = decoded_symbol(encoded[2]);
-    const auto code3 = decoded_symbol(encoded[3]);
-
-    if ((code0 == -1) || (code1 == -1) || (code2 == -1) || (code3 == -1))
-    {
-        return 0;
-    }
-
-    // All 6 bits of the first code, first 2 bits of the second code.
-    decoded[0] = static_cast<std::ios::char_type>((code0 << 2) | ((code1 >> 4) & 0x03));
-
-    // Last 4 bits of the second code, first 4 bits of the third code.
-    decoded[1] = static_cast<std::ios::char_type>(((code1 & 0x0f) << 4) | ((code2 & 0xfc) >> 2));
-
-    // Last 2 bits of the third code, all 6 bits of the fourth code.
-    decoded[2] = static_cast<std::ios::char_type>(((code2 & 0x03) << 6) | code3);
-
-    return s_decoded_chunk_size -
-        ((code0 == -2) ? 4 : ((code1 == -2) ? 3 : ((code2 == -2) ? 2 : ((code3 == -2) ? 1 : 0))));
 }
 
 } // namespace fly

--- a/fly/coders/base64/base64_coder.hpp
+++ b/fly/coders/base64/base64_coder.hpp
@@ -38,25 +38,6 @@ protected:
     bool decode_internal(std::istream &encoded, std::ostream &decoded) override;
 
 private:
-    /**
-     * Encode a chunk of data into Base64 symbols.
-     *
-     * @param decoded Buffer holding the contents to encode.
-     * @param encoded Buffer to store the encoded contents.
-     */
-    void encode_chunk(const std::ios::char_type *decoded, std::ios::char_type *encoded) const;
-
-    /**
-     * Decode a chunk of Base64 symbols.
-     *
-     * @param encoded Buffer holding the contents to decode.
-     * @param decoded Buffer to store the decoded contents.
-     *
-     * @return The number of valid, non-padding symbols decoded.
-     */
-    std::size_t
-    decode_chunk(const std::ios::char_type *encoded, std::ios::char_type *decoded) const;
-
     static constexpr const std::size_t s_decoded_chunk_size = 3;
     static constexpr const std::size_t s_encoded_chunk_size = 4;
 


### PR DESCRIPTION
The implementation of decoding a single chunk can be specialized to only
handle padding symbols on the very last chunk of the encoded stream. For
all other chunks, the decoder can effieciently check if any symbol is
invalid or padding by examining just the MSB.

With this change, Base64 decoding performance is improved by about 60ms
on the enwik8 file (about a 20% improvement).