### PR TITLE
Update BasicStringConverter to use std::from_chars when able

### DIFF
--- a/bench/json/README.md
+++ b/bench/json/README.md
@@ -23,17 +23,17 @@ could use some work :)
 
 | Parser   | Duration (ms) | Speed (MB/s) |
 | :--      |           --: |          --: |
-| libfly   |        93.639 |       22.926 |
-| boost    |        11.822 |      181.592 |
-| nlohmann |        54.645 |       39.285 |
+| libfly   |        88.977 |       24.127 |
+| boost    |        11.938 |      179.822 |
+| nlohmann |        54.969 |       39.054 |
 
 ### [gsoc-2018.json](/bench/json/data/gsoc-2018.json)
 
 | Parser   | Duration (ms) | Speed (MB/s) |
 | :--      |           --: |          --: |
-| libfly   |        42.389 |       74.869 |
-| boost    |        14.014 |      226.463 |
-| nlohmann |        33.634 |       94.359 |
+| libfly   |        41.520 |       76.437 |
+| boost    |        14.111 |      224.903 |
+| nlohmann |        32.927 |       96.386 |
 
 ## Profile
 

--- a/fly/types/string/detail/string_traits.hpp
+++ b/fly/types/string/detail/string_traits.hpp
@@ -128,14 +128,6 @@ struct BasicStringTraits
     inline static constexpr bool is_string_like_v = is_string_like<T>::value;
 
     /**
-     * Define a trait for testing if the STL has defined the std::stoi family of functions for
-     * StringType.
-     */
-    using has_stoi_family = any_same<StringType, std::string, std::wstring>;
-
-    inline static constexpr bool has_stoi_family_v = has_stoi_family::value;
-
-    /**
      * Define a trait for whether operator<< is defined for a type on the stream type used for
      * StringType.
      */

--- a/fly/types/string/string.hpp
+++ b/fly/types/string/string.hpp
@@ -783,7 +783,7 @@ std::optional<T> BasicString<StringType>::convert(const StringType &value)
 
         return std::nullopt;
     }
-    else if constexpr (traits::has_stoi_family_v)
+    else if constexpr (std::is_same_v<char_type, char>)
     {
         return detail::BasicStringConverter<StringType, T>::convert(value);
     }
@@ -792,9 +792,9 @@ std::optional<T> BasicString<StringType>::convert(const StringType &value)
         auto it = value.cbegin();
         const auto end = value.cend();
 
-        if (auto result = unicode::template convert_encoding<streamed_type>(it, end); result)
+        if (auto result = unicode::template convert_encoding<std::string>(it, end); result)
         {
-            return detail::BasicStringConverter<streamed_type, T>::convert(*result);
+            return detail::BasicStringConverter<std::string, T>::convert(*result);
         }
 
         return std::nullopt;

--- a/test/types/string_converter.cpp
+++ b/test/types/string_converter.cpp
@@ -1,3 +1,4 @@
+#include "fly/traits/traits.hpp"
 #include "fly/types/numeric/literals.hpp"
 #include "fly/types/string/string.hpp"
 
@@ -54,12 +55,8 @@ CATCH_TEMPLATE_TEST_CASE(
 {
     using StringType = TestType;
     using BasicString = fly::BasicString<StringType>;
-    using BasicStringTraits = fly::detail::BasicStringTraits<StringType>;
     using char_type = typename BasicString::char_type;
     using codepoint_type = typename BasicString::codepoint_type;
-    using streamed_type = typename BasicString::streamed_type;
-    using streamed_char = typename streamed_type::value_type;
-    using ustreamed_char = std::make_unsigned_t<streamed_char>;
 
     auto out_of_range_codepoint = []() -> StringType
     {
@@ -185,64 +182,6 @@ CATCH_TEMPLATE_TEST_CASE(
         }
     }
 
-    CATCH_SECTION("Convert a string to a Boolean")
-    {
-        StringType s;
-
-        s = FLY_STR(char_type, "0");
-        CATCH_CHECK(BasicString::template convert<bool>(s) == false);
-
-        s = FLY_STR(char_type, "1");
-        CATCH_CHECK(BasicString::template convert<bool>(s) == true);
-
-        s = FLY_STR(char_type, "-1");
-        CATCH_CHECK_FALSE(BasicString::template convert<bool>(s));
-
-        s = FLY_STR(char_type, "2");
-        CATCH_CHECK_FALSE(BasicString::template convert<bool>(s));
-
-        s = FLY_STR(char_type, "abc");
-        CATCH_CHECK_FALSE(BasicString::template convert<bool>(s));
-
-        s = FLY_STR(char_type, "2a");
-        CATCH_CHECK_FALSE(BasicString::template convert<bool>(s));
-    }
-
-    CATCH_SECTION("Convert a string to a streamable character type")
-    {
-        StringType s;
-
-        s = FLY_STR(char_type, "0");
-        CATCH_CHECK(BasicString::template convert<streamed_char>(s) == '\0');
-        CATCH_CHECK(BasicString::template convert<ustreamed_char>(s) == '\0');
-
-        s = FLY_STR(char_type, "65");
-        CATCH_CHECK(BasicString::template convert<streamed_char>(s) == 'A');
-        CATCH_CHECK(
-            BasicString::template convert<ustreamed_char>(s) == static_cast<ustreamed_char>(65));
-
-        s = FLY_STR(char_type, "abc");
-        CATCH_CHECK_FALSE(BasicString::template convert<streamed_char>(s));
-        CATCH_CHECK_FALSE(BasicString::template convert<ustreamed_char>(s));
-
-        s = FLY_STR(char_type, "2a");
-        CATCH_CHECK_FALSE(BasicString::template convert<streamed_char>(s));
-        CATCH_CHECK_FALSE(BasicString::template convert<ustreamed_char>(s));
-
-        if constexpr (BasicStringTraits::has_stoi_family_v)
-        {
-            CATCH_CHECK_FALSE(
-                BasicString::template convert<streamed_char>(minstr<StringType, streamed_char>()));
-            CATCH_CHECK_FALSE(
-                BasicString::template convert<streamed_char>(maxstr<StringType, streamed_char>()));
-
-            CATCH_CHECK_FALSE(BasicString::template convert<ustreamed_char>(
-                minstr<StringType, ustreamed_char>()));
-            CATCH_CHECK_FALSE(BasicString::template convert<ustreamed_char>(
-                maxstr<StringType, ustreamed_char>()));
-        }
-    }
-
     CATCH_SECTION("Convert a string to an 8-bit integer")
     {
         StringType s;
@@ -267,7 +206,7 @@ CATCH_TEMPLATE_TEST_CASE(
         CATCH_CHECK_FALSE(BasicString::template convert<std::int8_t>(s));
         CATCH_CHECK_FALSE(BasicString::template convert<std::uint8_t>(s));
 
-        if constexpr (BasicStringTraits::has_stoi_family_v)
+        if constexpr (fly::any_same_v<char_type, char, wchar_t>)
         {
             CATCH_CHECK_FALSE(
                 BasicString::template convert<std::int8_t>(minstr<StringType, std::int8_t>()));
@@ -305,7 +244,7 @@ CATCH_TEMPLATE_TEST_CASE(
         CATCH_CHECK_FALSE(BasicString::template convert<std::int16_t>(s));
         CATCH_CHECK_FALSE(BasicString::template convert<std::uint16_t>(s));
 
-        if constexpr (BasicStringTraits::has_stoi_family_v)
+        if constexpr (fly::any_same_v<char_type, char, wchar_t>)
         {
             CATCH_CHECK_FALSE(
                 BasicString::template convert<std::int16_t>(minstr<StringType, std::int16_t>()));
@@ -343,7 +282,7 @@ CATCH_TEMPLATE_TEST_CASE(
         CATCH_CHECK_FALSE(BasicString::template convert<std::int32_t>(s));
         CATCH_CHECK_FALSE(BasicString::template convert<std::uint32_t>(s));
 
-        if constexpr (BasicStringTraits::has_stoi_family_v)
+        if constexpr (fly::any_same_v<char_type, char, wchar_t>)
         {
             CATCH_CHECK_FALSE(
                 BasicString::template convert<std::int32_t>(minstr<StringType, std::int32_t>()));

--- a/test/types/string_traits.cpp
+++ b/test/types/string_traits.cpp
@@ -87,23 +87,6 @@ constexpr bool is_string_like(const T &)
     return false;
 }
 
-template <
-    typename StringType,
-    fly::enable_if_all<typename fly::detail::BasicStringTraits<StringType>::has_stoi_family> = 0>
-constexpr int call_stoi(const StringType &str)
-{
-    return std::stoi(str);
-}
-
-template <
-    typename StringType,
-    fly::enable_if_not_all<typename fly::detail::BasicStringTraits<StringType>::has_stoi_family> =
-        0>
-constexpr int call_stoi(const StringType &)
-{
-    return -1;
-}
-
 } // namespace
 
 CATCH_TEMPLATE_TEST_CASE(
@@ -127,27 +110,6 @@ CATCH_TEMPLATE_TEST_CASE(
     constexpr bool is_string8 = std::is_same_v<StringType, std::u8string>;
     constexpr bool is_string16 = std::is_same_v<StringType, std::u16string>;
     constexpr bool is_string32 = std::is_same_v<StringType, std::u32string>;
-
-    CATCH_SECTION("Check whether the STL defines the std::stoi family of functions via traits")
-    {
-        CATCH_CHECK(traits::has_stoi_family_v == (is_string || is_wstring));
-    }
-
-    CATCH_SECTION(
-        "Check whether the STL defines the std::stoi family of functions via SFINAE overloads")
-    {
-        const StringType s = FLY_STR(char_type, "123");
-        const int i = call_stoi(s);
-
-        if constexpr (is_string || is_wstring)
-        {
-            CATCH_CHECK(i == 123);
-        }
-        else
-        {
-            CATCH_CHECK(i == -1);
-        }
-    }
 
     CATCH_SECTION("Check whether types are supported strings via traits")
     {


### PR DESCRIPTION
Integral types can use std::from_chars, which is a bit better than the
std::stoi family. It is non-exceptional and performs range checking.
Floating point types are not supported by any compiler yet, though.

One downside is that std::from_chars only supports char, not wchar_t,
char8_t, etc. So string types other than std::string are first converted
to std::string. This is only slightly worse than the situation was with
std::stoi, as only char and wchar_t were supported.