### PR TITLE
Simplify string formatting loop

### DIFF
--- a/fly/types/string/detail/string_lexer.hpp
+++ b/fly/types/string/detail/string_lexer.hpp
@@ -25,8 +25,6 @@ class BasicStringLexer
     using view_type = typename traits::view_type;
 
 public:
-    using iterator = typename view_type::const_iterator;
-
     /**
      * Constructor. Stores a view into a C-string literal. This class is not interested in the null
      * terminator, thus if provided, it is excluded from the view.
@@ -37,6 +35,16 @@ public:
      */
     template <std::size_t N>
     constexpr explicit BasicStringLexer(const char_type (&literals)[N]) noexcept;
+
+    /**
+     * @return A string view into the C-string literal.
+     */
+    constexpr view_type view() const;
+
+    /**
+     * @return The lexer's current position into the C-string literal.
+     */
+    constexpr std::size_t position() const;
 
     /**
      * If a character is available at the current position (or some offset from the current
@@ -78,16 +86,6 @@ public:
      */
     constexpr std::optional<std::size_t> consume_number();
 
-    /**
-     * @return A pointer to the beginning of the C-string literal.
-     */
-    constexpr iterator begin() const;
-
-    /**
-     * @return A pointer to the end of the C-string literal.
-     */
-    constexpr iterator end() const;
-
 private:
     /**
      * If a character is available at the current position in the C-string literal, and if that
@@ -118,6 +116,20 @@ constexpr BasicStringLexer<StringType>::BasicStringLexer(const char_type (&liter
     m_size(N - ((literals[N - 1] == s_null_terminator) ? 1 : 0)),
     m_view(literals, m_size)
 {
+}
+
+//==================================================================================================
+template <typename StringType>
+constexpr auto BasicStringLexer<StringType>::view() const -> view_type
+{
+    return m_view;
+}
+
+//==================================================================================================
+template <typename StringType>
+constexpr std::size_t BasicStringLexer<StringType>::position() const
+{
+    return m_index;
 }
 
 //==================================================================================================
@@ -187,20 +199,6 @@ constexpr std::optional<std::size_t> BasicStringLexer<StringType>::consume_numbe
     }
 
     return parsed_number ? std::optional<std::size_t>(number) : std::nullopt;
-}
-
-//==================================================================================================
-template <typename StringType>
-constexpr auto BasicStringLexer<StringType>::begin() const -> iterator
-{
-    return m_view.cbegin();
-}
-
-//==================================================================================================
-template <typename StringType>
-constexpr auto BasicStringLexer<StringType>::end() const -> iterator
-{
-    return m_view.cend();
 }
 
 } // namespace fly::detail

--- a/test/types/string_formatter_types.cpp
+++ b/test/types/string_formatter_types.cpp
@@ -170,24 +170,6 @@ CATCH_TEMPLATE_TEST_CASE(
     constexpr const float f = 3.14f;
     constexpr const bool b = true;
 
-    CATCH_SECTION("Format string begin points at the first character in string")
-    {
-        auto format = make_format(FMT("ab"));
-        CATCH_CHECK_FALSE(format.has_error());
-
-        auto begin = format.begin();
-        CATCH_CHECK(*begin == FLY_CHR(char_type, 'a'));
-    }
-
-    CATCH_SECTION("Format string end points just past the last character in string")
-    {
-        auto format = make_format(FMT("ab"));
-        CATCH_CHECK_FALSE(format.has_error());
-
-        auto end = format.end() - 1;
-        CATCH_CHECK(*end == FLY_CHR(char_type, 'b'));
-    }
-
     CATCH_SECTION("No specifiers are parsed from empty string")
     {
         test_format(make_format(FMT("")));
@@ -229,8 +211,7 @@ CATCH_TEMPLATE_TEST_CASE(
             1);
         CATCH_CHECK_FALSE(format.has_error());
 
-        const auto length = static_cast<std::size_t>(std::distance(format.begin(), format.end()));
-        const std::size_t specifiers_created = length / 3;
+        const std::size_t specifiers_created = format.view().size() / 3;
         std::size_t specifiers_parsed = 0;
 
         while (format.next_specifier())
@@ -610,6 +591,26 @@ CATCH_TEMPLATE_TEST_CASE(
 
         specifier.m_locale_specific_form = false;
         test_format(make_format(FMT("{1:F}"), f, f), specifier);
+    }
+
+    CATCH_SECTION("Specifiers track their size in the format string")
+    {
+        auto format = make_format(FMT("ab {0} cd {1:d} ef {2:#0x}"), 1, 2, 3);
+        CATCH_CHECK_FALSE(format.has_error());
+
+        auto specifier1 = format.next_specifier();
+        CATCH_REQUIRE(specifier1);
+        CATCH_CHECK(specifier1->m_size == 3);
+
+        auto specifier2 = format.next_specifier();
+        CATCH_REQUIRE(specifier2);
+        CATCH_CHECK(specifier2->m_size == 5);
+
+        auto specifier3 = format.next_specifier();
+        CATCH_REQUIRE(specifier3);
+        CATCH_CHECK(specifier3->m_size == 7);
+
+        CATCH_CHECK_FALSE(format.next_specifier());
     }
 }
 

--- a/test/types/string_lexer.cpp
+++ b/test/types/string_lexer.cpp
@@ -27,7 +27,17 @@ CATCH_TEMPLATE_TEST_CASE(
         CATCH_CHECK_FALSE(lexer.consume());
         CATCH_CHECK_FALSE(lexer.consume_if(FLY_CHR(char_type, '\0')));
         CATCH_CHECK_FALSE(lexer.consume_number());
-        CATCH_CHECK(lexer.begin() == lexer.end());
+        CATCH_CHECK(lexer.position() == 0);
+    }
+
+    CATCH_SECTION("Lexer accepts null-terminated string")
+    {
+        Lexer lexer(FLY_ARR(char_type, "ab"));
+        CATCH_CHECK(lexer.view() == FLY_ARR(char_type, "ab"));
+
+        CATCH_CHECK(lexer.consume_if(FLY_CHR(char_type, 'a')));
+        CATCH_CHECK(lexer.consume_if(FLY_CHR(char_type, 'b')));
+        CATCH_CHECK_FALSE(lexer.consume());
     }
 
     CATCH_SECTION("Lexer accepts non-null-terminated string")
@@ -38,6 +48,8 @@ CATCH_TEMPLATE_TEST_CASE(
         };
 
         Lexer lexer(str);
+        CATCH_CHECK(lexer.view() == FLY_ARR(char_type, "ab"));
+
         CATCH_CHECK(lexer.consume_if(FLY_CHR(char_type, 'a')));
         CATCH_CHECK(lexer.consume_if(FLY_CHR(char_type, 'b')));
         CATCH_CHECK_FALSE(lexer.consume());
@@ -46,14 +58,17 @@ CATCH_TEMPLATE_TEST_CASE(
     CATCH_SECTION("Peeking does not advance internal pointer")
     {
         Lexer lexer(FLY_ARR(char_type, "ab"));
+        CATCH_CHECK(lexer.position() == 0);
 
         auto p1 = lexer.peek();
         CATCH_REQUIRE(p1.has_value());
         CATCH_CHECK(p1.value() == FLY_CHR(char_type, 'a'));
+        CATCH_CHECK(lexer.position() == 0);
 
         auto p2 = lexer.peek();
         CATCH_REQUIRE(p2.has_value());
         CATCH_CHECK(p2.value() == FLY_CHR(char_type, 'a'));
+        CATCH_CHECK(lexer.position() == 0);
     }
 
     CATCH_SECTION("Cannot peek past end of lexer")
@@ -74,121 +89,156 @@ CATCH_TEMPLATE_TEST_CASE(
     CATCH_SECTION("Consuming character advances internal pointer")
     {
         Lexer lexer(FLY_ARR(char_type, "ab"));
+        CATCH_CHECK(lexer.position() == 0);
 
         auto p1 = lexer.peek();
         CATCH_REQUIRE(p1.has_value());
         CATCH_CHECK(p1.value() == FLY_CHR(char_type, 'a'));
+        CATCH_CHECK(lexer.position() == 0);
 
         auto c1 = lexer.consume();
         CATCH_REQUIRE(c1.has_value());
         CATCH_CHECK(c1.value() == FLY_CHR(char_type, 'a'));
+        CATCH_CHECK(lexer.position() == 1);
 
         auto p2 = lexer.peek();
         CATCH_REQUIRE(p2.has_value());
         CATCH_CHECK(p2.value() == FLY_CHR(char_type, 'b'));
+        CATCH_CHECK(lexer.position() == 1);
     }
 
     CATCH_SECTION("Cannot consume past end of lexer")
     {
         Lexer lexer(FLY_ARR(char_type, "ab"));
+        CATCH_CHECK(lexer.position() == 0);
 
         auto c1 = lexer.consume();
         CATCH_REQUIRE(c1.has_value());
         CATCH_CHECK(c1.value() == FLY_CHR(char_type, 'a'));
+        CATCH_CHECK(lexer.position() == 1);
 
         auto c2 = lexer.consume();
         CATCH_REQUIRE(c2.has_value());
         CATCH_CHECK(c2.value() == FLY_CHR(char_type, 'b'));
+        CATCH_CHECK(lexer.position() == 2);
 
         CATCH_CHECK_FALSE(lexer.consume());
+        CATCH_CHECK(lexer.position() == 2);
     }
 
     CATCH_SECTION("Conditional consumption fails if character does not match")
     {
         Lexer lexer(FLY_ARR(char_type, "ab"));
+        CATCH_CHECK(lexer.position() == 0);
 
         CATCH_CHECK_FALSE(lexer.consume_if(FLY_CHR(char_type, 'b')));
+        CATCH_CHECK(lexer.position() == 0);
 
         auto c1 = lexer.consume();
         CATCH_REQUIRE(c1.has_value());
         CATCH_CHECK(c1.value() == FLY_CHR(char_type, 'a'));
+        CATCH_CHECK(lexer.position() == 1);
 
         CATCH_CHECK_FALSE(lexer.consume_if(FLY_CHR(char_type, 'a')));
+        CATCH_CHECK(lexer.position() == 1);
 
         auto c2 = lexer.consume();
         CATCH_REQUIRE(c2.has_value());
         CATCH_CHECK(c2.value() == FLY_CHR(char_type, 'b'));
+        CATCH_CHECK(lexer.position() == 2);
     }
 
     CATCH_SECTION("Conditional consumption advances internal pointer if character matches")
     {
         Lexer lexer(FLY_ARR(char_type, "ab"));
+        CATCH_CHECK(lexer.position() == 0);
 
         auto p1 = lexer.peek();
         CATCH_REQUIRE(p1.has_value());
         CATCH_CHECK(p1.value() == FLY_CHR(char_type, 'a'));
+        CATCH_CHECK(lexer.position() == 0);
 
         CATCH_CHECK(lexer.consume_if(FLY_CHR(char_type, 'a')));
+        CATCH_CHECK(lexer.position() == 1);
 
         auto p2 = lexer.peek();
         CATCH_REQUIRE(p2.has_value());
         CATCH_CHECK(p2.value() == FLY_CHR(char_type, 'b'));
+        CATCH_CHECK(lexer.position() == 1);
     }
 
     CATCH_SECTION("Cannot conditionally consume past end of lexer")
     {
         Lexer lexer(FLY_ARR(char_type, "ab"));
+        CATCH_CHECK(lexer.position() == 0);
 
         CATCH_CHECK(lexer.consume_if(FLY_CHR(char_type, 'a')));
+        CATCH_CHECK(lexer.position() == 1);
+
         CATCH_CHECK(lexer.consume_if(FLY_CHR(char_type, 'b')));
+        CATCH_CHECK(lexer.position() == 2);
+
         CATCH_CHECK_FALSE(lexer.consume_if(FLY_CHR(char_type, '\0')));
+        CATCH_CHECK(lexer.position() == 2);
     }
 
     CATCH_SECTION("Cannot consume number if no number exists")
     {
         Lexer lexer(FLY_ARR(char_type, "ab"));
+        CATCH_CHECK(lexer.position() == 0);
 
         CATCH_CHECK_FALSE(lexer.consume_number());
+        CATCH_CHECK(lexer.position() == 0);
     }
 
     CATCH_SECTION("Cannot consume number past end of lexer")
     {
         Lexer lexer(FLY_ARR(char_type, "1"));
+        CATCH_CHECK(lexer.position() == 0);
 
         auto n1 = lexer.consume_number();
         CATCH_REQUIRE(n1.has_value());
         CATCH_CHECK(n1.value() == 1);
+        CATCH_CHECK(lexer.position() == 1);
 
         CATCH_CHECK_FALSE(lexer.consume_number());
+        CATCH_CHECK(lexer.position() == 1);
     }
 
     CATCH_SECTION("Cannot consume number if number exists past internal pointer")
     {
         Lexer lexer(FLY_ARR(char_type, "ab1"));
+        CATCH_CHECK(lexer.position() == 0);
 
         CATCH_CHECK_FALSE(lexer.consume_number());
+        CATCH_CHECK(lexer.position() == 0);
     }
 
     CATCH_SECTION("Number consumption stops at first non-digit character")
     {
         Lexer lexer(FLY_ARR(char_type, "1ab"));
+        CATCH_CHECK(lexer.position() == 0);
 
         auto n1 = lexer.consume_number();
         CATCH_REQUIRE(n1.has_value());
         CATCH_CHECK(n1.value() == 1);
+        CATCH_CHECK(lexer.position() == 1);
 
         auto p1 = lexer.peek();
         CATCH_REQUIRE(p1.has_value());
         CATCH_CHECK(p1.value() == FLY_CHR(char_type, 'a'));
+        CATCH_CHECK(lexer.position() == 1);
     }
 
     CATCH_SECTION("Number consumption stops at end of lexer")
     {
         Lexer lexer(FLY_ARR(char_type, "1"));
+        CATCH_CHECK(lexer.position() == 0);
 
         auto n1 = lexer.consume_number();
         CATCH_REQUIRE(n1.has_value());
         CATCH_CHECK(n1.value() == 1);
+        CATCH_CHECK(lexer.position() == 1);
 
         CATCH_CHECK_FALSE(lexer.peek());
     }
@@ -196,21 +246,12 @@ CATCH_TEMPLATE_TEST_CASE(
     CATCH_SECTION("Number consumption consumes all digits in a row")
     {
         Lexer lexer(FLY_ARR(char_type, "123"));
+        CATCH_CHECK(lexer.position() == 0);
 
         auto n1 = lexer.consume_number();
         CATCH_REQUIRE(n1.has_value());
         CATCH_CHECK(n1.value() == 123);
-
-        CATCH_CHECK_FALSE(lexer.peek());
-    }
-
-    CATCH_SECTION("Number consumption consumes all digits in a row")
-    {
-        Lexer lexer(FLY_ARR(char_type, "123"));
-
-        auto n1 = lexer.consume_number();
-        CATCH_REQUIRE(n1.has_value());
-        CATCH_CHECK(n1.value() == 123);
+        CATCH_CHECK(lexer.position() == 3);
 
         CATCH_CHECK_FALSE(lexer.peek());
     }
@@ -218,41 +259,19 @@ CATCH_TEMPLATE_TEST_CASE(
     CATCH_SECTION("Number consumption can succeed multiple times per lexer if separated")
     {
         Lexer lexer(FLY_ARR(char_type, "123a456"));
+        CATCH_CHECK(lexer.position() == 0);
 
         auto n1 = lexer.consume_number();
         CATCH_REQUIRE(n1.has_value());
         CATCH_CHECK(n1.value() == 123);
+        CATCH_CHECK(lexer.position() == 3);
 
         CATCH_CHECK(lexer.consume_if(FLY_CHR(char_type, 'a')));
+        CATCH_CHECK(lexer.position() == 4);
 
         auto n2 = lexer.consume_number();
         CATCH_REQUIRE(n2.has_value());
         CATCH_CHECK(n2.value() == 456);
-    }
-
-    CATCH_SECTION("Lexer begin always points at the first character in lexer")
-    {
-        Lexer lexer(FLY_ARR(char_type, "ab"));
-
-        auto b1 = lexer.begin();
-        CATCH_CHECK(*b1 == FLY_CHR(char_type, 'a'));
-
-        CATCH_CHECK(lexer.consume_if(FLY_CHR(char_type, 'a')));
-
-        auto b2 = lexer.begin();
-        CATCH_CHECK(*b2 == FLY_CHR(char_type, 'a'));
-    }
-
-    CATCH_SECTION("Lexer end always points just past the last character in lexer")
-    {
-        Lexer lexer(FLY_ARR(char_type, "ab"));
-
-        auto e1 = lexer.end() - 1;
-        CATCH_CHECK(*e1 == FLY_CHR(char_type, 'b'));
-
-        CATCH_CHECK(lexer.consume_if(FLY_CHR(char_type, 'a')));
-
-        auto e2 = lexer.end() - 1;
-        CATCH_CHECK(*e2 == FLY_CHR(char_type, 'b'));
+        CATCH_CHECK(lexer.position() == 7);
     }
 }


### PR DESCRIPTION
Track each replacement field's length in the format string. This removes
the need for the 'while' statement in the formatting loop to increment
the iterator to the closing } character. Now the loop can simply
increment the iterator by the replacement field's length.