### PR TITLE
Split BasicStringFormatter::format_value based on type

### DIFF
--- a/fly/logger/logger.hpp
+++ b/fly/logger/logger.hpp
@@ -244,7 +244,7 @@ public:
      * thread while invoking a LOG* macro on another thread. The default logger should be set once
      * during initialization.
      *
-     * @param logger The logger instance.
+     * @param default_logger The logger instance.
      */
     static void set_default_logger(const std::shared_ptr<Logger> &default_logger);
 

--- a/fly/types/string/detail/string_formatter_types.hpp
+++ b/fly/types/string/detail/string_formatter_types.hpp
@@ -174,19 +174,9 @@ struct BasicFormatSpecifier
     static constexpr std::optional<Type> type_of(CharType ch);
 
     /**
-     * @return True if the presentation type is a numeric (integral or floating point) type.
+     * @return True if the presentation type is a numeric type.
      */
     constexpr bool is_numeric() const;
-
-    /**
-     * @return True if the presentation type is an integral type.
-     */
-    constexpr bool is_integral() const;
-
-    /**
-     * @return True if the presentation type is a floating point type.
-     */
-    constexpr bool is_floating_point() const;
 
     /**
      * Compare two replacement field instances for equality.
@@ -566,36 +556,18 @@ constexpr auto BasicFormatSpecifier<CharType>::type_of(CharType ch) -> std::opti
 template <typename CharType>
 constexpr bool BasicFormatSpecifier<CharType>::is_numeric() const
 {
-    return is_integral() || is_floating_point();
-}
-
-//==================================================================================================
-template <typename CharType>
-constexpr bool BasicFormatSpecifier<CharType>::is_integral() const
-{
     switch (m_type)
     {
         case Type::Binary:
         case Type::Octal:
         case Type::Decimal:
         case Type::Hex:
-            return true;
-        default:
-            return false;
-    }
-}
-
-//==================================================================================================
-template <typename CharType>
-constexpr bool BasicFormatSpecifier<CharType>::is_floating_point() const
-{
-    switch (m_type)
-    {
         case Type::HexFloat:
         case Type::Scientific:
         case Type::Fixed:
         case Type::General:
             return true;
+
         default:
             return false;
     }

--- a/fly/types/string/detail/string_formatter_types.hpp
+++ b/fly/types/string/detail/string_formatter_types.hpp
@@ -329,7 +329,7 @@ private:
     using is_integer = std::conjunction<
         std::is_integral<T>,
         std::negation<is_supported_character<T>>,
-        std::negation<std::is_same<bool, T>>>;
+        std::negation<std::is_same<T, bool>>>;
 
     template <typename T>
     static inline constexpr bool is_integer_v = is_integer<T>::value;


### PR DESCRIPTION
This method was just pretty huge. Create SFINAE overloads of a helper
method to format values based on their types. This also removes the need
for several constant if statements that were used to prevent the compiler
from errantly generating type-specific code for generic types.