### PR TITLE
Use clearer language in std::enable_if wrappers

### DIFF
--- a/fly/traits/traits.hpp
+++ b/fly/traits/traits.hpp
@@ -43,24 +43,24 @@ template <typename... Conditions>
 using enable_if_any = enable_if<std::disjunction<Conditions...>>;
 
 /**
- * Wrapper around std::enable_if for testing that all conditions in a sequence of traits are false.
- * Example:
- *
- *     template <typename T, fly::enable_if_none<std::is_class<T>, std::is_empty<T>> = 0>
- *     void func(const T &) { }
- */
-template <typename... Conditions>
-using enable_if_none = enable_if<std::negation<std::disjunction<Conditions...>>>;
-
-/**
  * Wrapper around std::enable_if for testing that any condition in a sequence of traits is false.
  * Example:
  *
- *     template <typename T, fly::enable_if_not_all<std::is_class<T>, std::is_empty<T>> = 0>
+ *     template <typename T, fly::disable_if_all<std::is_class<T>, std::is_empty<T>> = 0>
  *     void func(const T &) { }
  */
 template <typename... Conditions>
-using enable_if_not_all = enable_if<std::negation<std::conjunction<Conditions...>>>;
+using disable_if_all = disable_if<std::conjunction<Conditions...>>;
+
+/**
+ * Wrapper around std::enable_if for testing that all conditions in a sequence of traits are false.
+ * Example:
+ *
+ *     template <typename T, fly::disable_if_any<std::is_class<T>, std::is_empty<T>> = 0>
+ *     void func(const T &) { }
+ */
+template <typename... Conditions>
+using disable_if_any = disable_if<std::disjunction<Conditions...>>;
 
 /**
  * Wrapper around std::is_same for testing that all types in a sequence of types are the same as a

--- a/fly/types/string/detail/string_formatter.hpp
+++ b/fly/types/string/detail/string_formatter.hpp
@@ -196,7 +196,7 @@ private:
      * @param specifier The replacement field to format.
      * @param value The value to format.
      */
-    template <typename T, fly::enable_if_none<std::is_integral<T>, std::is_floating_point<T>> = 0>
+    template <typename T, fly::disable_if_any<std::is_integral<T>, std::is_floating_point<T>> = 0>
     static void format_value_for_type(
         ostream_type &stream,
         stream_modifiers &&modifiers,
@@ -525,7 +525,7 @@ void BasicStringFormatter<StringType>::format_value_for_type(
 
 //==================================================================================================
 template <typename StringType>
-template <typename T, fly::enable_if_none<std::is_integral<T>, std::is_floating_point<T>>>
+template <typename T, fly::disable_if_any<std::is_integral<T>, std::is_floating_point<T>>>
 inline void BasicStringFormatter<StringType>::format_value_for_type(
     ostream_type &stream,
     stream_modifiers &&,

--- a/test/traits/traits.cpp
+++ b/test/traits/traits.cpp
@@ -62,7 +62,7 @@ bool call_foo(const T &arg)
     return arg.foo();
 }
 
-template <typename T, fly::enable_if_not_all<FooTraits::is_declared<T>> = 0>
+template <typename T, fly::disable_if_all<FooTraits::is_declared<T>> = 0>
 bool call_foo(const T &)
 {
     return false;
@@ -76,7 +76,7 @@ bool is_streamable(std::ostream &stream, const T &arg)
     return true;
 }
 
-template <typename T, fly::enable_if_not_all<OstreamTraits::is_declared<T>> = 0>
+template <typename T, fly::disable_if_all<OstreamTraits::is_declared<T>> = 0>
 bool is_streamable(std::ostream &, const T &)
 {
     return false;
@@ -106,7 +106,7 @@ bool is_class_pointer(const T &)
 
 template <
     typename T,
-    fly::enable_if_not_all<std::is_pointer<T>, std::is_class<std::remove_pointer_t<T>>> = 0>
+    fly::disable_if_all<std::is_pointer<T>, std::is_class<std::remove_pointer_t<T>>> = 0>
 bool is_class_pointer(const T &)
 {
     return false;
@@ -123,7 +123,7 @@ bool is_class_or_pointer(const T &)
 
 template <
     typename T,
-    fly::enable_if_none<std::is_pointer<T>, std::is_class<std::remove_pointer_t<T>>> = 0>
+    fly::disable_if_any<std::is_pointer<T>, std::is_class<std::remove_pointer_t<T>>> = 0>
 bool is_class_or_pointer(const T &)
 {
     return false;
@@ -197,7 +197,7 @@ CATCH_TEST_CASE("Traits", "[traits]")
         CATCH_CHECK_FALSE(is_class(&f));
     }
 
-    CATCH_SECTION("Combination of traits for enable_if_all and enable_if_not_all")
+    CATCH_SECTION("Combination of traits for enable_if_all and disable_if_all")
     {
         const FooClass fc;
         const std::string str("a");
@@ -219,7 +219,7 @@ CATCH_TEST_CASE("Traits", "[traits]")
         CATCH_CHECK_FALSE(is_class_pointer(&f));
     }
 
-    CATCH_SECTION("Combination of traits for enable_if_any and enable_if_none")
+    CATCH_SECTION("Combination of traits for enable_if_any and disable_if_any")
     {
         const FooClass fc;
         const std::string str("a");

--- a/test/types/string/string_traits.cpp
+++ b/test/types/string/string_traits.cpp
@@ -76,7 +76,7 @@ constexpr bool is_string_like(const T &)
 
 template <
     typename T,
-    fly::enable_if_none<
+    fly::disable_if_any<
         fly::detail::BasicStringTraits<std::string>::is_string_like<T>,
         fly::detail::BasicStringTraits<std::wstring>::is_string_like<T>,
         fly::detail::BasicStringTraits<std::u8string>::is_string_like<T>,


### PR DESCRIPTION
Pairing enable_if_all with disable_if_all, and enable_if_any with
disable_if_any, visually makes much more sense.