### PR TITLE
BasicStringStreamer can take maxiumum string length as plain type

### DIFF
--- a/fly/types/string/detail/string_formatter.hpp
+++ b/fly/types/string/detail/string_formatter.hpp
@@ -7,7 +7,7 @@
 #include "fly/types/string/string_literal.hpp"
 
 #include <iomanip>
-#include <limits>
+#include <optional>
 #include <type_traits>
 
 namespace fly::detail {
@@ -401,7 +401,7 @@ void BasicStringFormatter<StringType, ParameterTypes...>::format_value_for_type(
     else
     {
         using integral_type =
-            std::conditional_t<std::numeric_limits<T>::is_signed, std::intmax_t, std::uintmax_t>;
+            std::conditional_t<std::is_signed_v<T>, std::intmax_t, std::uintmax_t>;
         streamer::template stream_value<decltype(value), integral_type>(m_stream, value);
     }
 }
@@ -462,7 +462,7 @@ void BasicStringFormatter<StringType, ParameterTypes...>::format_value_for_type(
     }
     else
     {
-        streamer::stream_string(m_stream, value, std::nullopt);
+        streamer::stream_string(m_stream, value, StringType::npos);
     }
 }
 

--- a/fly/types/string/detail/string_streamer.hpp
+++ b/fly/types/string/detail/string_streamer.hpp
@@ -9,7 +9,6 @@
 #include <cstdint>
 #include <ios>
 #include <locale>
-#include <optional>
 #include <type_traits>
 
 namespace fly::detail {
@@ -70,8 +69,7 @@ struct BasicStringStreamer
      * @param max_string_length The maximum number of characters from the string to stream.
      */
     template <typename T>
-    static void
-    stream_string(ostream_type &stream, T &&value, std::optional<std::size_t> max_string_length);
+    static void stream_string(ostream_type &stream, T &&value, std::size_t max_string_length);
 };
 
 /**
@@ -220,7 +218,7 @@ void BasicStringStreamer<StringType>::stream_value(ostream_type &stream, T &&val
     }
     else if constexpr (detail::is_like_supported_string_v<U>)
     {
-        stream_string(stream, std::forward<T>(value), std::nullopt);
+        stream_string(stream, std::forward<T>(value), StringType::npos);
     }
     else if constexpr (detail::is_supported_character_v<T>)
     {
@@ -239,7 +237,7 @@ template <typename T>
 void BasicStringStreamer<StringType>::stream_string(
     ostream_type &stream,
     T &&value,
-    std::optional<std::size_t> max_string_length)
+    std::size_t max_string_length)
 {
     using string_like_type = detail::is_like_supported_string_t<T>;
     using string_like_traits = BasicStringTraits<string_like_type>;
@@ -248,14 +246,7 @@ void BasicStringStreamer<StringType>::stream_string(
 
     if constexpr (std::is_same_v<streamed_type, string_like_type>)
     {
-        if (max_string_length && (*max_string_length < view.size()))
-        {
-            stream << view.substr(0, *max_string_length);
-        }
-        else
-        {
-            stream << view;
-        }
+        stream << view.substr(0, max_string_length);
     }
     else
     {
@@ -267,7 +258,7 @@ void BasicStringStreamer<StringType>::stream_string(
 
         if (auto converted = unicode::template convert_encoding<streamed_type>(it, end); converted)
         {
-            streamer::stream_string(stream, *std::move(converted), std::move(max_string_length));
+            streamer::stream_string(stream, *std::move(converted), max_string_length);
         }
     }
 }

--- a/test/types/string/string_formatter.cpp
+++ b/test/types/string/string_formatter.cpp
@@ -328,8 +328,13 @@ CATCH_TEMPLATE_TEST_CASE(
 
     CATCH_SECTION("Precision value sets maximum string size")
     {
+        test_format(FMT("{:.3s}"), FMT("a"), FLY_STR(char_type, "a"));
         test_format(FMT("{:.3s}"), FMT("ab"), FLY_STR(char_type, "ab"));
         test_format(FMT("{:.3s}"), FMT("abc"), FLY_STR(char_type, "abcdef"));
+
+        test_format(FMT("{:.0s}"), FMT(""), FLY_STR(char_type, "a"));
+        test_format(FMT("{:.0s}"), FMT(""), FLY_STR(char_type, "ab"));
+        test_format(FMT("{:.0s}"), FMT(""), FLY_STR(char_type, "abcdef"));
     }
 
     CATCH_SECTION("Precision position sets floating point precision")
@@ -344,6 +349,10 @@ CATCH_TEMPLATE_TEST_CASE(
         test_format(FMT("{:.{}s}"), FMT("ab"), FLY_STR(char_type, "ab"), 3);
         test_format(FMT("{0:.{1}s}"), FMT("abc"), FLY_STR(char_type, "abcdef"), 3);
         test_format(FMT("{1:.{0}s}"), FMT("abc"), 3, FLY_STR(char_type, "abcdef"));
+
+        test_format(FMT("{:.{}s}"), FMT(""), FLY_STR(char_type, "ab"), 0);
+        test_format(FMT("{0:.{1}s}"), FMT(""), FLY_STR(char_type, "abcdef"), 0);
+        test_format(FMT("{1:.{0}s}"), FMT(""), 0, FLY_STR(char_type, "abcdef"));
     }
 
     CATCH_SECTION("Precision position is ignored if the position value is negative")


### PR DESCRIPTION
Rather than accepting a std::optional<std::size_t>, match the STL
practice of using std::string::npos as unspecified.