### PR TITLE
Implement string and integral formatters without IO streams

### DIFF
--- a/bench/main.cpp
+++ b/bench/main.cpp
@@ -57,7 +57,7 @@ public:
     void testCaseStarting(const Catch::TestCaseInfo &info) override
     {
         const auto style = fly::Styler(fly::Style::Bold, fly::Color::Cyan);
-        fly::String::format(stream, "[{}{:=>13}{}{:=<13}]\n\n", style, ' ', info.name, ' ');
+        stream << style << fly::String::format("[{:=>13}{}{:=<13}]\n\n", ' ', info.name, ' ');
     }
 };
 

--- a/bench/string/README.md
+++ b/bench/string/README.md
@@ -7,31 +7,69 @@ Benchmark of the libfly JSON parser against the popular {fmt} library and the ST
 
 ## Results
 
-Results below are the median of 1000001 iterations of creating a formatted string. Obviously, libfly
-could use some work :)
+All results below are the median of 1000001 iterations of creating a formatted string.
+
+### Formatting with floats
 
 | Formatter      | Duration (ns) |
 | :--            |           --: |
-| libfly         |         2.337 |
-| {fmt}          |         0.592 |
-| STL IO Streams |         1.857 |
+| libfly         |         1.784 |
+| STL IO Streams |         1.877 |
+| {fmt}          |         0.586 |
 
-## Profile
+### Formatting without floats
+
+| Formatter      | Duration (ns) |
+| :--            |           --: |
+| libfly         |         0.748 |
+| {fmt}          |         0.411 |
+| STL IO Streams |         1.011 |
+
+## Profiles
+
+### Formatting with floats
 
 ```
 Each sample counts as 0.01 seconds.
   %   cumulative   self              self     total
  time   seconds   seconds    calls  ms/call  ms/call  name
- 26.92      0.56     0.21  1000001     0.00     0.00  fly::detail::BasicStringFormatter<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, double, int, double, char const (&) [4], decltype(nullptr), char>::format(fly::detail::BasicFormatString<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, double, int, double, char const (&) [4], decltype(nullptr), char>&&)
-  3.85      0.65     0.03  6000038     0.00     0.00  fly::detail::BasicStreamModifiers<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::BasicStreamModifiers(std::ostream&)
-  3.85      0.68     0.03  2000002     0.00     0.00  void fly::detail::BasicStringFormatter<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, double, int, double, char const (&) [4], decltype(nullptr), char>::set_numeric_options<double>(fly::detail::BasicStreamModifiers<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >&, fly::detail::BasicFormatSpecifier<char> const&, double const&) const
-  2.56      0.73     0.02  6000038     0.00     0.00  fly::detail::BasicStreamModifiers<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::~BasicStreamModifiers()
-  2.56      0.75     0.02  6000006     0.00     0.00  fly::detail::BasicStringFormatter<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, double, int, double, char const (&) [4], decltype(nullptr), char>::set_generic_options(fly::detail::BasicStreamModifiers<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >&, fly::detail::BasicFormatSpecifier<char> const&) const
-  1.28      0.76     0.01        2     5.00     5.00  std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::reserve(unsigned long)
-  1.28      0.77     0.01                             std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_replace(unsigned long, unsigned long, char const*, unsigned long)
-  1.28      0.78     0.01                             std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::swap(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&)
-  0.00      0.78     0.00  1000001     0.00     0.00  void fly::detail::BasicStringStreamer<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::stream_string<char const (&) [4]>(std::ostream&, char const (&) [4], unsigned long)
-  0.00      0.78     0.00     1196     0.00     0.00  std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release()
-  0.00      0.78     0.00     1172     0.00     0.00  std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
-  0.00      0.78     0.00     1016     0.00     0.00  std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >::vector(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&)
+ 10.45      0.46     0.07  2000002     0.00     0.00  void fly::detail::BasicStringFormatter<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, double, int, double, char const (&) [4], decltype(nullptr), char>::format_value<double, false>(fly::detail::BasicFormatSpecifier<char>&&, double const&)
+ 10.45      0.53     0.07  1000001     0.00     0.00  fly::detail::BasicStringFormatter<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, double, int, double, char const (&) [4], decltype(nullptr), char>::format(fly::detail::BasicFormatString<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, double, int, double, char const (&) [4], decltype(nullptr), char>&&)
+  8.96      0.59     0.06  5000005     0.00     0.00  void fly::detail::BasicFormatParameters<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, double, int, double, char const (&) [4], decltype(nullptr), char>::visit<fly::detail::BasicStringFormatter<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, double, int, double, char const (&) [4], decltype(nullptr), char>::format(fly::detail::BasicFormatString<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, double, int, double, char const (&) [4], decltype(nullptr), char>&&)::{lambda(auto:1&&, auto:2 const&)#1}, 1ul>(fly::detail::BasicFormatSpecifier<char>&&, fly::detail::BasicStringFormatter<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, double, int, double, char const (&) [4], decltype(nullptr), char>::format(fly::detail::BasicFormatString<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, double, int, double, char const (&) [4], decltype(nullptr), char>&&)::{lambda(auto:1&&, auto:2 const&)#1}) const
+  5.97      0.63     0.04 11000011     0.00     0.00  TLS init function for fly::detail::BasicStringFormatter<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, double, int, double, char const (&) [4], decltype(nullptr), char>::s_stream
+  2.99      0.65     0.02  1000013     0.00     0.00  std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::reserve(unsigned long)
+  1.49      0.66     0.01  2000004     0.00     0.00  fly::detail::BasicStreamModifiers<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::~BasicStreamModifiers()
+  1.49      0.67     0.01  1000001     0.00     0.00  void fly::detail::BasicStringFormatter<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, double, int, double, char const (&) [4], decltype(nullptr), char>::format_value<unsigned char, false>(fly::detail::BasicFormatSpecifier<char>&&, unsigned char, bool)
+  0.00      0.67     0.00  2000004     0.00     0.00  fly::detail::BasicStreamModifiers<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::BasicStreamModifiers(std::ostream&)
+  0.00      0.67     0.00  1000001     0.00     0.00  void fly::detail::BasicStringFormatter<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, double, int, double, char const (&) [4], decltype(nullptr), char>::format_value<char [4], false>(fly::detail::BasicFormatSpecifier<char>&&, char const (&) [4])
+  0.00      0.67     0.00  1000001     0.00     0.00  void fly::detail::BasicStringFormatter<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, double, int, double, char const (&) [4], decltype(nullptr), char>::format_value<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, false>(fly::detail::BasicFormatSpecifier<char>&&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
+  0.00      0.67     0.00  1000001     0.00     0.00  void fly::detail::BasicStringFormatter<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, double, int, double, char const (&) [4], decltype(nullptr), char>::format_value<unsigned int, false>(fly::detail::BasicFormatSpecifier<char>&&, unsigned int, bool)
+  0.00      0.67     0.00  1000001     0.00     0.00  void fly::detail::BasicStringFormatter<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, double, int, double, char const (&) [4], decltype(nullptr), char>::append_string<char [4], false>(char const (&) [4], unsigned long)
+  0.00      0.67     0.00  1000001     0.00     0.00  std::enable_if<std::__or_<std::__or_<std::is_same<std::remove_cv<unsigned int>::type, signed char>, std::is_same<std::remove_cv<unsigned int>::type, short>, std::is_same<std::remove_cv<unsigned int>::type, int>, std::is_same<std::remove_cv<unsigned int>::type, long>, std::is_same<std::remove_cv<unsigned int>::type, long long> >, std::__or_<std::is_same<std::remove_cv<unsigned int>::type, unsigned char>, std::is_same<std::remove_cv<unsigned int>::type, unsigned short>, std::is_same<std::remove_cv<unsigned int>::type, unsigned int>, std::is_same<std::remove_cv<unsigned int>::type, unsigned long>, std::is_same<std::remove_cv<unsigned int>::type, unsigned long long> >, std::is_same<char, std::remove_cv<unsigned int>::type> >::value, std::to_chars_result>::type std::__to_chars_i<unsigned int>(char*, char*, unsigned int, int)
+  0.00      0.67     0.00     2131     0.00     0.00  std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
+  0.00      0.67     0.00     1196     0.00     0.00  std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release()
+  0.00      0.67     0.00     1016     0.00     0.00  std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >::vector(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&)
+```
+
+### Formatting without floats
+
+```
+Each sample counts as 0.01 seconds.
+  %   cumulative   self              self     total
+ time   seconds   seconds    calls  ms/call  ms/call  name
+ 16.42      0.50     0.11  1000001     0.00     0.00  fly::detail::BasicStringFormatter<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, int, int, int, char const (&) [4], decltype(nullptr), char>::format(fly::detail::BasicFormatString<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, int, int, int, char const (&) [4], decltype(nullptr), char>&&)
+  7.46      0.62     0.05  3000003     0.00     0.00  void fly::detail::BasicStringFormatter<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, int, int, int, char const (&) [4], decltype(nullptr), char>::format_value<unsigned int, false>(fly::detail::BasicFormatSpecifier<char>&&, unsigned int, bool)
+  4.48      0.65     0.03  3000003     0.00     0.00  TLS init function for fly::detail::BasicStringFormatter<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, double, int, double, char const (&) [4], decltype(nullptr), char>::s_stream
+  1.49      0.67     0.01                             fly::detail::BasicStringFormatter<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, double, int, double, char const (&) [4], decltype(nullptr), char>::format(fly::detail::BasicFormatString<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, double, int, double, char const (&) [4], decltype(nullptr), char>&&)
+  0.00      0.67     0.00  3000003     0.00     0.00  std::enable_if<std::__or_<std::__or_<std::is_same<std::remove_cv<unsigned int>::type, signed char>, std::is_same<std::remove_cv<unsigned int>::type, short>, std::is_same<std::remove_cv<unsigned int>::type, int>, std::is_same<std::remove_cv<unsigned int>::type, long>, std::is_same<std::remove_cv<unsigned int>::type, long long> >, std::__or_<std::is_same<std::remove_cv<unsigned int>::type, unsigned char>, std::is_same<std::remove_cv<unsigned int>::type, unsigned short>, std::is_same<std::remove_cv<unsigned int>::type, unsigned int>, std::is_same<std::remove_cv<unsigned int>::type, unsigned long>, std::is_same<std::remove_cv<unsigned int>::type, unsigned long long> >, std::is_same<char, std::remove_cv<unsigned int>::type> >::value, std::to_chars_result>::type std::__to_chars_i<unsigned int>(char*, char*, unsigned int, int)
+  0.00      0.67     0.00  1000013     0.00     0.00  std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::reserve(unsigned long)
+  0.00      0.67     0.00  1000001     0.00     0.00  void fly::detail::BasicStringFormatter<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, int, int, int, char const (&) [4], decltype(nullptr), char>::format_value<char [4], false>(fly::detail::BasicFormatSpecifier<char>&&, char const (&) [4])
+  0.00      0.67     0.00  1000001     0.00     0.00  void fly::detail::BasicStringFormatter<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, int, int, int, char const (&) [4], decltype(nullptr), char>::format_value<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, false>(fly::detail::BasicFormatSpecifier<char>&&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
+  0.00      0.67     0.00  1000001     0.00     0.00  void fly::detail::BasicStringFormatter<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, int, int, int, char const (&) [4], decltype(nullptr), char>::format_value<unsigned char, false>(fly::detail::BasicFormatSpecifier<char>&&, unsigned char, bool)
+  0.00      0.67     0.00  1000001     0.00     0.00  void fly::detail::BasicStringFormatter<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, int, int, int, char const (&) [4], decltype(nullptr), char>::append_string<char [4], false>(char const (&) [4], unsigned long)
+  0.00      0.67     0.00     2131     0.00     0.00  std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
+  0.00      0.67     0.00     1196     0.00     0.00  std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release()
+  0.00      0.67     0.00     1016     0.00     0.00  std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >::vector(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&)
+  0.00      0.67     0.00      139     0.00     0.00  std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_dispose()
+  0.00      0.67     0.00      120     0.00     0.00  void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<char const*>(char const*, char const*, std::forward_iterator_tag)
 ```

--- a/bench/string/benchmark_string.cpp
+++ b/bench/string/benchmark_string.cpp
@@ -13,19 +13,21 @@
 namespace {
 
 using StringTable = fly::benchmark::Table<std::string, double>;
+static constexpr std::size_t s_iterations = 1000001;
 
 class StringBase
 {
 public:
     virtual ~StringBase() = default;
-    virtual void format() = 0;
+    virtual void format_with_floats() = 0;
+    virtual void format_without_floats() = 0;
 };
 
 // libfly - https://github.com/trflynn89/libfly
 class LibflyFormat : public StringBase
 {
 public:
-    void format() override
+    void format_with_floats() override
     {
         FLY_UNUSED(fly::String::format(
             "{:.10f}:{:04}:{:+}:{}:{}:{}:%\n",
@@ -36,16 +38,34 @@ public:
             nullptr,
             'X'));
     }
+
+    void format_without_floats() override
+    {
+        FLY_UNUSED(fly::String::format(
+            "{:10}:{:04}:{:+}:{}:{}:{}:%\n",
+            1234,
+            42,
+            313,
+            "str",
+            nullptr,
+            'X'));
+    }
 };
 
 // {fmt} - https://github.com/fmtlib/fmt
 class FmtFormat : public StringBase
 {
 public:
-    void format() override
+    void format_with_floats() override
     {
         FLY_UNUSED(
             fmt::format("{:.10f}:{:04}:{:+}:{}:{}:{}:%\n", 1.234, 42, 3.13, "str", nullptr, 'X'));
+    }
+
+    void format_without_floats() override
+    {
+        FLY_UNUSED(
+            fmt::format("{:10}:{:04}:{:+}:{}:{}:{}:%\n", 1234, 42, 313, "str", nullptr, 'X'));
     }
 };
 
@@ -53,7 +73,7 @@ public:
 class STLStreamFormat : public StringBase
 {
 public:
-    void format() override
+    void format_with_floats() override
     {
         std::stringstream stream;
         stream << std::setprecision(10) << std::fixed << 1.234 << ':'
@@ -62,14 +82,20 @@ public:
                << std::resetiosflags(std::ios::showpos) << ':' << "str" << ':' << nullptr << ':'
                << 'X' << ":%\n";
     }
+
+    void format_without_floats() override
+    {
+        std::stringstream stream;
+        stream << std::setw(10) << 1234 << ':' << std::setw(4) << std::setfill('0') << 42
+               << std::setfill(' ') << ':' << std::setiosflags(std::ios::showpos) << 313
+               << std::resetiosflags(std::ios::showpos) << ':' << "str" << ':' << nullptr << ':'
+               << 'X' << ":%\n";
+    }
 };
 
-} // namespace
-
-CATCH_TEST_CASE("String", "[bench]")
+template <typename WithFloats>
+void run_format_test(std::string &&name)
 {
-    static constexpr std::size_t s_iterations = 1000001;
-
     std::map<std::string, std::unique_ptr<StringBase>> formatters;
 #if !defined(FLY_PROFILE)
     formatters.emplace("{fmt}", std::make_unique<FmtFormat>());
@@ -77,7 +103,7 @@ CATCH_TEST_CASE("String", "[bench]")
 #endif
     formatters.emplace("libfly", std::make_unique<LibflyFormat>());
 
-    StringTable table("String Formatting", {"Formatter", "Duration (ns)"});
+    StringTable table(std::move(name), {"Formatter", "Duration (ns)"});
 
     for (auto &formatter : formatters)
     {
@@ -86,7 +112,16 @@ CATCH_TEST_CASE("String", "[bench]")
         for (std::size_t i = 0; i < s_iterations; ++i)
         {
             const auto start = std::chrono::system_clock::now();
-            formatter.second->format();
+
+            if constexpr (std::is_same_v<WithFloats, std::true_type>)
+            {
+                formatter.second->format_with_floats();
+            }
+            else
+            {
+                formatter.second->format_without_floats();
+            }
+
             const auto end = std::chrono::system_clock::now();
 
             const auto duration = std::chrono::duration<double>(end - start);
@@ -100,4 +135,12 @@ CATCH_TEST_CASE("String", "[bench]")
     }
 
     std::cout << table << '\n';
+}
+
+} // namespace
+
+CATCH_TEST_CASE("String", "[bench]")
+{
+    run_format_test<std::true_type>("Formatting (with floats)");
+    run_format_test<std::false_type>("Formatting (without floats)");
 }

--- a/bench/util/stream_util.hpp
+++ b/bench/util/stream_util.hpp
@@ -9,50 +9,6 @@
 namespace fly::benchmark {
 
 /**
- * Helper class to center text within a specified width within a steam.
- *
- * @author Timothy Flynn (trflynn89@pm.me)
- * @version Decmber 12, 2020
- */
-template <typename StringType>
-class Center
-{
-public:
-    /**
-     * Constructor.
-     *
-     * @param width The width to center the text within.
-     * @param value The text to be centered.
-     */
-    Center(std::size_t width, const StringType &value);
-
-    /**
-     * Print the centered text.
-     *
-     * @param stream The stream to print the text into.
-     * @param center The instance holding the centering data.
-     *
-     * @return The same stream object.
-     */
-    friend std::ostream &operator<<(std::ostream &stream, const Center &center)
-    {
-        center.print(stream);
-        return stream;
-    }
-
-private:
-    /**
-     * Print the centered text.
-     *
-     * @param stream The stream to print the text into.
-     */
-    void print(std::ostream &stream) const;
-
-    const std::streamsize m_width;
-    const StringType &m_value;
-};
-
-/**
  * Locale facet to format numbers with comma separators.
  *
  * @author Timothy Flynn (trflynn89@pm.me)
@@ -71,34 +27,5 @@ protected:
      */
     std::string do_grouping() const override;
 };
-
-//==================================================================================================
-template <typename StringType>
-Center<StringType>::Center(std::size_t width, const StringType &value) :
-    m_width(static_cast<std::streamsize>(width)),
-    m_value(value)
-{
-}
-
-//==================================================================================================
-template <typename StringType>
-void Center<StringType>::print(std::ostream &stream) const
-{
-    const std::streamsize length = static_cast<std::streamsize>(m_value.size());
-
-    if (m_width > length)
-    {
-        const std::streamsize left = (m_width + length) / 2;
-
-        fly::detail::BasicStreamModifiers<std::string> scoped_modifiers(stream);
-        stream << std::right;
-        stream << std::setw(left) << m_value;
-        stream << std::setw(m_width - left) << "";
-    }
-    else
-    {
-        stream << m_value;
-    }
-}
 
 } // namespace fly::benchmark

--- a/bench/util/table.hpp
+++ b/bench/util/table.hpp
@@ -264,7 +264,7 @@ void Table<Args...>::print_title(std::ostream &stream, std::size_t table_width) 
     const std::size_t title_width = table_width - 4;
 
     auto title = std::string_view(m_title).substr(0, title_width);
-    fly::String::format(stream, "{} {} ", style, Center(title_width, title));
+    stream << style << fly::String::format(" {} ", Center(title_width, title));
 
     print_column_separator(stream, s_border_style) << '\n';
     print_row_separator(stream, table_width);
@@ -278,11 +278,10 @@ void Table<Args...>::print_headers(std::ostream &stream, std::size_t table_width
     {
         print_column_separator(stream, index == 0 ? s_border_style : fly::Style::Default);
 
-        fly::String::format(
-            stream,
-            "{} {} ",
-            fly::Styler(s_header_style, s_header_color),
-            Center(m_column_widths[index], m_headers[index]));
+        const auto style = fly::Styler(s_header_style, s_header_color);
+        stream << style;
+
+        stream << fly::String::format(" {} ", Center(m_column_widths[index], m_headers[index]));
     }
 
     print_column_separator(stream, s_border_style) << '\n';
@@ -298,21 +297,17 @@ void Table<Args...>::print_row(std::ostream &stream, const Row &row) const
     auto print_value = [this, &stream, &index](const auto &value)
     {
         print_column_separator(stream, index == 0 ? s_border_style : fly::Style::Default);
+
         const auto style = fly::Styler(s_data_style, s_data_color);
+        stream << style;
 
         if constexpr (std::is_floating_point_v<std::remove_cvref_t<decltype(value)>>)
         {
-            fly::String::format(
-                stream,
-                "{} {:{}.{}f} ",
-                style,
-                value,
-                m_column_widths[index],
-                s_precision);
+            fly::String::format(stream, " {:{}.{}f} ", value, m_column_widths[index], s_precision);
         }
         else
         {
-            fly::String::format(stream, "{} {:{}} ", style, value, m_column_widths[index]);
+            fly::String::format(stream, " {:{}} ", value, m_column_widths[index]);
         }
 
         ++index;
@@ -333,7 +328,7 @@ template <class... Args>
 std::ostream &
 Table<Args...>::print_row_separator(std::ostream &stream, std::size_t width, fly::Style style) const
 {
-    fly::String::format(stream, "{}{:->{}}\n", fly::Styler(style, s_border_color), '-', width);
+    stream << fly::Styler(style, s_border_color) << fly::String::format("{:->{}}\n", '-', width);
     return stream;
 }
 
@@ -341,7 +336,7 @@ Table<Args...>::print_row_separator(std::ostream &stream, std::size_t width, fly
 template <class... Args>
 std::ostream &Table<Args...>::print_column_separator(std::ostream &stream, fly::Style style) const
 {
-    fly::String::format(stream, "{}|", fly::Styler(style, s_border_color));
+    stream << fly::Styler(style, s_border_color) << '|';
     return stream;
 }
 

--- a/bench/util/table.hpp
+++ b/bench/util/table.hpp
@@ -264,7 +264,7 @@ void Table<Args...>::print_title(std::ostream &stream, std::size_t table_width) 
     const std::size_t title_width = table_width - 4;
 
     auto title = std::string_view(m_title).substr(0, title_width);
-    stream << style << fly::String::format(" {} ", Center(title_width, title));
+    stream << style << fly::String::format(" {:^{}} ", title, title_width);
 
     print_column_separator(stream, s_border_style) << '\n';
     print_row_separator(stream, table_width);
@@ -281,7 +281,7 @@ void Table<Args...>::print_headers(std::ostream &stream, std::size_t table_width
         const auto style = fly::Styler(s_header_style, s_header_color);
         stream << style;
 
-        stream << fly::String::format(" {} ", Center(m_column_widths[index], m_headers[index]));
+        stream << fly::String::format(" {:^{}} ", m_headers[index], m_column_widths[index]);
     }
 
     print_column_separator(stream, s_border_style) << '\n';

--- a/fly/logger/detail/console_sink.cpp
+++ b/fly/logger/detail/console_sink.cpp
@@ -47,7 +47,9 @@ bool ConsoleSink::stream(fly::Log &&log)
 
     {
         auto styler = color ? fly::Styler(std::move(style), *std::move(color)) : fly::Styler(style);
-        String::format(*stream, "{}{} {}", styler, fly::System::local_time(), log.m_trace);
+        *stream << styler;
+
+        String::format(*stream, "{} {}", fly::System::local_time(), log.m_trace);
     }
 
     *stream << ": " << log.m_message << std::endl;

--- a/fly/types/string/detail/string_classifier.hpp
+++ b/fly/types/string/detail/string_classifier.hpp
@@ -62,6 +62,34 @@ public:
     static constexpr bool is_lower(char_type ch);
 
     /**
+     * Converts the given character to an upper-case alphabetic character as classified by the
+     * default C locale.
+     *
+     * The STL's std:tosupper and std::towupper require that the provided character fits into an
+     * unsigned char and unsigned wchar_t, respectively. Other values result in undefined behavior.
+     * This method has no such restriction.
+     *
+     * @param ch The character to convert.
+     *
+     * @return The converted character.
+     */
+    static constexpr char_type to_upper(char_type ch);
+
+    /**
+     * Converts the given character to a lower-case alphabetic character as classified by the
+     * default C locale.
+     *
+     * The STL's std:toslower and std::towlower require that the provided character fits into an
+     * unsigned char and unsigned wchar_t, respectively. Other values result in undefined behavior.
+     * This method has no such restriction.
+     *
+     * @param ch The character to convert.
+     *
+     * @return The converted character.
+     */
+    static constexpr char_type to_lower(char_type ch);
+
+    /**
      * Checks if the given character is a decimal digit character.
      *
      * The STL's std::isdigit and std::iswdigit require that the provided character fits into an
@@ -105,7 +133,8 @@ private:
     static constexpr const char_type s_lower_a = FLY_CHR(char_type, 'a');
     static constexpr const char_type s_lower_z = FLY_CHR(char_type, 'z');
 
-    static constexpr const int_type s_case_mask = static_cast<int_type>(~0x20);
+    static constexpr const int_type s_case_bit = static_cast<int_type>(0x20);
+    static constexpr const int_type s_case_mask = static_cast<int_type>(~s_case_bit);
 };
 
 //==================================================================================================
@@ -127,6 +156,30 @@ template <typename StringType>
 constexpr inline bool BasicStringClassifier<StringType>::is_lower(char_type ch)
 {
     return (ch >= s_lower_a) && (ch <= s_lower_z);
+}
+
+//==================================================================================================
+template <typename StringType>
+constexpr inline auto BasicStringClassifier<StringType>::to_upper(char_type ch) -> char_type
+{
+    if (is_lower(ch))
+    {
+        ch = static_cast<char_type>(static_cast<int_type>(ch) & s_case_mask);
+    }
+
+    return ch;
+}
+
+//==================================================================================================
+template <typename StringType>
+constexpr inline auto BasicStringClassifier<StringType>::to_lower(char_type ch) -> char_type
+{
+    if (is_upper(ch))
+    {
+        ch = static_cast<char_type>(static_cast<int_type>(ch) | s_case_bit);
+    }
+
+    return ch;
 }
 
 //==================================================================================================

--- a/fly/types/string/detail/string_formatter.hpp
+++ b/fly/types/string/detail/string_formatter.hpp
@@ -27,7 +27,7 @@ class BasicStringFormatter
     using char_type = typename traits::char_type;
     using view_type = typename traits::view_type;
     using ostream_type = typename traits::ostream_type;
-    using streamed_char_type = typename streamer::streamed_char_type;
+    using streamed_char_type = typename traits::streamed_char_type;
 
     using FormatSpecifier = BasicFormatSpecifier<char_type>;
     using FormatString = BasicFormatString<StringType, ParameterTypes...>;

--- a/fly/types/string/detail/string_formatter.hpp
+++ b/fly/types/string/detail/string_formatter.hpp
@@ -1,19 +1,33 @@
 #pragma once
 
 #include "fly/traits/traits.hpp"
+#include "fly/types/string/detail/string_classifier.hpp"
 #include "fly/types/string/detail/string_formatter_types.hpp"
 #include "fly/types/string/detail/string_streamer.hpp"
 #include "fly/types/string/detail/string_traits.hpp"
+#include "fly/types/string/detail/string_unicode.hpp"
 #include "fly/types/string/string_literal.hpp"
 
+#include <array>
+#include <charconv>
+#include <cmath>
 #include <iomanip>
+#include <limits>
 #include <optional>
+#include <system_error>
 #include <type_traits>
 
 namespace fly::detail {
 
 /**
- * Helper class to format and stream generic values into a std::basic_string's output stream type.
+ * Helper trait to classify a type as an integer, excluding boolean types.
+ */
+template <typename T>
+using is_format_integral =
+    std::conjunction<std::is_integral<T>, std::negation<std::is_same<T, bool>>>;
+
+/**
+ * Class to format parameters according to a provided format string.
  *
  * @author Timothy Flynn (trflynn89@pm.me)
  * @version January 3, 2021
@@ -22,12 +36,12 @@ template <typename StringType, typename... ParameterTypes>
 class BasicStringFormatter
 {
     using traits = BasicStringTraits<StringType>;
-    using streamer = BasicStringStreamer<StringType>;
+    using classifier = BasicStringClassifier<StringType>;
     using stream_modifiers = BasicStreamModifiers<StringType>;
     using char_type = typename traits::char_type;
     using view_type = typename traits::view_type;
-    using ostream_type = typename traits::ostream_type;
     using streamed_char_type = typename traits::streamed_char_type;
+    using ostringstream_type = typename traits::ostringstream_type;
 
     using FormatSpecifier = BasicFormatSpecifier<char_type>;
     using FormatString = BasicFormatString<StringType, ParameterTypes...>;
@@ -62,22 +76,27 @@ public:
      * compile error with a diagnostic message will be raised. On other compilers, the error message
      * will returned rather than a formatted string.
      *
-     * @param stream The stream to insert the formatted string into.
      * @param parameters The variadic list of format parameters to be formatted.
      */
-    BasicStringFormatter(ostream_type &stream, ParameterTypes &&...parameters) noexcept;
+    BasicStringFormatter(ParameterTypes &&...parameters) noexcept;
 
     /**
-     * Format the provided format string with the format parameters, inserting the formatted string
-     * into thea stream.
+     * Format the provided format string with the format parameters, returning the result as a
+     * string.
      *
      * @param fmt The string to format.
+     *
+     * @return The formatted result.
      */
-    void format(FormatString &&fmt);
+    StringType format(FormatString &&fmt);
 
 private:
     /**
      * Format a single replacement field with the provided generic value.
+     *
+     * Currently, rather than supporting a set of std::formatter specializations, the generic value
+     * will be converted to a string via the streaming operator. The resulting string will then be
+     * formatted using the string formatting overload.
      *
      * @tparam T The type of the value to format.
      *
@@ -86,7 +105,7 @@ private:
      */
     template <
         typename T,
-        fly::disable_if_any<detail::is_like_supported_string<T>, std::is_integral<T>> = 0>
+        fly::disable_if_any<detail::is_like_supported_string<T>, std::is_arithmetic<T>> = 0>
     void format_value(FormatSpecifier &&specifier, const T &value);
 
     /**
@@ -101,38 +120,86 @@ private:
     void format_value(FormatSpecifier &&specifier, const T &value);
 
     /**
-     * Format a single replacement field with the provided integral value.
+     * Format a single replacement field with the provided non-boolean integral value.
      *
      * @tparam T The type of the value to format.
      *
      * @param specifier The replacement field to format.
      * @param value The value to format.
      */
-    template <typename T, fly::enable_if<std::is_integral<T>> = 0>
+    template <typename T, fly::enable_if<is_format_integral<T>> = 0>
+    void format_value(FormatSpecifier &&specifier, T value);
+
+    /**
+     * Format a single replacement field with the provided unsigned, non-boolean integral value.
+     *
+     * @tparam T The type of the value to format.
+     *
+     * @param specifier The replacement field to format.
+     * @param value The value to format.
+     * @param is_negative Whether the original value was negative.
+     */
+    template <typename T, fly::enable_if<is_format_integral<T>> = 0>
+    void format_value(FormatSpecifier &&specifier, T value, bool is_negative);
+
+    /**
+     * Format a single replacement field with the provided floating point value.
+     *
+     * Currently, major compilers do not support std::to_chars for floating point values. Until they
+     * do, this implementation uses an IO stream to format the value.
+     *
+     * @tparam T The type of the value to format.
+     *
+     * @param specifier The replacement field to format.
+     * @param value The value to format.
+     */
+    template <typename T, fly::enable_if<std::is_floating_point<T>> = 0>
     void format_value(FormatSpecifier &&specifier, const T &value);
 
     /**
-     * Handle formatting options for generic format parameter types.
-     *
-     * @param modifiers The active stream manipulator container.
-     * @param specifier The replacement field to format.
-     */
-    void set_generic_options(stream_modifiers &modifiers, const FormatSpecifier &specifier) const;
-
-    /**
-     * Handle formatting options for numeric format parameter types.
+     * Format a single replacement field with the provided boolean value.
      *
      * @tparam T The type of the value to format.
      *
-     * @param modifiers The active stream manipulator container.
      * @param specifier The replacement field to format.
      * @param value The value to format.
      */
-    template <typename T, fly::enable_if<std::is_arithmetic<T>> = 0>
-    void set_numeric_options(
-        stream_modifiers &modifiers,
-        const FormatSpecifier &specifier,
-        const T &value) const;
+    template <typename T, fly::enable_if<std::is_same<T, bool>> = 0>
+    void format_value(FormatSpecifier &&specifier, T value);
+
+    /**
+     * Append a string-like value to the buffer, with an optional maximum string length.
+     *
+     * If the string-like value's character type is the same as the format string, the value is
+     * inserted directly. Otherwise, it is first transcoded to the appropriate Unicode encoding.
+     *
+     * @tparam T The type of the value to append.
+     *
+     * @param value The value to append.
+     * @param max_width The maximum number of characters from the value to append.
+     */
+    template <typename T, fly::enable_if<detail::is_like_supported_string<T>> = 0>
+    void append_string(const T &value, std::size_t max_width = StringType::npos);
+
+    /**
+     * Append the string representation of a base-N integral value to the buffer, where N is the
+     * provided integer base.
+     *
+     * Internally, std::to_chars is used for the conversion. Since std::to_chars only supports
+     * char-based strings, this method behaves differently depending on the type of the format
+     * string. If the format string is char-based, the conversion is applied directly to the buffer.
+     * Otherwise, an intermediate char-based buffer is used for the conversion, then that buffer is
+     * transcoded to the appropriate Unicode encoding, incurring extra string copying.
+     *
+     * @tparam T The type of the value to append.
+     *
+     * @param value The value to convert.
+     * @param base The base to use.
+     *
+     * @return The number of base-N digits converted.
+     */
+    template <typename T, fly::enable_if<is_format_integral<T>> = 0>
+    std::size_t append_number(T value, int base);
 
     /**
      * The width and precision formatting options may either be a number or a nested replacement
@@ -147,46 +214,61 @@ private:
      * @return If either option was specified, and the corresponding value is non-negative, returns
      *         that value. Otherwise, an uninitialized value.
      */
-    template <typename T = std::streamsize>
-    std::optional<T> resolve_size(
-        const std::optional<typename FormatSpecifier::SizeOrPosition> &size_or_position) const;
+    template <typename T = std::size_t>
+    T resolve_size(
+        const std::optional<typename FormatSpecifier::SizeOrPosition> &size_or_position,
+        T fallback = 0) const;
+
+    /**
+     * Count the number of base-N digits in a value, where N is the provided integer base.
+     *
+     * @param value The value to count digits in.
+     * @param base The base to use.
+     *
+     * @return The number of base-N digits in the value.
+     */
+    template <typename T, fly::enable_if<is_format_integral<T>> = 0>
+    std::size_t count_digits(T value, int base);
 
     static constexpr const auto s_left_brace = FLY_CHR(char_type, '{');
     static constexpr const auto s_right_brace = FLY_CHR(char_type, '}');
-    static constexpr const auto s_zero = FLY_CHR(streamed_char_type, '0');
+    static constexpr const auto s_plus_sign = FLY_CHR(char_type, '+');
+    static constexpr const auto s_minus_sign = FLY_CHR(char_type, '-');
+    static constexpr const auto s_space = FLY_CHR(char_type, ' ');
+    static constexpr const auto s_zero = FLY_CHR(char_type, '0');
+    static constexpr const auto s_lower_b = FLY_CHR(char_type, 'b');
+    static constexpr const auto s_upper_b = FLY_CHR(char_type, 'B');
+    static constexpr const auto s_lower_x = FLY_CHR(char_type, 'x');
+    static constexpr const auto s_upper_x = FLY_CHR(char_type, 'X');
 
-    ostream_type &m_stream;
+    static constexpr const char_type *s_true = FLY_STR(char_type, "true");
+    static constexpr const char_type *s_false = FLY_STR(char_type, "false");
+
+    static inline thread_local ostringstream_type s_stream;
+
     const FormatParameters m_parameters;
+    StringType m_buffer;
 };
 
 //==================================================================================================
 template <typename StringType, typename... ParameterTypes>
 BasicStringFormatter<StringType, ParameterTypes...>::BasicStringFormatter(
-    ostream_type &stream,
     ParameterTypes &&...parameters) noexcept :
-    m_stream(stream),
     m_parameters(std::forward<ParameterTypes>(parameters)...)
 {
 }
 
 //==================================================================================================
 template <typename StringType, typename... ParameterTypes>
-void BasicStringFormatter<StringType, ParameterTypes...>::format(FormatString &&fmt)
+StringType BasicStringFormatter<StringType, ParameterTypes...>::format(FormatString &&fmt)
 {
     auto formatter = [this](auto &&specifier, const auto &value)
     {
-        stream_modifiers modifiers(m_stream);
-        set_generic_options(modifiers, specifier);
-
-        if constexpr (std::is_arithmetic_v<std::remove_cvref_t<decltype(value)>>)
-        {
-            set_numeric_options(modifiers, specifier, value);
-        }
-
-        format_value(std::move(specifier), value);
+        this->format_value(std::move(specifier), value);
     };
 
     const view_type view = fmt.view();
+    m_buffer.reserve(view.size() * 2);
 
     for (std::size_t pos = 0; pos < view.size();)
     {
@@ -195,7 +277,7 @@ void BasicStringFormatter<StringType, ParameterTypes...>::format(FormatString &&
             case s_left_brace:
                 if (view[pos + 1] == s_left_brace)
                 {
-                    streamer::stream_value(m_stream, ch);
+                    m_buffer.push_back(ch);
                     pos += 2;
                 }
                 else
@@ -208,26 +290,32 @@ void BasicStringFormatter<StringType, ParameterTypes...>::format(FormatString &&
                 break;
 
             case s_right_brace:
-                streamer::stream_value(m_stream, ch);
+                m_buffer.push_back(ch);
                 pos += 2;
                 break;
 
             default:
-                streamer::stream_value(m_stream, ch);
+                m_buffer.push_back(ch);
                 ++pos;
                 break;
         }
     }
+
+    return std::move(m_buffer);
 }
 
 //==================================================================================================
 template <typename StringType, typename... ParameterTypes>
-template <typename T, fly::disable_if_any<detail::is_like_supported_string<T>, std::is_integral<T>>>
+template <
+    typename T,
+    fly::disable_if_any<detail::is_like_supported_string<T>, std::is_arithmetic<T>>>
 inline void BasicStringFormatter<StringType, ParameterTypes...>::format_value(
-    FormatSpecifier &&,
+    FormatSpecifier &&specifier,
     const T &value)
 {
-    streamer::stream_value(m_stream, value);
+    s_stream << value;
+    format_value(std::move(specifier), s_stream.str());
+    s_stream.str({});
 }
 
 //==================================================================================================
@@ -237,48 +325,178 @@ inline void BasicStringFormatter<StringType, ParameterTypes...>::format_value(
     FormatSpecifier &&specifier,
     const T &value)
 {
-    // There isn't a standard manipulator to limit the number of characters from the string that are
-    // written to the stream. Instead, inform the streamer to limit the streamed length.
-    if (const auto max_string_length = resolve_size<std::size_t>(specifier.m_precision);
-        max_string_length)
+    using string_like_type = detail::is_like_supported_string_t<T>;
+
+    const std::size_t min_width = resolve_size(specifier.m_width);
+    const std::size_t max_width = resolve_size(specifier.m_precision, StringType::npos);
+
+    const std::size_t actual_size = BasicStringClassifier<string_like_type>::size(value);
+    const std::size_t value_size = std::min(max_width, actual_size);
+
+    const std::size_t padding_size = std::max(value_size, min_width) - value_size;
+    const auto padding_char = specifier.m_fill ? *specifier.m_fill : s_space;
+
+    switch (specifier.m_alignment)
     {
-        streamer::stream_string(m_stream, value, *max_string_length);
-    }
-    else
-    {
-        streamer::stream_string(m_stream, value, StringType::npos);
+        case FormatSpecifier::Alignment::Left:
+        case FormatSpecifier::Alignment::Default:
+            append_string(value, max_width);
+            m_buffer.append(padding_size, padding_char);
+            break;
+
+        case FormatSpecifier::Alignment::Right:
+            m_buffer.append(padding_size, padding_char);
+            append_string(value, max_width);
+            break;
+
+        case FormatSpecifier::Alignment::Center:
+        {
+            const std::size_t left_padding = padding_size / 2;
+            const std::size_t right_padding =
+                (padding_size % 2 == 0) ? left_padding : left_padding + 1;
+
+            m_buffer.append(left_padding, padding_char);
+            append_string(value, max_width);
+            m_buffer.append(right_padding, padding_char);
+            break;
+        }
     }
 }
 
 //==================================================================================================
 template <typename StringType, typename... ParameterTypes>
-template <typename T, fly::enable_if<std::is_integral<T>>>
+template <typename T, fly::enable_if<is_format_integral<T>>>
+inline void BasicStringFormatter<StringType, ParameterTypes...>::format_value(
+    FormatSpecifier &&specifier,
+    T value)
+{
+    if constexpr (std::is_signed_v<T>)
+    {
+        using unsigned_type = std::make_unsigned_t<std::remove_cvref_t<T>>;
+
+        // Compute the absolute value of the integer. Benchmarks showed this is exactly as fast as
+        // std::abs, but this also tracks whether the original value was negative without branches.
+        const T sign = value >> std::numeric_limits<T>::digits;
+        value ^= sign;
+        value += sign & 1;
+
+        format_value(std::move(specifier), static_cast<unsigned_type>(value), sign);
+    }
+    else
+    {
+        format_value(std::move(specifier), value, false);
+    }
+}
+
+//==================================================================================================
+template <typename StringType, typename... ParameterTypes>
+template <typename T, fly::enable_if<is_format_integral<T>>>
+void BasicStringFormatter<StringType, ParameterTypes...>::format_value(
+    FormatSpecifier &&specifier,
+    T value,
+    bool is_negative)
+{
+    const std::size_t original_size = m_buffer.size();
+    std::size_t prefix_size = 0;
+    std::size_t value_size = 0;
+
+    if (specifier.m_type == FormatSpecifier::Type::Character)
+    {
+        // TODO: Validate the value fits into char_type / convert Unicode encoding.
+        m_buffer.push_back(static_cast<char_type>(value));
+        value_size = 1;
+    }
+    else
+    {
+        const bool is_upper_case = specifier.m_case == FormatSpecifier::Case::Upper;
+        const int base = static_cast<int>(specifier.m_type);
+
+        if (is_negative)
+        {
+            m_buffer.push_back(s_minus_sign);
+        }
+        else if (specifier.m_sign == FormatSpecifier::Sign::Always)
+        {
+            m_buffer.push_back(s_plus_sign);
+        }
+        else if (specifier.m_sign == FormatSpecifier::Sign::NegativeOnlyWithPositivePadding)
+        {
+            m_buffer.push_back(s_space);
+        }
+
+        if (specifier.m_alternate_form)
+        {
+            m_buffer.push_back(s_zero);
+
+            if (specifier.m_type == FormatSpecifier::Type::Binary)
+            {
+                m_buffer.push_back(is_upper_case ? s_upper_b : s_lower_b);
+            }
+            else if (specifier.m_type == FormatSpecifier::Type::Hex)
+            {
+                m_buffer.push_back(is_upper_case ? s_upper_x : s_lower_x);
+            }
+        }
+
+        prefix_size = m_buffer.size() - original_size;
+        value_size = append_number(value, base) + prefix_size;
+
+        if ((specifier.m_type == FormatSpecifier::Type::Hex) && is_upper_case)
+        {
+            for (std::size_t i = original_size + prefix_size; i < m_buffer.size(); ++i)
+            {
+                m_buffer[i] = classifier::to_upper(m_buffer[i]);
+            }
+        }
+    }
+
+    const std::size_t width = resolve_size(specifier.m_width);
+    const std::size_t padding_size = std::max(value_size, width) - value_size;
+    const char_type padding_char = specifier.m_fill ? *specifier.m_fill : s_space;
+
+    switch (specifier.m_alignment)
+    {
+        case FormatSpecifier::Alignment::Left:
+            m_buffer.append(padding_size, padding_char);
+            break;
+
+        case FormatSpecifier::Alignment::Right:
+            m_buffer.insert(original_size, padding_size, padding_char);
+            break;
+
+        case FormatSpecifier::Alignment::Center:
+        {
+            const std::size_t left_padding = padding_size / 2;
+            const std::size_t right_padding =
+                (padding_size % 2 == 0) ? left_padding : left_padding + 1;
+
+            m_buffer.insert(original_size, left_padding, padding_char);
+            m_buffer.append(right_padding, padding_char);
+            break;
+        }
+
+        case FormatSpecifier::Alignment::Default:
+            if (specifier.m_zero_padding)
+            {
+                m_buffer.insert(original_size + prefix_size, padding_size, s_zero);
+            }
+            else
+            {
+                m_buffer.insert(original_size, padding_size, padding_char);
+            }
+            break;
+    }
+}
+
+//==================================================================================================
+template <typename StringType, typename... ParameterTypes>
+template <typename T, fly::enable_if<std::is_floating_point<T>>>
 inline void BasicStringFormatter<StringType, ParameterTypes...>::format_value(
     FormatSpecifier &&specifier,
     const T &value)
 {
-    if (specifier.m_type == FormatSpecifier::Type::Character)
-    {
-        // TODO: Validate the value fits into streamed_char_type / convert Unicode encoding.
-        streamer::template stream_value<decltype(value), streamed_char_type>(m_stream, value);
-    }
-    else
-    {
-        using preferred_type = std::conditional_t<
-            std::is_same_v<T, bool>,
-            bool,
-            std::conditional_t<std::is_signed_v<T>, std::intmax_t, std::uintmax_t>>;
+    stream_modifiers modifiers(s_stream);
 
-        streamer::template stream_value<decltype(value), preferred_type>(m_stream, value);
-    }
-}
-
-//==================================================================================================
-template <typename StringType, typename... ParameterTypes>
-void BasicStringFormatter<StringType, ParameterTypes...>::set_generic_options(
-    stream_modifiers &modifiers,
-    const FormatSpecifier &specifier) const
-{
     if (specifier.m_fill)
     {
         modifiers.fill(static_cast<streamed_char_type>(*specifier.m_fill));
@@ -300,20 +518,6 @@ void BasicStringFormatter<StringType, ParameterTypes...>::set_generic_options(
             break;
     }
 
-    if (const auto width = resolve_size(specifier.m_width); width && (*width > 0))
-    {
-        modifiers.width(*width);
-    }
-}
-
-//==================================================================================================
-template <typename StringType, typename... ParameterTypes>
-template <typename T, fly::enable_if<std::is_arithmetic<T>>>
-void BasicStringFormatter<StringType, ParameterTypes...>::set_numeric_options(
-    stream_modifiers &modifiers,
-    const FormatSpecifier &specifier,
-    const T &value) const
-{
     switch (specifier.m_sign)
     {
         case FormatSpecifier::Sign::Always:
@@ -331,88 +535,137 @@ void BasicStringFormatter<StringType, ParameterTypes...>::set_numeric_options(
 
     if (specifier.m_alternate_form)
     {
-        if constexpr (std::is_integral_v<T>)
-        {
-            modifiers.setf(std::ios_base::showbase);
-        }
-        else
-        {
-            modifiers.setf(std::ios_base::showpoint);
-        }
+        modifiers.setf(std::ios_base::showpoint);
     }
 
     if (specifier.m_zero_padding)
     {
         modifiers.setf(std::ios_base::internal, std::ios_base::adjustfield);
-        modifiers.fill(s_zero);
+        modifiers.fill(static_cast<streamed_char_type>(s_zero));
     }
 
-    if constexpr (std::is_integral_v<T>)
+    modifiers.width(resolve_size<std::streamsize>(specifier.m_width));
+    modifiers.precision(resolve_size<std::streamsize>(specifier.m_precision, 6));
+
+    switch (specifier.m_type)
     {
-        switch (specifier.m_type)
-        {
-            case FormatSpecifier::Type::String:
-                modifiers.setf(std::ios_base::boolalpha);
-                break;
+        case FormatSpecifier::Type::HexFloat:
+            modifiers.setf(std::ios_base::fixed | std::ios_base::scientific);
+            break;
 
-            case FormatSpecifier::Type::Binary:
-                modifiers.template locale<BinaryFacet<streamed_char_type>>();
-                break;
+        case FormatSpecifier::Type::Scientific:
+            modifiers.setf(std::ios_base::scientific, std::ios::floatfield);
+            break;
 
-            case FormatSpecifier::Type::Octal:
-                modifiers.setf(std::ios_base::oct, std::ios::basefield);
-                break;
+        case FormatSpecifier::Type::Fixed:
+            // Only Apple's Clang seems to respect std::uppercase with std::fixed values. To
+            // ensure consistency, format these values as general types.
+            if (!std::isnan(value) && !std::isinf(value))
+            {
+                modifiers.setf(std::ios_base::fixed, std::ios::floatfield);
+            }
+            break;
 
-            case FormatSpecifier::Type::Hex:
-                modifiers.setf(std::ios_base::hex, std::ios::basefield);
-                break;
-
-            default:
-                break;
-        }
-    }
-    else
-    {
-        if (const auto precision = resolve_size(specifier.m_precision); precision)
-        {
-            modifiers.precision(*precision);
-        }
-
-        switch (specifier.m_type)
-        {
-            case FormatSpecifier::Type::HexFloat:
-                modifiers.setf(std::ios_base::fixed | std::ios_base::scientific);
-                break;
-
-            case FormatSpecifier::Type::Scientific:
-                modifiers.setf(std::ios_base::scientific, std::ios::floatfield);
-                break;
-
-            case FormatSpecifier::Type::Fixed:
-                // Only Apple's Clang seems to respect std::uppercase with std::fixed values. To
-                // ensure consistency, format these values as general types.
-                if (!std::isnan(value) && !std::isinf(value))
-                {
-                    modifiers.setf(std::ios_base::fixed, std::ios::floatfield);
-                }
-                break;
-
-            default:
-                break;
-        }
+        default:
+            break;
     }
 
     if (specifier.m_case == FormatSpecifier::Case::Upper)
     {
         modifiers.setf(std::ios_base::uppercase);
     }
+
+    s_stream << value;
+    append_string(s_stream.str());
+    s_stream.str({});
+}
+
+//==================================================================================================
+template <typename StringType, typename... ParameterTypes>
+template <typename T, fly::enable_if<std::is_same<T, bool>>>
+inline void BasicStringFormatter<StringType, ParameterTypes...>::format_value(
+    FormatSpecifier &&specifier,
+    T value)
+{
+    if (specifier.m_type == FormatSpecifier::Type::String)
+    {
+        format_value(std::move(specifier), value ? s_true : s_false);
+    }
+    else
+    {
+        format_value(std::move(specifier), static_cast<unsigned>(value));
+    }
+}
+
+//==================================================================================================
+template <typename StringType, typename... ParameterTypes>
+template <typename T, fly::enable_if<detail::is_like_supported_string<T>>>
+void BasicStringFormatter<StringType, ParameterTypes...>::append_string(
+    const T &value,
+    std::size_t max_width)
+{
+    using string_like_type = detail::is_like_supported_string_t<T>;
+    using view_like_type = std::basic_string_view<typename string_like_type::value_type>;
+
+    if constexpr (std::is_same_v<StringType, string_like_type>)
+    {
+        m_buffer.append(value, 0, max_width);
+    }
+    else
+    {
+        using unicode = BasicStringUnicode<string_like_type>;
+        view_like_type view(value);
+
+        auto it = view.cbegin();
+        const auto end = view.cend();
+
+        if (auto converted = unicode::template convert_encoding<StringType>(it, end); converted)
+        {
+            m_buffer.append(*std::move(converted), 0, max_width);
+        }
+    }
+}
+
+//==================================================================================================
+template <typename StringType, typename... ParameterTypes>
+template <typename T, fly::enable_if<is_format_integral<T>>>
+std::size_t BasicStringFormatter<StringType, ParameterTypes...>::append_number(T value, int base)
+{
+    const std::size_t digits = count_digits(value, base);
+
+    if constexpr (std::is_same_v<StringType, std::string>)
+    {
+        m_buffer.resize(m_buffer.size() + digits);
+
+        char *end = m_buffer.data() + m_buffer.size();
+        char *begin = end - digits;
+
+        std::to_chars(begin, end, value, base);
+    }
+    else
+    {
+        static thread_local std::array<char, std::numeric_limits<std::uintmax_t>::digits> s_buffer;
+        using unicode = BasicStringUnicode<std::string>;
+
+        char *begin = s_buffer.data();
+        char *end = begin + s_buffer.size();
+
+        const auto result = std::to_chars(begin, end, value, base);
+
+        // TODO: Support something like "convert_encoding_into" to avoid a string copy.
+        auto converted = unicode::template convert_encoding<StringType>(begin, result.ptr);
+        m_buffer.append(*converted);
+    }
+
+    return digits;
 }
 
 //==================================================================================================
 template <typename StringType, typename... ParameterTypes>
 template <typename T>
-inline std::optional<T> BasicStringFormatter<StringType, ParameterTypes...>::resolve_size(
-    const std::optional<typename FormatSpecifier::SizeOrPosition> &size_or_position) const
+inline T BasicStringFormatter<StringType, ParameterTypes...>::resolve_size(
+    const std::optional<typename FormatSpecifier::SizeOrPosition> &size_or_position,
+    T fallback) const
 {
     if (size_or_position)
     {
@@ -429,7 +682,23 @@ inline std::optional<T> BasicStringFormatter<StringType, ParameterTypes...>::res
         }
     }
 
-    return std::nullopt;
+    return fallback;
+}
+
+//==================================================================================================
+template <typename StringType, typename... ParameterTypes>
+template <typename T, fly::enable_if<is_format_integral<T>>>
+inline std::size_t
+BasicStringFormatter<StringType, ParameterTypes...>::count_digits(T value, int base)
+{
+    std::size_t digits = 0;
+
+    do
+    {
+        ++digits;
+    } while ((value /= static_cast<T>(base)) != 0);
+
+    return digits;
 }
 
 } // namespace fly::detail

--- a/fly/types/string/detail/string_formatter_types.hpp
+++ b/fly/types/string/detail/string_formatter_types.hpp
@@ -142,20 +142,22 @@ struct BasicFormatSpecifier
         NegativeOnlyWithPositivePadding,
     };
 
+    // For runtime convenience, this enumeration is valued such that binary, octal, decimal, and
+    // hexadecimal presentation types correspond to their base (2, 8, 10, and 16, respectively).
     enum class Type : std::uint8_t
     {
-        None,
-        Character,
-        String,
-        Pointer,
-        Binary,
-        Octal,
-        Decimal,
-        Hex,
-        HexFloat,
-        Scientific,
-        Fixed,
-        General,
+        None = 20,
+        Character = 21,
+        String = 22,
+        Pointer = 23,
+        Binary = 2,
+        Octal = 8,
+        Decimal = 10,
+        Hex = 16,
+        HexFloat = 24,
+        Scientific = 25,
+        Fixed = 26,
+        General = 27,
     };
 
     enum class Case : std::uint8_t

--- a/fly/types/string/detail/string_streamer.hpp
+++ b/fly/types/string/detail/string_streamer.hpp
@@ -32,7 +32,7 @@ struct BasicStringStreamer
 
     using ostream_type = typename traits::ostream_type;
     using streamed_type = typename traits::streamed_type;
-    using streamed_char_type = typename streamed_type::value_type;
+    using streamed_char_type = typename traits::streamed_char_type;
 
     /**
      * Stream the given value into the given stream.
@@ -82,10 +82,10 @@ struct BasicStringStreamer
 template <typename StringType>
 class BasicStreamModifiers
 {
-    using streamer = BasicStringStreamer<StringType>;
+    using traits = BasicStringTraits<StringType>;
 
-    using ostream_type = typename streamer::ostream_type;
-    using streamed_char_type = typename streamer::streamed_char_type;
+    using ostream_type = typename traits::ostream_type;
+    using streamed_char_type = typename traits::streamed_char_type;
 
 public:
     /**

--- a/fly/types/string/detail/string_traits.hpp
+++ b/fly/types/string/detail/string_traits.hpp
@@ -107,6 +107,7 @@ struct BasicStringTraits
 
     using streamer_traits = BasicStringStreamerTraits<StringType>;
     using streamed_type = typename streamer_traits::streamed_type;
+    using streamed_char_type = typename streamed_type::value_type;
 
     using istream_type = typename streamer_traits::istream_type;
     using ostream_type = typename streamer_traits::ostream_type;

--- a/fly/types/string/string.hpp
+++ b/fly/types/string/string.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "fly/traits/traits.hpp"
 #include "fly/types/string/detail/string_classifier.hpp"
 #include "fly/types/string/detail/string_converter.hpp"
 #include "fly/types/string/detail/string_formatter.hpp"
@@ -82,7 +81,7 @@ public:
      * @return The length of the string-like value.
      */
     template <typename T, enable_if<detail::is_like_supported_string<T>> = 0>
-    static size_type size(const T &value);
+    static size_type size(T &&value);
 
     /**
      * Checks if the given character is an alphabetic character as classified by the default C
@@ -536,18 +535,9 @@ private:
 //==================================================================================================
 template <typename StringType>
 template <typename T, enable_if<detail::is_like_supported_string<T>>>
-auto BasicString<StringType>::size(const T &value) -> size_type
+auto BasicString<StringType>::size(T &&value) -> size_type
 {
-    using U = std::decay_t<T>;
-
-    if constexpr (any_same_v<U, StringType, std::basic_string_view<char_type>>)
-    {
-        return value.size();
-    }
-    else
-    {
-        return std::char_traits<char_type>::length(value);
-    }
+    return classifier::size(std::forward<T>(value));
 }
 
 //==================================================================================================

--- a/fly/types/string/string.hpp
+++ b/fly/types/string/string.hpp
@@ -127,6 +127,34 @@ public:
     static constexpr bool is_lower(char_type ch);
 
     /**
+     * Converts the given character to an upper-case alphabetic character as classified by the
+     * default C locale.
+     *
+     * The STL's std:tosupper and std::towupper require that the provided character fits into an
+     * unsigned char and unsigned wchar_t, respectively. Other values result in undefined behavior.
+     * This method has no such restriction.
+     *
+     * @param ch The character to convert.
+     *
+     * @return The converted character.
+     */
+    static constexpr char_type to_upper(char_type ch);
+
+    /**
+     * Converts the given character to a lower-case alphabetic character as classified by the
+     * default C locale.
+     *
+     * The STL's std:toslower and std::towlower require that the provided character fits into an
+     * unsigned char and unsigned wchar_t, respectively. Other values result in undefined behavior.
+     * This method has no such restriction.
+     *
+     * @param ch The character to convert.
+     *
+     * @return The converted character.
+     */
+    static constexpr char_type to_lower(char_type ch);
+
+    /**
      * Checks if the given character is a decimal digit character.
      *
      * The STL's std::isdigit and std::iswdigit require that the provided character fits into an
@@ -548,6 +576,20 @@ template <typename StringType>
 constexpr inline bool BasicString<StringType>::is_digit(char_type ch)
 {
     return classifier::is_digit(ch);
+}
+
+//==================================================================================================
+template <typename StringType>
+constexpr inline auto BasicString<StringType>::to_upper(char_type ch) -> char_type
+{
+    return classifier::to_upper(ch);
+}
+
+//==================================================================================================
+template <typename StringType>
+constexpr inline auto BasicString<StringType>::to_lower(char_type ch) -> char_type
+{
+    return classifier::to_lower(ch);
 }
 
 //==================================================================================================

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -44,7 +44,7 @@ public:
     void testCaseStarting(const Catch::TestCaseInfo &info) override
     {
         const auto style = fly::Styler(fly::Style::Bold, fly::Color::Green);
-        fly::String::format(stream, "[{}{:=>4}{} Test{:=<4}]\n", style, ' ', info.name, ' ');
+        stream << style << fly::String::format("[{:=>4}{} Test{:=<4}]\n", ' ', info.name, ' ');
 
         Catch::ConsoleReporter::testCaseStarting(info);
 
@@ -57,7 +57,7 @@ public:
         if (info.name != m_current_test_case)
         {
             const auto style = fly::Styler(fly::Style::Italic, fly::Color::Cyan);
-            fly::String::format(stream, "{}[ {} ]\n", style, info.name);
+            stream << style << fly::String::format("[ {} ]\n", info.name);
         }
 
         Catch::ConsoleReporter::sectionStarting(info);
@@ -72,19 +72,23 @@ public:
 
         if (stats.totals.assertions.allOk())
         {
+            const auto style = fly::Styler(fly::Style::Bold, fly::Color::Green);
+            stream << style;
+
             fly::String::format(
                 stream,
-                "{}[==== PASSED {} ({:.3f} seconds) ====]\n\n",
-                fly::Styler(fly::Style::Bold, fly::Color::Green),
+                "[==== PASSED {} ({:.3f} seconds) ====]\n\n",
                 name,
                 duration.count());
         }
         else
         {
+            const auto style = fly::Styler(fly::Style::Bold, fly::Color::Red);
+            stream << style;
+
             fly::String::format(
                 stream,
-                "{}[==== FAILED {} ({:.3f} seconds) ====]\n\n",
-                fly::Styler(fly::Style::Bold, fly::Color::Red),
+                "[==== FAILED {} ({:.3f} seconds) ====]\n\n",
                 name,
                 duration.count());
         }

--- a/test/types/string/string.cpp
+++ b/test/types/string/string.cpp
@@ -61,20 +61,8 @@ CATCH_TEMPLATE_TEST_CASE(
     using BasicString = fly::BasicString<StringType>;
     using size_type = typename BasicString::size_type;
     using char_type = typename BasicString::char_type;
-    using view_type = typename BasicString::view_type;
     using streamed_type = typename BasicString::streamed_type;
     using streamed_char = typename streamed_type::value_type;
-
-    CATCH_SECTION("Get the size of a string-like type")
-    {
-        const char_type *cstr = FLY_STR(char_type, "ten chars!");
-        StringType str = cstr;
-        view_type view = str;
-
-        CATCH_CHECK(BasicString::size(cstr) == 10);
-        CATCH_CHECK(BasicString::size(str) == 10);
-        CATCH_CHECK(BasicString::size(view) == 10);
-    }
 
     CATCH_SECTION("Split a string by a character delimeter")
     {

--- a/test/types/string/string_classifier.cpp
+++ b/test/types/string/string_classifier.cpp
@@ -17,6 +17,18 @@ CATCH_TEMPLATE_TEST_CASE(
     using StringType = TestType;
     using BasicString = fly::BasicString<StringType>;
     using char_type = typename BasicString::char_type;
+    using view_type = typename BasicString::view_type;
+
+    CATCH_SECTION("Get the size of a string-like type")
+    {
+        const char_type *cstr = FLY_STR(char_type, "ten chars!");
+        StringType str = cstr;
+        view_type view = str;
+
+        CATCH_CHECK(BasicString::size(cstr) == 10);
+        CATCH_CHECK(BasicString::size(str) == 10);
+        CATCH_CHECK(BasicString::size(view) == 10);
+    }
 
     CATCH_SECTION("Check if a character is an alphabetic character")
     {

--- a/test/types/string/string_classifier.cpp
+++ b/test/types/string/string_classifier.cpp
@@ -86,6 +86,52 @@ CATCH_TEMPLATE_TEST_CASE(
         }
     }
 
+    CATCH_SECTION("Convert a character to an upper-case alphabetic character")
+    {
+        for (char_type ch = 0; (ch >= 0) && (ch < 0x80); ++ch)
+        {
+            CATCH_CHECK(
+                BasicString::to_upper(ch) ==
+                static_cast<char_type>(std::toupper(static_cast<unsigned char>(ch))));
+        }
+
+        if constexpr (sizeof(char_type) > 1)
+        {
+            // Spot check some values that incorrectly result in std::toupper returning an
+            // upper-case character when cast to unsigned char (which is how the spec suggests to
+            // avoid undefined behavior).
+            for (char_type ch = 0xaa41; ch <= 0xaa5a; ++ch)
+            {
+                CATCH_CHECK(
+                    ch != static_cast<char_type>(std::toupper(static_cast<unsigned char>(ch))));
+                CATCH_CHECK(ch == BasicString::to_upper(ch));
+            }
+        }
+    }
+
+    CATCH_SECTION("Convert a character to a lower-case alphabetic character")
+    {
+        for (char_type ch = 0; (ch >= 0) && (ch < 0x80); ++ch)
+        {
+            CATCH_CHECK(
+                BasicString::to_lower(ch) ==
+                static_cast<char_type>(std::tolower(static_cast<unsigned char>(ch))));
+        }
+
+        if constexpr (sizeof(char_type) > 1)
+        {
+            // Spot check some values that incorrectly result in std::toupper returning a lower-case
+            // character when cast to unsigned char (which is how the spec suggests to avoid
+            // undefined behavior).
+            for (char_type ch = 0xaa61; ch <= 0xaa7a; ++ch)
+            {
+                CATCH_CHECK(
+                    ch != static_cast<char_type>(std::tolower(static_cast<unsigned char>(ch))));
+                CATCH_CHECK(ch == BasicString::to_lower(ch));
+            }
+        }
+    }
+
     CATCH_SECTION("Check if a character is a decimal digit character")
     {
         for (char_type ch = 0; (ch >= 0) && (ch < 0x80); ++ch)

--- a/test/types/string/string_formatter.cpp
+++ b/test/types/string/string_formatter.cpp
@@ -115,12 +115,14 @@ CATCH_TEMPLATE_TEST_CASE(
     CATCH_SECTION("Fill character defaults to a space character")
     {
         test_format(FMT("{:6}"), FMT("     1"), 1);
+        test_format(FMT("{:6}"), FMT("  3.14"), 3.14);
         test_format(FMT("{:4}_{:4}"), FMT("   1_ab  "), 1, FLY_STR(char_type, "ab"));
     }
 
     CATCH_SECTION("Fill character may be set")
     {
         test_format(FMT("{:*>6}"), FMT("*****1"), 1);
+        test_format(FMT("{:*>6}"), FMT("**3.14"), 3.14);
         test_format(FMT("{:|>4} {:_>4}"), FMT("|||1 __ab"), 1, FLY_STR(char_type, "ab"));
     }
 
@@ -128,6 +130,8 @@ CATCH_TEMPLATE_TEST_CASE(
     {
         test_format(FMT("{:*<+6}"), FMT("+1****"), 1);
         test_format(FMT("{:*< 6}"), FMT(" 1****"), 1);
+        test_format(FMT("{:*<+6}"), FMT("+3.14*"), 3.14);
+        test_format(FMT("{:*< 6}"), FMT(" 3.14*"), 3.14);
         test_format(FMT("{:*<#6b}"), FMT("0b11**"), 0b11);
         test_format(FMT("{:*<#6B}"), FMT("0B11**"), 0b11);
         test_format(FMT("{:*<#6x}"), FMT("0x41**"), 0x41);
@@ -135,17 +139,21 @@ CATCH_TEMPLATE_TEST_CASE(
 
         test_format(FMT("{:*>+6}"), FMT("****+1"), 1);
         test_format(FMT("{:*> 6}"), FMT("**** 1"), 1);
+        test_format(FMT("{:*>+6}"), FMT("*+3.14"), 3.14);
+        test_format(FMT("{:*> 6}"), FMT("* 3.14"), 3.14);
         test_format(FMT("{:*>#6b}"), FMT("**0b11"), 0b11);
         test_format(FMT("{:*>#6B}"), FMT("**0B11"), 0b11);
         test_format(FMT("{:*>#6x}"), FMT("**0x41"), 0x41);
         test_format(FMT("{:*>#6X}"), FMT("**0X41"), 0x41);
 
-        test_format(FMT("{:*^+6}"), FMT("****+1"), 1);
-        test_format(FMT("{:*^ 6}"), FMT("**** 1"), 1);
-        test_format(FMT("{:*^#6b}"), FMT("**0b11"), 0b11);
-        test_format(FMT("{:*^#6B}"), FMT("**0B11"), 0b11);
-        test_format(FMT("{:*^#6x}"), FMT("**0x41"), 0x41);
-        test_format(FMT("{:*^#6X}"), FMT("**0X41"), 0x41);
+        test_format(FMT("{:*^+6}"), FMT("**+1**"), 1);
+        test_format(FMT("{:*^ 6}"), FMT("** 1**"), 1);
+        test_format(FMT("{:*>+6}"), FMT("*+3.14"), 3.14);
+        test_format(FMT("{:*> 6}"), FMT("* 3.14"), 3.14);
+        test_format(FMT("{:*^#6b}"), FMT("*0b11*"), 0b11);
+        test_format(FMT("{:*^#6B}"), FMT("*0B11*"), 0b11);
+        test_format(FMT("{:*^#6x}"), FMT("*0x41*"), 0x41);
+        test_format(FMT("{:*^#6X}"), FMT("*0X41*"), 0x41);
     }
 
     CATCH_SECTION("Alignment default is based on presentation type")
@@ -188,19 +196,19 @@ CATCH_TEMPLATE_TEST_CASE(
         test_format(FMT("{:>#6x}"), FMT("  0x41"), 0x41);
         test_format(FMT("{:>#6X}"), FMT("  0X41"), 0x41);
 
-        test_format(FMT("{:^+6}"), FMT("    +1"), 1);
-        test_format(FMT("{:^ 6}"), FMT("     1"), 1);
-        test_format(FMT("{:^#6b}"), FMT("  0b11"), 0b11);
-        test_format(FMT("{:^#6B}"), FMT("  0B11"), 0b11);
-        test_format(FMT("{:^#6x}"), FMT("  0x41"), 0x41);
-        test_format(FMT("{:^#6X}"), FMT("  0X41"), 0x41);
+        test_format(FMT("{:^+6}"), FMT("  +1  "), 1);
+        test_format(FMT("{:^ 6}"), FMT("   1  "), 1);
+        test_format(FMT("{:^#6b}"), FMT(" 0b11 "), 0b11);
+        test_format(FMT("{:^#6B}"), FMT(" 0B11 "), 0b11);
+        test_format(FMT("{:^#6x}"), FMT(" 0x41 "), 0x41);
+        test_format(FMT("{:^#6X}"), FMT(" 0X41 "), 0x41);
     }
 
-    CATCH_SECTION("Alignment may be set to center-alignment (defaults to type-based alignment)")
+    CATCH_SECTION("Alignment may be set to center-alignment (actual alignment depends on type)")
     {
-        test_format(FMT("{:^6}"), FMT("ab    "), FLY_STR(char_type, "ab"));
-        test_format(FMT("{:^6}"), FMT("     1"), 1);
-        test_format(FMT("{:^6b}"), FMT("    11"), 0b11);
+        test_format(FMT("{:^6}"), FMT("  ab  "), FLY_STR(char_type, "ab"));
+        test_format(FMT("{:^6}"), FMT("  1   "), 1);
+        test_format(FMT("{:^6b}"), FMT("  11  "), 0b11);
         test_format(FMT("{:^6.2f}"), FMT("  3.14"), 3.14);
     }
 
@@ -268,6 +276,9 @@ CATCH_TEMPLATE_TEST_CASE(
         test_format(FMT("{:6}"), FMT("   -41"), -41);
         test_format(FMT("{:+6}"), FMT("   +41"), 41);
         test_format(FMT("{: 6}"), FMT("    41"), 41);
+        test_format(FMT("{:6}"), FMT(" -3.14"), -3.14);
+        test_format(FMT("{:+6}"), FMT(" +3.14"), 3.14);
+        test_format(FMT("{: 6}"), FMT("  3.14"), 3.14);
     }
 
     CATCH_SECTION("Zero-padding inserts zeros before sign and base indicators")
@@ -279,6 +290,9 @@ CATCH_TEMPLATE_TEST_CASE(
         test_format(FMT("{:06}"), FMT("-00041"), -41);
         test_format(FMT("{:+06}"), FMT("+00041"), 41);
         test_format(FMT("{: 06}"), FMT(" 00041"), 41);
+        test_format(FMT("{:06}"), FMT("-03.14"), -3.14);
+        test_format(FMT("{:+06}"), FMT("+03.14"), 3.14);
+        test_format(FMT("{: 06}"), FMT(" 03.14"), 3.14);
     }
 
     CATCH_SECTION("Zero-padding indicator ignored when alignment option is set")
@@ -290,6 +304,9 @@ CATCH_TEMPLATE_TEST_CASE(
         test_format(FMT("{:>06}"), FMT("   -41"), -41);
         test_format(FMT("{:>+06}"), FMT("   +41"), 41);
         test_format(FMT("{:> 06}"), FMT("    41"), 41);
+        test_format(FMT("{:>06}"), FMT(" -3.14"), -3.14);
+        test_format(FMT("{:>+06}"), FMT(" +3.14"), 3.14);
+        test_format(FMT("{:> 06}"), FMT("  3.14"), 3.14);
     }
 
     CATCH_SECTION("Width value may be set")
@@ -423,6 +440,25 @@ CATCH_TEMPLATE_TEST_CASE(
         test_format(FMT("{:b}"), FMT("1000001"), char8_t(0x41));
         test_format(FMT("{:b}"), FMT("1000001"), char16_t(0x41));
         test_format(FMT("{:b}"), FMT("1000001"), char32_t(0x41));
+
+        test_format(FMT("{:b}"), FMT("11111111"), std::numeric_limits<std::uint8_t>::max());
+        test_format(FMT("{:b}"), FMT("0"), std::numeric_limits<std::uint8_t>::min());
+        test_format(FMT("{:b}"), FMT("1111111"), std::numeric_limits<std::int8_t>::max());
+        test_format(FMT("{:b}"), FMT("-10000000"), std::numeric_limits<std::int8_t>::min());
+
+        test_format(
+            FMT("{:b}"),
+            FMT("1111111111111111111111111111111111111111111111111111111111111111"),
+            std::numeric_limits<std::uint64_t>::max());
+        test_format(FMT("{:b}"), FMT("0"), std::numeric_limits<std::uint64_t>::min());
+        test_format(
+            FMT("{:b}"),
+            FMT("111111111111111111111111111111111111111111111111111111111111111"),
+            std::numeric_limits<std::int64_t>::max());
+        test_format(
+            FMT("{:b}"),
+            FMT("-1000000000000000000000000000000000000000000000000000000000000000"),
+            std::numeric_limits<std::int64_t>::min());
     }
 
     CATCH_SECTION("Presentation type may be set (octal)")
@@ -435,6 +471,25 @@ CATCH_TEMPLATE_TEST_CASE(
         test_format(FMT("{:o}"), FMT("101"), char8_t(0x41));
         test_format(FMT("{:o}"), FMT("101"), char16_t(0x41));
         test_format(FMT("{:o}"), FMT("101"), char32_t(0x41));
+
+        test_format(FMT("{:o}"), FMT("377"), std::numeric_limits<std::uint8_t>::max());
+        test_format(FMT("{:o}"), FMT("0"), std::numeric_limits<std::uint8_t>::min());
+        test_format(FMT("{:o}"), FMT("177"), std::numeric_limits<std::int8_t>::max());
+        test_format(FMT("{:o}"), FMT("-200"), std::numeric_limits<std::int8_t>::min());
+
+        test_format(
+            FMT("{:o}"),
+            FMT("1777777777777777777777"),
+            std::numeric_limits<std::uint64_t>::max());
+        test_format(FMT("{:o}"), FMT("0"), std::numeric_limits<std::uint64_t>::min());
+        test_format(
+            FMT("{:o}"),
+            FMT("777777777777777777777"),
+            std::numeric_limits<std::int64_t>::max());
+        test_format(
+            FMT("{:o}"),
+            FMT("-1000000000000000000000"),
+            std::numeric_limits<std::int64_t>::min());
     }
 
     CATCH_SECTION("Presentation type may be set (decimal)")
@@ -447,6 +502,25 @@ CATCH_TEMPLATE_TEST_CASE(
         test_format(FMT("{:d}"), FMT("65"), char8_t(0x41));
         test_format(FMT("{:d}"), FMT("65"), char16_t(0x41));
         test_format(FMT("{:d}"), FMT("65"), char32_t(0x41));
+
+        test_format(FMT("{:d}"), FMT("255"), std::numeric_limits<std::uint8_t>::max());
+        test_format(FMT("{:d}"), FMT("0"), std::numeric_limits<std::uint8_t>::min());
+        test_format(FMT("{:d}"), FMT("127"), std::numeric_limits<std::int8_t>::max());
+        test_format(FMT("{:d}"), FMT("-128"), std::numeric_limits<std::int8_t>::min());
+
+        test_format(
+            FMT("{:d}"),
+            FMT("18446744073709551615"),
+            std::numeric_limits<std::uint64_t>::max());
+        test_format(FMT("{:d}"), FMT("0"), std::numeric_limits<std::uint64_t>::min());
+        test_format(
+            FMT("{:d}"),
+            FMT("9223372036854775807"),
+            std::numeric_limits<std::int64_t>::max());
+        test_format(
+            FMT("{:d}"),
+            FMT("-9223372036854775808"),
+            std::numeric_limits<std::int64_t>::min());
     }
 
     CATCH_SECTION("Presentation type may be set (hex)")
@@ -461,6 +535,22 @@ CATCH_TEMPLATE_TEST_CASE(
         test_format(FMT("{:x}"), FMT("41"), char32_t(0x41));
 
         test_format(FMT("{:X}"), FMT("BEEF"), 0xbeef);
+
+        test_format(FMT("{:x}"), FMT("ff"), std::numeric_limits<std::uint8_t>::max());
+        test_format(FMT("{:x}"), FMT("0"), std::numeric_limits<std::uint8_t>::min());
+        test_format(FMT("{:x}"), FMT("7f"), std::numeric_limits<std::int8_t>::max());
+        test_format(FMT("{:x}"), FMT("-80"), std::numeric_limits<std::int8_t>::min());
+
+        test_format(
+            FMT("{:x}"),
+            FMT("ffffffffffffffff"),
+            std::numeric_limits<std::uint64_t>::max());
+        test_format(FMT("{:x}"), FMT("0"), std::numeric_limits<std::uint64_t>::min());
+        test_format(FMT("{:x}"), FMT("7fffffffffffffff"), std::numeric_limits<std::int64_t>::max());
+        test_format(
+            FMT("{:x}"),
+            FMT("-8000000000000000"),
+            std::numeric_limits<std::int64_t>::min());
     }
 
     CATCH_SECTION("Presentation type may be set (hexfloat)")
@@ -515,19 +605,6 @@ CATCH_TEMPLATE_TEST_CASE(
         test_format(FMT("{:G}"), FMT("NAN"), std::nan(""));
         test_format(FMT("{:G}"), FMT("INF"), std::numeric_limits<float>::infinity());
         test_format(FMT("{:G}"), FMT("2.1"), 2.1f);
-    }
-
-    if constexpr (!std::is_same_v<StringType, typename BasicString::streamed_type>)
-    {
-        CATCH_SECTION("Invalid Unicode cannot be converted to UTF-8")
-        {
-            static constexpr const char_type s_invalid_utf8_leading_byte[] {
-                static_cast<char_type>(0xff),
-            };
-
-            StringType result = BasicString::format(s_invalid_utf8_leading_byte);
-            CATCH_CHECK(result.empty());
-        }
     }
 
 #if defined(FLY_COMPILER_DISABLE_CONSTEVAL)


### PR DESCRIPTION
The goal is for BasicStringFormatter to not depend on IO streams at all.
IO streams are inherently slow due to localization.

With C++20, std::to_chars can be used to convert arithmetic types to
strings. However, major compilers do not yet support std::to_chars for
floating point types.

There's probably plenty of room here for optimizations, but this is a
good enough start to removing IO streams.

Further, with this implementation, string and integral types now support
center alignment. Floating point types will still fall back to default
alignment.