### PR TITLE
Defer some floating point formatting to string formatter

### DIFF
--- a/fly/types/string/detail/string_formatter.hpp
+++ b/fly/types/string/detail/string_formatter.hpp
@@ -497,25 +497,9 @@ inline void BasicStringFormatter<StringType, ParameterTypes...>::format_value(
 {
     stream_modifiers modifiers(s_stream);
 
-    if (specifier.m_fill)
+    if (specifier.m_alignment == FormatSpecifier::Alignment::Default)
     {
-        modifiers.fill(static_cast<streamed_char_type>(*specifier.m_fill));
-    }
-
-    switch (specifier.m_alignment)
-    {
-        case FormatSpecifier::Alignment::Left:
-            modifiers.setf(std::ios_base::left);
-            break;
-
-        case FormatSpecifier::Alignment::Right:
-            modifiers.setf(std::ios_base::right);
-            break;
-
-        case FormatSpecifier::Alignment::Center: // TODO: Implement center-alignment.
-        case FormatSpecifier::Alignment::Default:
-            modifiers.setf(specifier.is_numeric() ? std::ios_base::right : std::ios_base::left);
-            break;
+        specifier.m_alignment = FormatSpecifier::Alignment::Right;
     }
 
     switch (specifier.m_sign)
@@ -542,10 +526,11 @@ inline void BasicStringFormatter<StringType, ParameterTypes...>::format_value(
     {
         modifiers.setf(std::ios_base::internal, std::ios_base::adjustfield);
         modifiers.fill(static_cast<streamed_char_type>(s_zero));
+        modifiers.width(resolve_size<std::streamsize>(specifier.m_width));
     }
 
-    modifiers.width(resolve_size<std::streamsize>(specifier.m_width));
     modifiers.precision(resolve_size<std::streamsize>(specifier.m_precision, 6));
+    specifier.m_precision = std::nullopt;
 
     switch (specifier.m_type)
     {
@@ -576,7 +561,7 @@ inline void BasicStringFormatter<StringType, ParameterTypes...>::format_value(
     }
 
     s_stream << value;
-    append_string(s_stream.str());
+    format_value(std::move(specifier), s_stream.str());
     s_stream.str({});
 }
 

--- a/test/types/string/string_formatter.cpp
+++ b/test/types/string/string_formatter.cpp
@@ -180,6 +180,19 @@ CATCH_TEMPLATE_TEST_CASE(
         test_format(FMT("{:>6.2f}"), FMT("  3.14"), 3.14);
     }
 
+    CATCH_SECTION("Alignment may be set to center-alignment")
+    {
+        test_format(FMT("{:^6}"), FMT("  ab  "), FLY_STR(char_type, "ab"));
+        test_format(FMT("{:^6}"), FMT("  1   "), 1);
+        test_format(FMT("{:^6b}"), FMT("  11  "), 0b11);
+        test_format(FMT("{:^6.2f}"), FMT(" 3.14 "), 3.14);
+
+        test_format(FMT("{:^7}"), FMT("  ab   "), FLY_STR(char_type, "ab"));
+        test_format(FMT("{:^7}"), FMT("   1   "), 1);
+        test_format(FMT("{:^7b}"), FMT("  11   "), 0b11);
+        test_format(FMT("{:^7.2f}"), FMT(" 3.14  "), 3.14);
+    }
+
     CATCH_SECTION("Alignment affects sign and base indicators")
     {
         test_format(FMT("{:<+6}"), FMT("+1    "), 1);
@@ -188,6 +201,8 @@ CATCH_TEMPLATE_TEST_CASE(
         test_format(FMT("{:<#6B}"), FMT("0B11  "), 0b11);
         test_format(FMT("{:<#6x}"), FMT("0x41  "), 0x41);
         test_format(FMT("{:<#6X}"), FMT("0X41  "), 0x41);
+        test_format(FMT("{:<+6}"), FMT("+3.14 "), 3.14);
+        test_format(FMT("{:< 6}"), FMT(" 3.14 "), 3.14);
 
         test_format(FMT("{:>+6}"), FMT("    +1"), 1);
         test_format(FMT("{:> 6}"), FMT("     1"), 1);
@@ -195,6 +210,8 @@ CATCH_TEMPLATE_TEST_CASE(
         test_format(FMT("{:>#6B}"), FMT("  0B11"), 0b11);
         test_format(FMT("{:>#6x}"), FMT("  0x41"), 0x41);
         test_format(FMT("{:>#6X}"), FMT("  0X41"), 0x41);
+        test_format(FMT("{:>+6}"), FMT(" +3.14"), 3.14);
+        test_format(FMT("{:> 6}"), FMT("  3.14"), 3.14);
 
         test_format(FMT("{:^+6}"), FMT("  +1  "), 1);
         test_format(FMT("{:^ 6}"), FMT("   1  "), 1);
@@ -202,14 +219,8 @@ CATCH_TEMPLATE_TEST_CASE(
         test_format(FMT("{:^#6B}"), FMT(" 0B11 "), 0b11);
         test_format(FMT("{:^#6x}"), FMT(" 0x41 "), 0x41);
         test_format(FMT("{:^#6X}"), FMT(" 0X41 "), 0x41);
-    }
-
-    CATCH_SECTION("Alignment may be set to center-alignment (actual alignment depends on type)")
-    {
-        test_format(FMT("{:^6}"), FMT("  ab  "), FLY_STR(char_type, "ab"));
-        test_format(FMT("{:^6}"), FMT("  1   "), 1);
-        test_format(FMT("{:^6b}"), FMT("  11  "), 0b11);
-        test_format(FMT("{:^6.2f}"), FMT("  3.14"), 3.14);
+        test_format(FMT("{:^+8}"), FMT(" +3.14  "), 3.14);
+        test_format(FMT("{:^ 8}"), FMT("  3.14  "), 3.14);
     }
 
     CATCH_SECTION("Sign defaults to negative-only")


### PR DESCRIPTION
Floating-point-specific formatting options must be handled with the IO
stream. But options like fill and alignment can be deferred to the string
formatter. This is mainly to allow floating point types to have center
alignment.