### PR TITLE
Use std::jthread where appropriate

### DIFF
--- a/fly/task/task_manager.hpp
+++ b/fly/task/task_manager.hpp
@@ -5,9 +5,9 @@
 
 #include <atomic>
 #include <chrono>
-#include <future>
 #include <memory>
 #include <mutex>
+#include <thread>
 #include <vector>
 
 namespace fly {
@@ -122,9 +122,8 @@ private:
 
     std::atomic_bool m_keep_running;
 
-    std::vector<std::future<void>> m_futures;
-
-    std::uint32_t m_num_workers;
+    std::vector<std::jthread> m_threads;
+    std::uint32_t m_thread_count;
 };
 
 //==================================================================================================

--- a/test/socket/socket.cpp
+++ b/test/socket/socket.cpp
@@ -601,50 +601,26 @@ CATCH_TEST_CASE("Socket", "[socket]")
 
         CATCH_SECTION("A synchronous server with a synchronous client")
         {
-            auto server = std::async(std::launch::async, server_thread, false);
-            auto client = std::async(std::launch::async, client_thread, false);
-
-            CATCH_CHECK(server.valid());
-            server.get();
-
-            CATCH_CHECK(client.valid());
-            client.get();
+            auto server = std::jthread(server_thread, false);
+            auto client = std::jthread(client_thread, false);
         }
 
         CATCH_SECTION("An asynchronous server with a synchronous client")
         {
-            auto server = std::async(std::launch::async, server_thread, true);
-            auto client = std::async(std::launch::async, client_thread, false);
-
-            CATCH_CHECK(server.valid());
-            server.get();
-
-            CATCH_CHECK(client.valid());
-            client.get();
+            auto server = std::jthread(server_thread, true);
+            auto client = std::jthread(client_thread, false);
         }
 
         CATCH_SECTION("A synchronous server with an asynchronous client")
         {
-            auto server = std::async(std::launch::async, server_thread, false);
-            auto client = std::async(std::launch::async, client_thread, true);
-
-            CATCH_CHECK(server.valid());
-            server.get();
-
-            CATCH_CHECK(client.valid());
-            client.get();
+            auto server = std::jthread(server_thread, false);
+            auto client = std::jthread(client_thread, true);
         }
 
         CATCH_SECTION("An asynchronous server with an asynchronous client")
         {
-            auto server = std::async(std::launch::async, server_thread, true);
-            auto client = std::async(std::launch::async, client_thread, true);
-
-            CATCH_CHECK(server.valid());
-            server.get();
-
-            CATCH_CHECK(client.valid());
-            client.get();
+            auto server = std::jthread(server_thread, true);
+            auto client = std::jthread(client_thread, true);
         }
     }
 
@@ -744,50 +720,26 @@ CATCH_TEST_CASE("Socket", "[socket]")
 
         CATCH_SECTION("A synchronous server with a synchronous client")
         {
-            auto server = std::async(std::launch::async, server_thread, false);
-            auto client = std::async(std::launch::async, client_thread, false);
-
-            CATCH_CHECK(server.valid());
-            server.get();
-
-            CATCH_CHECK(client.valid());
-            client.get();
+            auto server = std::jthread(server_thread, false);
+            auto client = std::jthread(client_thread, false);
         }
 
         CATCH_SECTION("An asynchronous server with a synchronous client")
         {
-            auto server = std::async(std::launch::async, server_thread, true);
-            auto client = std::async(std::launch::async, client_thread, false);
-
-            CATCH_CHECK(server.valid());
-            server.get();
-
-            CATCH_CHECK(client.valid());
-            client.get();
+            auto server = std::jthread(server_thread, true);
+            auto client = std::jthread(client_thread, false);
         }
 
         CATCH_SECTION("A synchronous server with an asynchronous client")
         {
-            auto server = std::async(std::launch::async, server_thread, false);
-            auto client = std::async(std::launch::async, client_thread, true);
-
-            CATCH_CHECK(server.valid());
-            server.get();
-
-            CATCH_CHECK(client.valid());
-            client.get();
+            auto server = std::jthread(server_thread, false);
+            auto client = std::jthread(client_thread, true);
         }
 
         CATCH_SECTION("An asynchronous server with an asynchronous client")
         {
-            auto server = std::async(std::launch::async, server_thread, true);
-            auto client = std::async(std::launch::async, client_thread, true);
-
-            CATCH_CHECK(server.valid());
-            server.get();
-
-            CATCH_CHECK(client.valid());
-            client.get();
+            auto server = std::jthread(server_thread, true);
+            auto client = std::jthread(client_thread, true);
         }
     }
 


### PR DESCRIPTION
Unlike std::thread (and std::async), std::jthread joins itself upon
destruction.