### PR TITLE
Do not allow presentation types for generic format parameters

### DIFF
--- a/fly/types/string/detail/string_formatter.hpp
+++ b/fly/types/string/detail/string_formatter.hpp
@@ -332,14 +332,16 @@ template <
         std::is_arithmetic<T>,
         is_default_formatted_enum<StringType, T>>>
 inline void BasicStringFormatter<StringType, ParameterTypes...>::format_value(
-    FormatSpecifier &&specifier,
+    FormatSpecifier &&,
     const T &value)
 {
     static thread_local ostringstream_type s_stream;
 
     s_stream << value;
-    format_value(std::move(specifier), s_stream.str());
+    const auto formatted = s_stream.str();
     s_stream.str({});
+
+    append_string(formatted, formatted.size());
 }
 
 //==================================================================================================

--- a/fly/types/string/string.hpp
+++ b/fly/types/string/string.hpp
@@ -414,7 +414,7 @@ public:
      *       the type of the format string.
      *
      *    3. Any generic type for which an operator<< overload is defined will be converted to a
-     *       string using that overload. Formatting options will then be applied to that string.
+     *       string using that overload.
      *
      *    4. Formatting of strong enumeration types defaults to the format of the enumeration's
      *       underlying type. However, if an overload of operator<< is defined, the type is treated
@@ -474,7 +474,7 @@ public:
      *       the type of the format string.
      *
      *    3. Any generic type for which an operator<< overload is defined will be converted to a
-     *       string using that overload. Formatting options will then be applied to that string.
+     *       string using that overload.
      *
      *    4. Formatting of strong enumeration types defaults to the format of the enumeration's
      *       underlying type. However, if an overload of operator<< is defined, the type is treated

--- a/test/types/string/string_formatter.cpp
+++ b/test/types/string/string_formatter.cpp
@@ -21,6 +21,46 @@ namespace {
 
 #define FMT(format) FLY_ARR(char_type, format)
 
+struct GenericType
+{
+};
+
+[[maybe_unused]] std::ostream &operator<<(std::ostream &stream, const GenericType &)
+{
+    stream << "GenericType";
+    return stream;
+}
+
+[[maybe_unused]] std::wostream &operator<<(std::wostream &stream, const GenericType &)
+{
+    stream << L"GenericType";
+    return stream;
+}
+
+enum class DefaultFormattedEnum
+{
+    One = 1,
+    Two = 2,
+};
+
+enum class UserFormattedEnum
+{
+    One = 1,
+    Two = 2,
+};
+
+[[maybe_unused]] std::ostream &operator<<(std::ostream &stream, const UserFormattedEnum &u)
+{
+    stream << (u == UserFormattedEnum::One ? "One" : "Two");
+    return stream;
+}
+
+[[maybe_unused]] std::wostream &operator<<(std::wostream &stream, const UserFormattedEnum &u)
+{
+    stream << (u == UserFormattedEnum::One ? L"One" : L"Two");
+    return stream;
+}
+
 template <typename StringType, typename... ParameterTypes>
 using FormatString = fly::detail::BasicFormatString<
     fly::detail::is_like_supported_string_t<StringType>,
@@ -60,30 +100,6 @@ StringType reserved_codepoint()
     }
 
     return result;
-}
-
-enum class DefaultFormattedEnum
-{
-    One = 1,
-    Two = 2,
-};
-
-enum class UserFormattedEnum
-{
-    One = 1,
-    Two = 2,
-};
-
-[[maybe_unused]] std::ostream &operator<<(std::ostream &stream, const UserFormattedEnum &u)
-{
-    stream << (u == UserFormattedEnum::One ? "One" : "Two");
-    return stream;
-}
-
-[[maybe_unused]] std::wostream &operator<<(std::wostream &stream, const UserFormattedEnum &u)
-{
-    stream << (u == UserFormattedEnum::One ? "One" : "Two");
-    return stream;
 }
 
 } // namespace
@@ -460,6 +476,14 @@ CATCH_TEMPLATE_TEST_CASE(
         test_format(FMT("{1:.{0}s}"), FMT("abcdef"), -3, FLY_STR(char_type, "abcdef"));
     }
 
+    CATCH_SECTION("Generic types may be formatted without presentation type")
+    {
+        GenericType gt {};
+        test_format(FMT("{}"), FMT("GenericType"), gt);
+        test_format(FMT("{}"), FMT("One"), UserFormattedEnum::One);
+        test_format(FMT("{}"), FMT("Two"), UserFormattedEnum::Two);
+    }
+
     CATCH_SECTION("Presentation type may be set (character)")
     {
         test_format(FMT("{:c}"), FMT("a"), 'a');
@@ -515,9 +539,6 @@ CATCH_TEMPLATE_TEST_CASE(
 
         test_format(FMT("{:s}"), FMT("true"), true);
         test_format(FMT("{:s}"), FMT("false"), false);
-
-        test_format(FMT("{:s}"), FMT("One"), UserFormattedEnum::One);
-        test_format(FMT("{:s}"), FMT("Two"), UserFormattedEnum::Two);
     }
 
     CATCH_SECTION("Presentation type may be set (pointer)")

--- a/test/types/string/string_formatter_types.cpp
+++ b/test/types/string/string_formatter_types.cpp
@@ -162,13 +162,12 @@ constexpr const char *s_bad_precision_position =
     "Position of precision parameter must be an integral type";
 constexpr const char *s_bad_locale =
     "Locale-specific form may only be used for numeric and boolean types";
-constexpr const char *s_bad_generic = "Generic types must be formatted with {} or {:s}";
+constexpr const char *s_bad_generic = "Generic types must be formatted with {}";
 constexpr const char *s_bad_character = "Character types must be formatted with {} or {:cbBodxX}";
-constexpr const char *s_bad_string =
-    "String types and user-formatted enums must be formatted with {} or {:s}";
+constexpr const char *s_bad_string = "String types must be formatted with {} or {:s}";
 constexpr const char *s_bad_pointer = "Pointer types must be formatted with {} or {:p}";
 constexpr const char *s_bad_integer =
-    "Integral types and default-formatted enums must be formatted with {} or one of {:cbBodxX}";
+    "Integral types must be formatted with {} or one of {:cbBodxX}";
 constexpr const char *s_bad_float =
     "Floating point types must be formatted with {} or one of {:aAeEfFgG}";
 constexpr const char *s_bad_bool = "Boolean types must be formatted with {} or one of {:csbBodxX}";
@@ -445,26 +444,20 @@ CATCH_TEMPLATE_TEST_CASE(
 
         specifier.m_type = Specifier::Type::None;
         test_format(make_format(FMT("{}"), g), specifier);
+        test_format(make_format(FMT("{}"), u), specifier);
 
         specifier.m_type = Specifier::Type::Character;
         test_format(make_format(FMT("{}"), c), specifier);
 
         specifier.m_type = Specifier::Type::String;
         test_format(make_format(FMT("{}"), s), specifier);
-
-        specifier.m_type = Specifier::Type::String;
         test_format(make_format(FMT("{}"), a), specifier);
-
-        specifier.m_type = Specifier::Type::String;
-        test_format(make_format(FMT("{}"), u), specifier);
 
         specifier.m_type = Specifier::Type::Pointer;
         test_format(make_format(FMT("{}"), &i), specifier);
 
         specifier.m_type = Specifier::Type::Decimal;
         test_format(make_format(FMT("{}"), i), specifier);
-
-        specifier.m_type = Specifier::Type::Decimal;
         test_format(make_format(FMT("{}"), d), specifier);
 
         specifier.m_type = Specifier::Type::General;
@@ -472,6 +465,13 @@ CATCH_TEMPLATE_TEST_CASE(
 
         specifier.m_type = Specifier::Type::String;
         test_format(make_format(FMT("{}"), b), specifier);
+    }
+
+    CATCH_SECTION("Generic types may be formatted without presentation type")
+    {
+        Specifier specifier {};
+        test_format(make_format(FMT("{}"), g), specifier);
+        test_format(make_format(FMT("{}"), u), specifier);
     }
 
     CATCH_SECTION("Presentation type may be set (character)")
@@ -490,11 +490,9 @@ CATCH_TEMPLATE_TEST_CASE(
         Specifier specifier {};
         specifier.m_type = Specifier::Type::String;
 
-        test_format(make_format(FMT("{:s}"), g), specifier);
         test_format(make_format(FMT("{:s}"), s), specifier);
         test_format(make_format(FMT("{:s}"), a), specifier);
         test_format(make_format(FMT("{:s}"), b), specifier);
-        test_format(make_format(FMT("{:s}"), u), specifier);
     }
 
     CATCH_SECTION("Presentation type may be set (pointer)")
@@ -910,14 +908,16 @@ CATCH_TEMPLATE_TEST_CASE(
     CATCH_SECTION("Precision type mismatch (character)")
     {
         test_error(make_format(FMT("{:c}"), g), s_bad_generic);
+        test_error(make_format(FMT("{:c}"), u), s_bad_generic);
         test_error(make_format(FMT("{:c}"), s), s_bad_string);
-        test_error(make_format(FMT("{:c}"), u), s_bad_string);
         test_error(make_format(FMT("{:c}"), &g), s_bad_pointer);
         test_error(make_format(FMT("{:c}"), f), s_bad_float);
     }
 
     CATCH_SECTION("Precision type mismatch (string)")
     {
+        test_error(make_format(FMT("{:c}"), g), s_bad_generic);
+        test_error(make_format(FMT("{:c}"), u), s_bad_generic);
         test_error(make_format(FMT("{:s}"), c), s_bad_character);
         test_error(make_format(FMT("{:s}"), &g), s_bad_pointer);
         test_error(make_format(FMT("{:s}"), i), s_bad_integer);
@@ -938,8 +938,8 @@ CATCH_TEMPLATE_TEST_CASE(
     CATCH_SECTION("Precision type mismatch (binary)")
     {
         test_error(make_format(FMT("{:b}"), g), s_bad_generic);
+        test_error(make_format(FMT("{:b}"), u), s_bad_generic);
         test_error(make_format(FMT("{:b}"), s), s_bad_string);
-        test_error(make_format(FMT("{:b}"), u), s_bad_string);
         test_error(make_format(FMT("{:b}"), &g), s_bad_pointer);
         test_error(make_format(FMT("{:b}"), f), s_bad_float);
 
@@ -952,8 +952,8 @@ CATCH_TEMPLATE_TEST_CASE(
     CATCH_SECTION("Precision type mismatch (octal)")
     {
         test_error(make_format(FMT("{:o}"), g), s_bad_generic);
+        test_error(make_format(FMT("{:o}"), u), s_bad_generic);
         test_error(make_format(FMT("{:o}"), s), s_bad_string);
-        test_error(make_format(FMT("{:o}"), u), s_bad_string);
         test_error(make_format(FMT("{:o}"), &g), s_bad_pointer);
         test_error(make_format(FMT("{:o}"), f), s_bad_float);
     }
@@ -961,8 +961,8 @@ CATCH_TEMPLATE_TEST_CASE(
     CATCH_SECTION("Precision type mismatch (decimal)")
     {
         test_error(make_format(FMT("{:d}"), g), s_bad_generic);
+        test_error(make_format(FMT("{:d}"), u), s_bad_generic);
         test_error(make_format(FMT("{:d}"), s), s_bad_string);
-        test_error(make_format(FMT("{:d}"), u), s_bad_string);
         test_error(make_format(FMT("{:d}"), &g), s_bad_pointer);
         test_error(make_format(FMT("{:d}"), f), s_bad_float);
     }
@@ -970,14 +970,14 @@ CATCH_TEMPLATE_TEST_CASE(
     CATCH_SECTION("Precision type mismatch (hex)")
     {
         test_error(make_format(FMT("{:x}"), g), s_bad_generic);
+        test_error(make_format(FMT("{:x}"), u), s_bad_generic);
         test_error(make_format(FMT("{:x}"), s), s_bad_string);
-        test_error(make_format(FMT("{:x}"), u), s_bad_string);
         test_error(make_format(FMT("{:x}"), &g), s_bad_pointer);
         test_error(make_format(FMT("{:x}"), f), s_bad_float);
 
         test_error(make_format(FMT("{:X}"), g), s_bad_generic);
+        test_error(make_format(FMT("{:X}"), u), s_bad_generic);
         test_error(make_format(FMT("{:X}"), s), s_bad_string);
-        test_error(make_format(FMT("{:X}"), u), s_bad_string);
         test_error(make_format(FMT("{:X}"), &g), s_bad_pointer);
         test_error(make_format(FMT("{:X}"), f), s_bad_float);
     }
@@ -985,18 +985,18 @@ CATCH_TEMPLATE_TEST_CASE(
     CATCH_SECTION("Precision type mismatch (hexfloat)")
     {
         test_error(make_format(FMT("{:a}"), g), s_bad_generic);
+        test_error(make_format(FMT("{:a}"), u), s_bad_generic);
         test_error(make_format(FMT("{:a}"), c), s_bad_character);
         test_error(make_format(FMT("{:a}"), s), s_bad_string);
-        test_error(make_format(FMT("{:a}"), u), s_bad_string);
         test_error(make_format(FMT("{:a}"), &g), s_bad_pointer);
         test_error(make_format(FMT("{:a}"), i), s_bad_integer);
         test_error(make_format(FMT("{:a}"), d), s_bad_integer);
         test_error(make_format(FMT("{:a}"), b), s_bad_bool);
 
         test_error(make_format(FMT("{:A}"), g), s_bad_generic);
+        test_error(make_format(FMT("{:A}"), u), s_bad_generic);
         test_error(make_format(FMT("{:A}"), c), s_bad_character);
         test_error(make_format(FMT("{:A}"), s), s_bad_string);
-        test_error(make_format(FMT("{:A}"), u), s_bad_string);
         test_error(make_format(FMT("{:A}"), &g), s_bad_pointer);
         test_error(make_format(FMT("{:A}"), i), s_bad_integer);
         test_error(make_format(FMT("{:A}"), d), s_bad_integer);
@@ -1006,18 +1006,18 @@ CATCH_TEMPLATE_TEST_CASE(
     CATCH_SECTION("Precision type mismatch (scientific)")
     {
         test_error(make_format(FMT("{:e}"), g), s_bad_generic);
+        test_error(make_format(FMT("{:e}"), u), s_bad_generic);
         test_error(make_format(FMT("{:e}"), c), s_bad_character);
         test_error(make_format(FMT("{:e}"), s), s_bad_string);
-        test_error(make_format(FMT("{:e}"), u), s_bad_string);
         test_error(make_format(FMT("{:e}"), &g), s_bad_pointer);
         test_error(make_format(FMT("{:e}"), i), s_bad_integer);
         test_error(make_format(FMT("{:e}"), d), s_bad_integer);
         test_error(make_format(FMT("{:e}"), b), s_bad_bool);
 
         test_error(make_format(FMT("{:E}"), g), s_bad_generic);
+        test_error(make_format(FMT("{:E}"), u), s_bad_generic);
         test_error(make_format(FMT("{:E}"), c), s_bad_character);
         test_error(make_format(FMT("{:E}"), s), s_bad_string);
-        test_error(make_format(FMT("{:E}"), u), s_bad_string);
         test_error(make_format(FMT("{:E}"), &g), s_bad_pointer);
         test_error(make_format(FMT("{:E}"), i), s_bad_integer);
         test_error(make_format(FMT("{:E}"), d), s_bad_integer);
@@ -1027,18 +1027,18 @@ CATCH_TEMPLATE_TEST_CASE(
     CATCH_SECTION("Precision type mismatch (fixed)")
     {
         test_error(make_format(FMT("{:f}"), g), s_bad_generic);
+        test_error(make_format(FMT("{:f}"), u), s_bad_generic);
         test_error(make_format(FMT("{:f}"), c), s_bad_character);
         test_error(make_format(FMT("{:f}"), s), s_bad_string);
-        test_error(make_format(FMT("{:f}"), u), s_bad_string);
         test_error(make_format(FMT("{:f}"), &g), s_bad_pointer);
         test_error(make_format(FMT("{:f}"), i), s_bad_integer);
         test_error(make_format(FMT("{:f}"), d), s_bad_integer);
         test_error(make_format(FMT("{:f}"), b), s_bad_bool);
 
         test_error(make_format(FMT("{:F}"), g), s_bad_generic);
+        test_error(make_format(FMT("{:F}"), u), s_bad_generic);
         test_error(make_format(FMT("{:F}"), c), s_bad_character);
         test_error(make_format(FMT("{:F}"), s), s_bad_string);
-        test_error(make_format(FMT("{:F}"), u), s_bad_string);
         test_error(make_format(FMT("{:F}"), &g), s_bad_pointer);
         test_error(make_format(FMT("{:F}"), i), s_bad_integer);
         test_error(make_format(FMT("{:F}"), d), s_bad_integer);
@@ -1048,18 +1048,18 @@ CATCH_TEMPLATE_TEST_CASE(
     CATCH_SECTION("Precision type mismatch (general)")
     {
         test_error(make_format(FMT("{:g}"), g), s_bad_generic);
+        test_error(make_format(FMT("{:g}"), u), s_bad_generic);
         test_error(make_format(FMT("{:g}"), c), s_bad_character);
         test_error(make_format(FMT("{:g}"), s), s_bad_string);
-        test_error(make_format(FMT("{:g}"), u), s_bad_string);
         test_error(make_format(FMT("{:g}"), &g), s_bad_pointer);
         test_error(make_format(FMT("{:g}"), i), s_bad_integer);
         test_error(make_format(FMT("{:g}"), d), s_bad_integer);
         test_error(make_format(FMT("{:g}"), b), s_bad_bool);
 
         test_error(make_format(FMT("{:G}"), g), s_bad_generic);
+        test_error(make_format(FMT("{:G}"), u), s_bad_generic);
         test_error(make_format(FMT("{:G}"), c), s_bad_character);
         test_error(make_format(FMT("{:G}"), s), s_bad_string);
-        test_error(make_format(FMT("{:G}"), u), s_bad_string);
         test_error(make_format(FMT("{:G}"), &g), s_bad_pointer);
         test_error(make_format(FMT("{:G}"), i), s_bad_integer);
         test_error(make_format(FMT("{:G}"), d), s_bad_integer);


### PR DESCRIPTION
Originally, either "{}" or "{:s}" were permitted due to a misreading of
the std::format specification. The string presentation type should not be
alowed.

Eventually, a mechanism similar to std::formatter should be supported,
allowing callers to fully specify the format string for generic types.