### PR TITLE
Mark libfly library as a dependency of tests and benchmarks

### DIFF
--- a/bench/files.mk
+++ b/bench/files.mk
@@ -1,28 +1,16 @@
-SRC_DIRS_$(d) := \
-    fly/coders \
-    fly/coders/base64 \
-    fly/coders/huffman \
-    fly/logger \
-    fly/parser \
-    fly/system \
-    fly/task \
-    fly/types/bit_stream \
-    fly/types/bit_stream/detail \
-    fly/types/json \
-    bench/util \
-    test/util
-
-# Include the directories containing the benchmark tests.
 SRC_DIRS_$(d) += \
     bench/coders \
     bench/json \
-    bench/string
+    bench/string \
+    bench/util \
+    test/util
 
 SRC_$(d) := \
     $(d)/main.cpp
 
-CXXFLAGS_$(d) += -I$(SOURCE_ROOT)/test/Catch2/single_include
+# All benchmarks should have Catch2 on the include path.
 CXXFLAGS_$(d) += \
+    -I$(SOURCE_ROOT)/test/Catch2/single_include \
     -DCATCH_CONFIG_PREFIX_ALL \
     -DCATCH_CONFIG_FAST_COMPILE \
     -DCATCH_CONFIG_ENABLE_OPTIONAL_STRINGMAKER

--- a/build/nix/Makefile
+++ b/build/nix/Makefile
@@ -11,8 +11,8 @@ include /usr/local/src/fly/api.mk
 $(eval $(call ADD_TARGET, libfly, fly, LIB))
 
 # Test targets.
-$(eval $(call ADD_TARGET, libfly_unit_tests, test, TEST))
-$(eval $(call ADD_TARGET, libfly_benchmarks, bench, BIN))
+$(eval $(call ADD_TARGET, libfly_unit_tests, test, TEST, libfly))
+$(eval $(call ADD_TARGET, libfly_benchmarks, bench, BIN, libfly))
 
 # Paths to ignore during code coverage reporting.
 #

--- a/test/files.mk
+++ b/test/files.mk
@@ -1,25 +1,3 @@
-SRC_DIRS_$(d) := \
-    fly/coders \
-    fly/coders/base64 \
-    fly/coders/huffman \
-    fly/config \
-    fly/logger \
-    fly/parser \
-    fly/path \
-    fly/socket \
-    fly/system \
-    fly/task \
-    fly/types/bit_stream \
-    fly/types/bit_stream/detail \
-    fly/types/json \
-    test/util
-
-ifeq ($(SYSTEM), LINUX)
-    SRC_DIRS_$(d) += \
-        test/mock
-endif
-
-# Include the directories containing the unit tests.
 SRC_DIRS_$(d) += \
     test/coders \
     test/config \
@@ -34,15 +12,21 @@ SRC_DIRS_$(d) += \
     test/types/concurrency \
     test/types/json \
     test/types/numeric \
-    test/types/string
+    test/types/string \
+    test/util
+
+ifeq ($(SYSTEM), LINUX)
+    SRC_DIRS_$(d) += \
+        test/mock
+endif
 
 SRC_$(d) := \
     $(d)/fly.cpp \
     $(d)/main.cpp
 
 # All unit tests should have Catch2 on the include path.
-CXXFLAGS_$(d) += -I$(SOURCE_ROOT)/test/Catch2/single_include
 CXXFLAGS_$(d) += \
+    -I$(SOURCE_ROOT)/test/Catch2/single_include \
     -DCATCH_CONFIG_PREFIX_ALL \
     -DCATCH_CONFIG_FAST_COMPILE \
     -DCATCH_CONFIG_ENABLE_OPTIONAL_STRINGMAKER


### PR DESCRIPTION
flymake now supports inter-target dependencies. Mark libfly as a
dependency of libfly_benchmarks and libfly_unit_tests. This will
automatically link libfly.a into these targets, and means these
targets do not need to list out each libfly source directory.