### PR TITLE
Update files.mk files with latest flymake support

### DIFF
--- a/bench/files.mk
+++ b/bench/files.mk
@@ -1,11 +1,11 @@
 include $(SOURCE_ROOT)/extern/catchorg/flags.mk
 
 SRC_DIRS_$(d) += \
-    bench/coders \
-    bench/json \
-    bench/string \
-    bench/util \
-    test/util
+    $(d)/coders \
+    $(d)/json \
+    $(d)/string \
+    $(d)/util \
+    $(d)/../test/util
 
 SRC_$(d) := \
     $(d)/main.cpp

--- a/fly/coders/files.mk
+++ b/fly/coders/files.mk
@@ -1,4 +1,5 @@
 SRC_DIRS_$(d) := \
-    $(d)/nix
+    $(d)/base64 \
+    $(d)/huffman
 
 $(eval $(call WILDCARD_SOURCES, CPP))

--- a/fly/files.mk
+++ b/fly/files.mk
@@ -1,17 +1,13 @@
 SRC_DIRS_$(d) := \
-    fly/coders \
-    fly/coders/base64 \
-    fly/coders/huffman \
-    fly/config \
-    fly/logger \
-    fly/parser \
-    fly/path \
-    fly/socket \
-    fly/system \
-    fly/task \
-    fly/types/bit_stream \
-    fly/types/bit_stream/detail \
-    fly/types/json
+    $(d)/coders \
+    $(d)/config \
+    $(d)/logger \
+    $(d)/parser \
+    $(d)/path \
+    $(d)/socket \
+    $(d)/system \
+    $(d)/task \
+    $(d)/types
 
 # Add libfly.a and libfly.so to the archived release package.
 $(eval $(call ADD_REL_LIB))

--- a/fly/logger/files.mk
+++ b/fly/logger/files.mk
@@ -1,10 +1,5 @@
-SRC_$(d) := \
-    $(d)/detail/console_sink.cpp \
-    $(d)/detail/file_sink.cpp \
-    $(d)/detail/nix/styler_proxy_impl.cpp \
-    $(d)/detail/registry.cpp \
-    $(d)/detail/styler_proxy.cpp \
-    $(d)/log.cpp \
-    $(d)/logger.cpp \
-    $(d)/logger_config.cpp \
-    $(d)/styler.cpp
+SRC_DIRS_$(d) := \
+    $(d)/detail \
+    $(d)/detail/nix
+
+$(eval $(call WILDCARD_SOURCES, CPP))

--- a/fly/path/files.mk
+++ b/fly/path/files.mk
@@ -1,11 +1,9 @@
-SRC_$(d) := \
-    $(d)/path_config.cpp \
-    $(d)/path_monitor.cpp
-
 ifeq ($(SYSTEM), LINUX)
-    SRC_$(d) += \
-        $(d)/nix/path_monitor_impl.cpp
+    SRC_DIRS_$(d) := \
+        $(d)/nix
 else ifeq ($(SYSTEM), MACOS)
-    SRC_$(d) += \
-        $(d)/mac/path_monitor_impl.mm
+    SRC_DIRS_$(d) := \
+        $(d)/mac
 endif
+
+$(eval $(call WILDCARD_SOURCES, CPP))

--- a/fly/types/files.mk
+++ b/fly/types/files.mk
@@ -1,0 +1,4 @@
+SRC_DIRS_$(d) := \
+    $(d)/bit_stream \
+    $(d)/bit_stream/detail \
+    $(d)/json

--- a/test/files.mk
+++ b/test/files.mk
@@ -1,25 +1,21 @@
 include $(SOURCE_ROOT)/extern/catchorg/flags.mk
 
 SRC_DIRS_$(d) += \
-    test/coders \
-    test/config \
-    test/logger \
-    test/parser \
-    test/path \
-    test/socket \
-    test/system \
-    test/task \
-    test/traits \
-    test/types/bit_stream \
-    test/types/concurrency \
-    test/types/json \
-    test/types/numeric \
-    test/types/string \
-    test/util
+    $(d)/coders \
+    $(d)/config \
+    $(d)/logger \
+    $(d)/parser \
+    $(d)/path \
+    $(d)/socket \
+    $(d)/system \
+    $(d)/task \
+    $(d)/traits \
+    $(d)/types \
+    $(d)/util
 
 ifeq ($(SYSTEM), LINUX)
     SRC_DIRS_$(d) += \
-        test/mock
+        $(d)/mock
 endif
 
 SRC_$(d) := \

--- a/test/mock/files.mk
+++ b/test/mock/files.mk
@@ -1,5 +1,7 @@
+SRC_DIRS_$(d) := \
+    $(d)/nix
+
 SRC_$(d) := \
-    $(d)/mock_system.cpp \
-    $(d)/nix/mock_calls.cpp
+    $(d)/mock_system.cpp
 
 CXXFLAGS_$(d) += -Wno-missing-declarations

--- a/test/types/files.mk
+++ b/test/types/files.mk
@@ -1,0 +1,6 @@
+SRC_DIRS_$(d) += \
+    $(d)/bit_stream \
+    $(d)/concurrency \
+    $(d)/json \
+    $(d)/numeric \
+    $(d)/string


### PR DESCRIPTION
SRC_DIRS_$(d) values should now be prefixed with $(d), and may be defined
in any files.mk file.