### PR TITLE
Use std::chrono::steady_clock to measure durations

### DIFF
--- a/bench/coders/benchmark_coders.cpp
+++ b/bench/coders/benchmark_coders.cpp
@@ -84,7 +84,7 @@ void run_enwik8_impl(
             std::filesystem::remove(output);
         }
 
-        const auto start = std::chrono::system_clock::now();
+        const auto start = std::chrono::steady_clock::now();
 
         if constexpr (std::is_same_v<Encode, std::true_type>)
         {
@@ -95,7 +95,7 @@ void run_enwik8_impl(
             coder.decode(input, output);
         }
 
-        const auto end = std::chrono::system_clock::now();
+        const auto end = std::chrono::steady_clock::now();
 
         const auto duration = std::chrono::duration<double>(end - start);
         results.push_back(duration.count());

--- a/bench/json/benchmark_json.cpp
+++ b/bench/json/benchmark_json.cpp
@@ -104,9 +104,9 @@ CATCH_TEST_CASE("JSON", "[bench]")
 
             for (std::size_t i = 0; i < s_iterations; ++i)
             {
-                const auto start = std::chrono::system_clock::now();
+                const auto start = std::chrono::steady_clock::now();
                 parser.second->parse(file);
-                const auto end = std::chrono::system_clock::now();
+                const auto end = std::chrono::steady_clock::now();
 
                 const auto duration = std::chrono::duration<double>(end - start);
                 results.push_back(duration.count());

--- a/bench/string/benchmark_string.cpp
+++ b/bench/string/benchmark_string.cpp
@@ -111,7 +111,7 @@ void run_format_test(std::string &&name)
 
         for (std::size_t i = 0; i < s_iterations; ++i)
         {
-            const auto start = std::chrono::system_clock::now();
+            const auto start = std::chrono::steady_clock::now();
 
             if constexpr (std::is_same_v<WithFloats, std::true_type>)
             {
@@ -122,7 +122,7 @@ void run_format_test(std::string &&name)
                 formatter.second->format_without_floats();
             }
 
-            const auto end = std::chrono::system_clock::now();
+            const auto end = std::chrono::steady_clock::now();
 
             const auto duration = std::chrono::duration<double>(end - start);
             results.push_back(duration.count());

--- a/fly/coders/coder.cpp
+++ b/fly/coders/coder.cpp
@@ -19,11 +19,11 @@ namespace {
 
     template <typename SizeType>
     void log_encoder_stats(
-        std::chrono::time_point<std::chrono::system_clock> start,
+        std::chrono::steady_clock::time_point start,
         SizeType decoded_size,
         SizeType encoded_size)
     {
-        const auto end = std::chrono::system_clock::now();
+        const auto end = std::chrono::steady_clock::now();
         const auto ratio = (static_cast<double>(decoded_size) - encoded_size) / decoded_size;
 
         LOGD(
@@ -36,11 +36,11 @@ namespace {
 
     template <typename SizeType>
     void log_decoder_stats(
-        std::chrono::time_point<std::chrono::system_clock> start,
+        std::chrono::steady_clock::time_point start,
         SizeType encoded_size,
         SizeType decoded_size)
     {
-        const auto end = std::chrono::system_clock::now();
+        const auto end = std::chrono::steady_clock::now();
 
         LOGD(
             "Decoded {} bytes to {} bytes in {:.2f} seconds",
@@ -54,7 +54,7 @@ namespace {
 //==================================================================================================
 bool Encoder::encode_string(const std::string &decoded, std::string &encoded)
 {
-    const auto start = std::chrono::system_clock::now();
+    const auto start = std::chrono::steady_clock::now();
     bool successful = false;
 
     std::istringstream input(decoded, s_input_mode);
@@ -79,7 +79,7 @@ bool Encoder::encode_file(
     const std::filesystem::path &decoded,
     const std::filesystem::path &encoded)
 {
-    const auto start = std::chrono::system_clock::now();
+    const auto start = std::chrono::steady_clock::now();
     bool successful = false;
     {
         std::ifstream input(decoded, s_input_mode);
@@ -112,7 +112,7 @@ bool BinaryEncoder::encode_internal(std::istream &decoded, std::ostream &encoded
 //==================================================================================================
 bool Decoder::decode_string(const std::string &encoded, std::string &decoded)
 {
-    const auto start = std::chrono::system_clock::now();
+    const auto start = std::chrono::steady_clock::now();
     bool successful = false;
 
     std::istringstream input(encoded, s_input_mode);
@@ -137,7 +137,7 @@ bool Decoder::decode_file(
     const std::filesystem::path &encoded,
     const std::filesystem::path &decoded)
 {
-    const auto start = std::chrono::system_clock::now();
+    const auto start = std::chrono::steady_clock::now();
     bool successful = false;
     {
         std::ifstream input(encoded, s_input_mode);

--- a/fly/logger/logger.cpp
+++ b/fly/logger/logger.cpp
@@ -21,7 +21,7 @@ Logger::Logger(
     m_config(config),
     m_sink(std::move(sink)),
     m_task_runner(task_runner),
-    m_start_time(std::chrono::high_resolution_clock::now())
+    m_start_time(std::chrono::steady_clock::now())
 {
 }
 
@@ -142,7 +142,7 @@ void Logger::log(Log::Level level, Log::Trace &&trace, std::string &&message)
         return;
     }
 
-    const auto now = std::chrono::high_resolution_clock::now();
+    const auto now = std::chrono::steady_clock::now();
 
     if (m_task_runner)
     {
@@ -169,7 +169,7 @@ void Logger::log_to_sink(
     Log::Level level,
     Log::Trace &&trace,
     std::string &&message,
-    std::chrono::high_resolution_clock::time_point time)
+    std::chrono::steady_clock::time_point time)
 {
     const std::chrono::duration<double, std::milli> elapsed = time - m_start_time;
 

--- a/fly/logger/logger.hpp
+++ b/fly/logger/logger.hpp
@@ -477,7 +477,7 @@ private:
         Log::Level level,
         Log::Trace &&trace,
         std::string &&message,
-        std::chrono::high_resolution_clock::time_point time);
+        std::chrono::steady_clock::time_point time);
 
     const std::string m_name;
 
@@ -487,7 +487,7 @@ private:
     std::shared_ptr<SequencedTaskRunner> m_task_runner;
     std::atomic_bool m_last_task_failed {true};
 
-    const std::chrono::high_resolution_clock::time_point m_start_time;
+    const std::chrono::steady_clock::time_point m_start_time;
     std::uintmax_t m_index {0};
 };
 

--- a/fly/path/mac/path_monitor_impl.mm
+++ b/fly/path/mac/path_monitor_impl.mm
@@ -85,14 +85,14 @@ void PathMonitorImpl::poll(const std::chrono::milliseconds &timeout)
 
     while (time_remaining != std::chrono::milliseconds::zero())
     {
-        const auto start = std::chrono::high_resolution_clock::now();
+        const auto start = std::chrono::steady_clock::now();
 
         if (m_event_queue.pop(event, time_remaining))
         {
             handle_event(std::move(event));
         }
 
-        const auto end = std::chrono::high_resolution_clock::now();
+        const auto end = std::chrono::steady_clock::now();
         const auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
 
         if (duration >= time_remaining)

--- a/fly/system/mac/system_monitor_impl.hpp
+++ b/fly/system/mac/system_monitor_impl.hpp
@@ -43,7 +43,7 @@ private:
 
     std::uint64_t m_prev_process_user_time {0};
     std::uint64_t m_prev_process_system_time {0};
-    std::chrono::high_resolution_clock::time_point m_prev_time;
+    std::chrono::steady_clock::time_point m_prev_time;
 };
 
 } // namespace fly

--- a/fly/system/mac/system_monitor_impl.mm
+++ b/fly/system/mac/system_monitor_impl.mm
@@ -72,7 +72,7 @@ void SystemMonitorImpl::update_process_cpu_usage()
         return;
     }
 
-    const auto now = std::chrono::high_resolution_clock::now();
+    const auto now = std::chrono::steady_clock::now();
     const auto user = time_value_to_microseconds(thread_times.user_time);
     const auto system = time_value_to_microseconds(thread_times.system_time);
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -31,14 +31,14 @@ public:
     void testRunStarting(const Catch::TestRunInfo &info) override
     {
         Catch::ConsoleReporter::testRunStarting(info);
-        m_test_start = std::chrono::system_clock::now();
+        m_test_start = std::chrono::steady_clock::now();
     }
 
     void testRunEnded(const Catch::TestRunStats &stats) override
     {
         Catch::ConsoleReporter::testRunEnded(stats);
 
-        const auto end = std::chrono::system_clock::now();
+        const auto end = std::chrono::steady_clock::now();
         const auto duration = std::chrono::duration<double>(end - m_test_start);
 
         // ConsoleReporter prints a second newline above, so go up one line before logging the time.
@@ -53,7 +53,7 @@ public:
 
         Catch::ConsoleReporter::testCaseStarting(info);
 
-        m_current_test_case_start = std::chrono::system_clock::now();
+        m_current_test_case_start = std::chrono::steady_clock::now();
         m_current_test_case = info.name;
     }
 
@@ -70,7 +70,7 @@ public:
 
     void testCaseEnded(const Catch::TestCaseStats &stats) override
     {
-        const auto end = std::chrono::system_clock::now();
+        const auto end = std::chrono::steady_clock::now();
         const auto duration = std::chrono::duration<double>(end - m_current_test_case_start);
 
         const std::string &name = stats.testInfo->name;
@@ -101,9 +101,9 @@ public:
     }
 
 private:
-    std::chrono::system_clock::time_point m_test_start;
+    std::chrono::steady_clock::time_point m_test_start;
 
-    std::chrono::system_clock::time_point m_current_test_case_start;
+    std::chrono::steady_clock::time_point m_current_test_case_start;
     std::string m_current_test_case;
 };
 

--- a/test/task/task.cpp
+++ b/test/task/task.cpp
@@ -96,7 +96,7 @@ private:
 class TimerTask : public fly::Task
 {
 public:
-    TimerTask() noexcept : m_start_time(std::chrono::high_resolution_clock::now())
+    TimerTask() noexcept : m_start_time(std::chrono::steady_clock::now())
     {
     }
 
@@ -107,12 +107,12 @@ public:
 
     void run()
     {
-        m_stop_time = std::chrono::high_resolution_clock::now();
+        m_stop_time = std::chrono::steady_clock::now();
     }
 
 private:
-    std::chrono::high_resolution_clock::time_point m_start_time;
-    std::chrono::high_resolution_clock::time_point m_stop_time;
+    std::chrono::steady_clock::time_point m_start_time;
+    std::chrono::steady_clock::time_point m_stop_time;
 };
 
 } // namespace


### PR DESCRIPTION
steady_clock increases monotonically, whereas system_clock can go
backwards. high_resolution_clock should just be avoided:

https://en.cppreference.com/w/cpp/chrono/high_resolution_clock