### PR TITLE
Re-order parameters of post_task methods

### DIFF
--- a/fly/config/config_manager.cpp
+++ b/fly/config/config_manager.cpp
@@ -90,7 +90,7 @@ bool ConfigManager::start()
                 nested_self->update_config();
             };
 
-            self->m_task_runner->post_task(FROM_HERE, std::move(task), std::move(weak_self));
+            self->m_task_runner->post_task(FROM_HERE, std::move(weak_self), std::move(task));
         }
     };
 

--- a/fly/logger/detail/console_sink.cpp
+++ b/fly/logger/detail/console_sink.cpp
@@ -48,7 +48,7 @@ bool ConsoleSink::stream(fly::logger::Log &&log)
     {
         auto styler = color ? fly::logger::Styler(std::move(style), *std::move(color)) :
                               fly::logger::Styler(std::move(style));
-        *stream << styler << String::format("{} {}", fly::system::local_time(), log.m_trace);
+        *stream << styler << fly::String::format("{} {}", fly::system::local_time(), log.m_trace);
     }
 
     *stream << ": " << log.m_message << std::endl;

--- a/fly/logger/logger.cpp
+++ b/fly/logger/logger.cpp
@@ -194,7 +194,7 @@ void Logger::log(Level level, Trace &&trace, std::string &&message)
         };
 
         std::weak_ptr<Logger> weak_self = shared_from_this();
-        m_task_runner->post_task(FROM_HERE, std::move(task), std::move(weak_self));
+        m_task_runner->post_task(FROM_HERE, std::move(weak_self), std::move(task));
     }
     else
     {

--- a/fly/net/socket/socket_service.cpp
+++ b/fly/net/socket/socket_service.cpp
@@ -59,7 +59,7 @@ void SocketService::remove_socket(socket_type handle)
     };
 
     std::weak_ptr<SocketService> weak_self = shared_from_this();
-    m_task_runner->post_task(FROM_HERE, std::move(task), weak_self);
+    m_task_runner->post_task(FROM_HERE, weak_self, std::move(task));
 }
 
 //==================================================================================================
@@ -77,7 +77,7 @@ void SocketService::notify_when_writable(socket_type handle, Notification &&call
     };
 
     std::weak_ptr<SocketService> weak_self = shared_from_this();
-    m_task_runner->post_task(FROM_HERE, std::move(task), weak_self);
+    m_task_runner->post_task(FROM_HERE, weak_self, std::move(task));
 }
 
 //==================================================================================================
@@ -95,7 +95,7 @@ void SocketService::notify_when_readable(socket_type handle, Notification &&call
     };
 
     std::weak_ptr<SocketService> weak_self = shared_from_this();
-    m_task_runner->post_task(FROM_HERE, std::move(task), weak_self);
+    m_task_runner->post_task(FROM_HERE, weak_self, std::move(task));
 }
 
 //==================================================================================================
@@ -143,7 +143,7 @@ void SocketService::poll()
         };
 
         std::weak_ptr<SocketService> weak_self = shared_from_this();
-        m_task_runner->post_task(FROM_HERE, std::move(task), std::move(weak_self));
+        m_task_runner->post_task(FROM_HERE, std::move(weak_self), std::move(task));
     }
 }
 

--- a/fly/path/path_monitor.cpp
+++ b/fly/path/path_monitor.cpp
@@ -198,7 +198,7 @@ bool PathMonitor::poll_paths_later()
     };
 
     std::weak_ptr<PathMonitor> weak_self = shared_from_this();
-    return m_task_runner->post_task(FROM_HERE, std::move(task), std::move(weak_self));
+    return m_task_runner->post_task(FROM_HERE, std::move(weak_self), std::move(task));
 }
 
 //==================================================================================================

--- a/fly/system/system_monitor.cpp
+++ b/fly/system/system_monitor.cpp
@@ -103,9 +103,9 @@ bool SystemMonitor::poll_system_later()
 
     return m_task_runner->post_task_with_delay(
         FROM_HERE,
-        std::move(task),
         std::move(weak_self),
-        m_config->poll_interval());
+        m_config->poll_interval(),
+        std::move(task));
 }
 
 } // namespace fly::system

--- a/fly/task/task_manager.cpp
+++ b/fly/task/task_manager.cpp
@@ -83,14 +83,14 @@ bool TaskManager::stop()
 //==================================================================================================
 void TaskManager::post_task(
     TaskLocation &&location,
-    Task &&task,
-    std::weak_ptr<TaskRunner> weak_task_runner)
+    std::weak_ptr<TaskRunner> weak_task_runner,
+    Task &&task)
 {
     TaskHolder wrapped_task {
         std::move(location),
-        std::move(task),
         std::move(weak_task_runner),
-        std::chrono::steady_clock::now()};
+        std::chrono::steady_clock::now(),
+        std::move(task)};
 
     m_tasks.push(std::move(wrapped_task));
 }
@@ -98,15 +98,15 @@ void TaskManager::post_task(
 //==================================================================================================
 void TaskManager::post_task_with_delay(
     TaskLocation &&location,
-    Task &&task,
     std::weak_ptr<TaskRunner> weak_task_runner,
-    std::chrono::milliseconds delay)
+    std::chrono::milliseconds delay,
+    Task &&task)
 {
     TaskHolder wrapped_task {
         std::move(location),
-        std::move(task),
         std::move(weak_task_runner),
-        std::chrono::steady_clock::now() + delay};
+        std::chrono::steady_clock::now() + delay,
+        std::move(task)};
 
     std::unique_lock<std::mutex> lock(m_delayed_tasks_mutex);
     m_delayed_tasks.push_back(std::move(wrapped_task));

--- a/fly/task/task_manager.hpp
+++ b/fly/task/task_manager.hpp
@@ -68,9 +68,9 @@ private:
     struct TaskHolder
     {
         TaskLocation m_location;
-        Task m_task;
         std::weak_ptr<TaskRunner> m_weak_task_runner;
         std::chrono::steady_clock::time_point m_schedule;
+        Task m_task;
     };
 
     /**
@@ -84,25 +84,25 @@ private:
      * Post a task to be executed as soon as a worker thread is available.
      *
      * @param location The location from which the task was posted.
-     * @param task The task to be executed.
      * @param weak_task_runner The task runner posting the task.
+     * @param task The task to be executed.
      */
     void
-    post_task(TaskLocation &&location, Task &&task, std::weak_ptr<TaskRunner> weak_task_runner);
+    post_task(TaskLocation &&location, std::weak_ptr<TaskRunner> weak_task_runner, Task &&task);
 
     /**
      * Schedule a task to be posted for execution after some delay.
      *
      * @param location The location from which the task was posted.
-     * @param task The task to be executed.
      * @param weak_task_runner The task runner posting the task.
      * @param delay Delay before posting the task.
+     * @param task The task to be executed.
      */
     void post_task_with_delay(
         TaskLocation &&location,
-        Task &&task,
         std::weak_ptr<TaskRunner> weak_task_runner,
-        std::chrono::milliseconds delay);
+        std::chrono::milliseconds delay,
+        Task &&task);
 
     /**
      * Worker thread for executing tasks.

--- a/fly/task/task_runner.cpp
+++ b/fly/task/task_runner.cpp
@@ -15,7 +15,7 @@ bool TaskRunner::post_task_to_task_manager(TaskLocation &&location, Task &&task)
 {
     if (std::shared_ptr<TaskManager> task_manager = m_weak_task_manager.lock(); task_manager)
     {
-        task_manager->post_task(std::move(location), std::move(task), shared_from_this());
+        task_manager->post_task(std::move(location), shared_from_this(), std::move(task));
         return true;
     }
 
@@ -25,13 +25,17 @@ bool TaskRunner::post_task_to_task_manager(TaskLocation &&location, Task &&task)
 //==================================================================================================
 bool TaskRunner::post_task_to_task_manager_with_delay(
     TaskLocation &&location,
-    Task &&task,
-    std::chrono::milliseconds delay)
+    std::chrono::milliseconds delay,
+    Task &&task)
 {
     if (std::shared_ptr<TaskManager> task_manager = m_weak_task_manager.lock(); task_manager)
     {
-        task_manager
-            ->post_task_with_delay(std::move(location), std::move(task), shared_from_this(), delay);
+        task_manager->post_task_with_delay(
+            std::move(location),
+            shared_from_this(),
+            std::move(delay),
+            std::move(task));
+
         return true;
     }
 

--- a/test/task/task.cpp
+++ b/test/task/task.cpp
@@ -257,7 +257,7 @@ CATCH_TEST_CASE("Task", "[task]")
         const std::chrono::milliseconds delay(10);
 
         CATCH_REQUIRE(
-            task_runner->post_task_with_delay(FROM_HERE, std::bind(&TimerTask::run, &task), delay));
+            task_runner->post_task_with_delay(FROM_HERE, delay, std::bind(&TimerTask::run, &task)));
         task_runner->wait_for_task_to_complete(__FILE__);
 
         CATCH_CHECK(task.time() >= delay);
@@ -273,8 +273,8 @@ CATCH_TEST_CASE("Task", "[task]")
 
         CATCH_REQUIRE(task_runner->post_task_with_delay(
             FROM_HERE,
-            std::bind(&MarkerTask::run, &task, 1),
-            10ms));
+            10ms,
+            std::bind(&MarkerTask::run, &task, 1)));
         CATCH_REQUIRE(task_runner->post_task(FROM_HERE, std::bind(&MarkerTask::run, &task, 2)));
         CATCH_REQUIRE(task_runner->post_task(FROM_HERE, std::bind(&MarkerTask::run, &task, 3)));
 
@@ -313,9 +313,9 @@ CATCH_TEST_CASE("Task", "[task]")
 
         CATCH_REQUIRE(task_runner->post_task_with_delay_and_reply(
             FROM_HERE,
+            10ms,
             std::move(task),
-            std::move(reply),
-            10ms));
+            std::move(reply)));
         task_runner->wait_for_task_to_complete(__FILE__);
         task_runner->wait_for_task_to_complete(__FILE__);
 
@@ -342,9 +342,9 @@ CATCH_TEST_CASE("Task", "[task]")
 
         CATCH_REQUIRE(task_runner->post_task_with_delay_and_reply(
             FROM_HERE,
+            10ms,
             std::move(task),
-            std::move(reply),
-            10ms));
+            std::move(reply)));
         task_runner->wait_for_task_to_complete(__FILE__);
         task_runner->wait_for_task_to_complete(__FILE__);
 
@@ -368,7 +368,7 @@ CATCH_TEST_CASE("Task", "[task]")
             };
 
             std::weak_ptr<TaskClass> weak_task_class = task_class;
-            CATCH_REQUIRE(task_runner->post_task(FROM_HERE, std::move(task), weak_task_class));
+            CATCH_REQUIRE(task_runner->post_task(FROM_HERE, weak_task_class, std::move(task)));
             task_runner->wait_for_task_to_complete(__FILE__);
 
             CATCH_CHECK(task_was_called);
@@ -390,7 +390,7 @@ CATCH_TEST_CASE("Task", "[task]")
             std::weak_ptr<TaskClass> weak_task_class = task_class;
             task_class.reset();
 
-            CATCH_REQUIRE(task_runner->post_task(FROM_HERE, std::move(task), weak_task_class));
+            CATCH_REQUIRE(task_runner->post_task(FROM_HERE, weak_task_class, std::move(task)));
             task_runner->wait_for_task_to_complete(__FILE__);
 
             CATCH_CHECK_FALSE(task_was_called);
@@ -420,9 +420,9 @@ CATCH_TEST_CASE("Task", "[task]")
 
             CATCH_REQUIRE(task_runner->post_task_with_reply(
                 FROM_HERE,
+                weak_task_class,
                 std::move(task),
-                std::move(reply),
-                weak_task_class));
+                std::move(reply)));
             task_runner->wait_for_task_to_complete(__FILE__);
 
             CATCH_CHECK_FALSE(task_was_called);
@@ -454,9 +454,9 @@ CATCH_TEST_CASE("Task", "[task]")
 
             CATCH_REQUIRE(task_runner->post_task_with_reply(
                 FROM_HERE,
+                weak_task_class,
                 std::move(task),
-                std::move(reply),
-                weak_task_class));
+                std::move(reply)));
             task_runner->wait_for_task_to_complete(__FILE__);
             task_runner->wait_for_task_to_complete(__FILE__);
 
@@ -487,9 +487,9 @@ CATCH_TEST_CASE("Task", "[task]")
 
             CATCH_REQUIRE(task_runner->post_task_with_reply(
                 FROM_HERE,
+                weak_task_class,
                 std::move(task),
-                std::move(reply),
-                weak_task_class));
+                std::move(reply)));
             task_runner->wait_for_task_to_complete(__FILE__);
 
             CATCH_CHECK_FALSE(task_was_called);
@@ -520,9 +520,9 @@ CATCH_TEST_CASE("Task", "[task]")
 
             CATCH_REQUIRE(task_runner->post_task_with_reply(
                 FROM_HERE,
+                weak_task_class,
                 std::move(task),
-                std::move(reply),
-                weak_task_class));
+                std::move(reply)));
             task_runner->wait_for_task_to_complete(__FILE__);
             task_runner->wait_for_task_to_complete(__FILE__);
 
@@ -546,7 +546,7 @@ CATCH_TEST_CASE("Task", "[task]")
             std::weak_ptr<TaskClass> weak_task_class = task_class;
             CATCH_REQUIRE(
                 task_runner
-                    ->post_task_with_delay(FROM_HERE, std::move(task), weak_task_class, 10ms));
+                    ->post_task_with_delay(FROM_HERE, weak_task_class, 10ms, std::move(task)));
             task_runner->wait_for_task_to_complete(__FILE__);
 
             CATCH_CHECK(task_was_called);
@@ -570,7 +570,7 @@ CATCH_TEST_CASE("Task", "[task]")
 
             CATCH_REQUIRE(
                 task_runner
-                    ->post_task_with_delay(FROM_HERE, std::move(task), weak_task_class, 10ms));
+                    ->post_task_with_delay(FROM_HERE, weak_task_class, 10ms, std::move(task)));
             task_runner->wait_for_task_to_complete(__FILE__);
 
             CATCH_CHECK_FALSE(task_was_called);
@@ -600,10 +600,10 @@ CATCH_TEST_CASE("Task", "[task]")
 
             CATCH_REQUIRE(task_runner->post_task_with_delay_and_reply(
                 FROM_HERE,
-                std::move(task),
-                std::move(reply),
                 weak_task_class,
-                10ms));
+                10ms,
+                std::move(task),
+                std::move(reply)));
             task_runner->wait_for_task_to_complete(__FILE__);
 
             CATCH_CHECK_FALSE(task_was_called);
@@ -635,10 +635,10 @@ CATCH_TEST_CASE("Task", "[task]")
 
             CATCH_REQUIRE(task_runner->post_task_with_delay_and_reply(
                 FROM_HERE,
-                std::move(task),
-                std::move(reply),
                 weak_task_class,
-                10ms));
+                10ms,
+                std::move(task),
+                std::move(reply)));
             task_runner->wait_for_task_to_complete(__FILE__);
             task_runner->wait_for_task_to_complete(__FILE__);
 
@@ -669,10 +669,10 @@ CATCH_TEST_CASE("Task", "[task]")
 
             CATCH_REQUIRE(task_runner->post_task_with_delay_and_reply(
                 FROM_HERE,
-                std::move(task),
-                std::move(reply),
                 weak_task_class,
-                10ms));
+                10ms,
+                std::move(task),
+                std::move(reply)));
             task_runner->wait_for_task_to_complete(__FILE__);
 
             CATCH_CHECK_FALSE(task_was_called);
@@ -703,10 +703,10 @@ CATCH_TEST_CASE("Task", "[task]")
 
             CATCH_REQUIRE(task_runner->post_task_with_delay_and_reply(
                 FROM_HERE,
-                std::move(task),
-                std::move(reply),
                 weak_task_class,
-                10ms));
+                10ms,
+                std::move(task),
+                std::move(reply)));
             task_runner->wait_for_task_to_complete(__FILE__);
             task_runner->wait_for_task_to_complete(__FILE__);
 
@@ -823,10 +823,7 @@ CATCH_TEST_CASE("TaskManager", "[task]")
         task_manager.reset();
 
         CATCH_CHECK_FALSE(task_runner->post_task(FROM_HERE, []() {}));
-        CATCH_CHECK_FALSE(task_runner->post_task_with_delay(
-            FROM_HERE,
-            []() {},
-            0ms));
+        CATCH_CHECK_FALSE(task_runner->post_task_with_delay(FROM_HERE, 0ms, []() {}));
     }
 
     CATCH_SECTION("Sequenced tasks cannot be posted after the task manager is deleted")
@@ -837,9 +834,6 @@ CATCH_TEST_CASE("TaskManager", "[task]")
         task_manager.reset();
 
         CATCH_CHECK_FALSE(task_runner->post_task(FROM_HERE, []() {}));
-        CATCH_CHECK_FALSE(task_runner->post_task_with_delay(
-            FROM_HERE,
-            []() {},
-            0ms));
+        CATCH_CHECK_FALSE(task_runner->post_task_with_delay(FROM_HERE, 0ms, []() {}));
     }
 }


### PR DESCRIPTION
Put the task (and reply) at the end of the parameter list. IMO this:

    task_runner->post_task(
        FROM_HERE,
        shared_from_this(),
        [](std::shared_ptr<MyClass> self)
        {

        });

Feels better than this:

    task_runner->post_task(
        FROM_HERE,
        [](std::shared_ptr<MyClass> self)
        {

        },
        shared_from_this());