### PR TITLE
Enforce more strict JSON string conversion rules

### DIFF
--- a/test/config/config_manager.cpp
+++ b/test/config/config_manager.cpp
@@ -142,9 +142,8 @@ CATCH_TEST_CASE("ConfigManager", "[config]")
 
         const fly::Json json {
             {fly::test::TestConfig::identifier, {{"name", "John Doe"}, {"address", "MA"}}}};
-        const std::string contents(json);
 
-        CATCH_REQUIRE(fly::test::PathUtil::write_file(config_file, contents));
+        CATCH_REQUIRE(fly::test::PathUtil::write_file(config_file, json.serialize()));
         task_runner->wait_for_task_to_complete(s_config_manager_file);
         task_runner->wait_for_task_to_complete(s_config_manager_file);
 
@@ -156,7 +155,7 @@ CATCH_TEST_CASE("ConfigManager", "[config]")
             CATCH_CHECK(config->get_value<std::string>("address", "") == "MA");
         }
 
-        CATCH_REQUIRE(fly::test::PathUtil::write_file(config_file, contents + "\n"));
+        CATCH_REQUIRE(fly::test::PathUtil::write_file(config_file, json.serialize() + "\n"));
         task_runner->wait_for_task_to_complete(s_config_manager_file);
 
         CATCH_CHECK(config_manager->prune() == initial_size);
@@ -166,9 +165,8 @@ CATCH_TEST_CASE("ConfigManager", "[config]")
     {
         const fly::Json json {
             {fly::test::TestConfig::identifier, {{"name", "John Doe"}, {"address", "MA"}}}};
-        const std::string contents(json);
 
-        CATCH_REQUIRE(fly::test::PathUtil::write_file(config_file, contents));
+        CATCH_REQUIRE(fly::test::PathUtil::write_file(config_file, json.serialize()));
         task_runner->wait_for_task_to_complete(s_config_manager_file);
         task_runner->wait_for_task_to_complete(s_config_manager_file);
 
@@ -184,9 +182,8 @@ CATCH_TEST_CASE("ConfigManager", "[config]")
 
         const fly::Json json {
             {fly::test::TestConfig::identifier, {{"name", "John Doe"}, {"address", "MA"}}}};
-        const std::string contents(json);
 
-        CATCH_REQUIRE(fly::test::PathUtil::write_file(config_file, contents));
+        CATCH_REQUIRE(fly::test::PathUtil::write_file(config_file, json.serialize()));
         task_runner->wait_for_task_to_complete(s_config_manager_file);
         task_runner->wait_for_task_to_complete(s_config_manager_file);
 
@@ -200,9 +197,8 @@ CATCH_TEST_CASE("ConfigManager", "[config]")
 
         const fly::Json json1 {
             {fly::test::TestConfig::identifier, {{"name", "John Doe"}, {"address", "MA"}}}};
-        const std::string contents1(json1);
 
-        CATCH_REQUIRE(fly::test::PathUtil::write_file(config_file, contents1));
+        CATCH_REQUIRE(fly::test::PathUtil::write_file(config_file, json1.serialize()));
         task_runner->wait_for_task_to_complete(s_config_manager_file);
         task_runner->wait_for_task_to_complete(s_config_manager_file);
 
@@ -212,9 +208,8 @@ CATCH_TEST_CASE("ConfigManager", "[config]")
 
         const fly::Json json2 {
             {fly::test::TestConfig::identifier, {{"name", "Jane Doe"}, {"age", 27}}}};
-        const std::string contents2(json2);
 
-        CATCH_REQUIRE(fly::test::PathUtil::write_file(config_file, contents2));
+        CATCH_REQUIRE(fly::test::PathUtil::write_file(config_file, json2.serialize()));
         task_runner->wait_for_task_to_complete(s_config_manager_file);
 
         // Multiple fly::PathEvent::Changed events may be triggered even though the above write
@@ -235,9 +230,8 @@ CATCH_TEST_CASE("ConfigManager", "[config]")
 
         const fly::Json json {
             {fly::test::TestConfig::identifier, {{"name", "John Doe"}, {"address", "MA"}}}};
-        const std::string contents(json);
 
-        CATCH_REQUIRE(fly::test::PathUtil::write_file(config_file, contents));
+        CATCH_REQUIRE(fly::test::PathUtil::write_file(config_file, json.serialize()));
         task_runner->wait_for_task_to_complete(s_config_manager_file);
         task_runner->wait_for_task_to_complete(s_config_manager_file);
 

--- a/test/types/json/json_conversion.cpp
+++ b/test/types/json/json_conversion.cpp
@@ -19,35 +19,19 @@ CATCH_JSON_STRING_TEST_CASE("JsonConversion")
 
     CATCH_SECTION("Convert a JSON instance to string-like types")
     {
-        if constexpr (std::is_same_v<json_type, fly::JsonTraits::null_type>)
-        {
-            CATCH_CHECK(string_type(json) == J_STR("null"));
-            CATCH_CHECK(string_type(empty) == J_STR("null"));
-        }
-        else if constexpr (std::is_same_v<json_type, fly::JsonTraits::string_type>)
+        if constexpr (std::is_same_v<json_type, fly::JsonTraits::string_type>)
         {
             CATCH_CHECK(string_type(json) == J_STR("abcdef"));
             CATCH_CHECK(string_type(empty) == J_STR(""));
         }
-        else if constexpr (std::is_same_v<json_type, fly::JsonTraits::object_type>)
-        {
-            CATCH_CHECK(string_type(json) == J_STR("{\"a\":1,\"b\":2}"));
-            CATCH_CHECK(string_type(empty) == J_STR("{}"));
-        }
-        else if constexpr (std::is_same_v<json_type, fly::JsonTraits::array_type>)
-        {
-            CATCH_CHECK(string_type(json) == J_STR("[55,8,9,10]"));
-            CATCH_CHECK(string_type(empty) == J_STR("[]"));
-        }
-        else if constexpr (std::is_same_v<json_type, fly::JsonTraits::boolean_type>)
-        {
-            CATCH_CHECK(string_type(json) == J_STR("true"));
-            CATCH_CHECK(string_type(empty) == J_STR("false"));
-        }
-        else
+        else if constexpr (fly::JsonTraits::is_number_v<json_type>)
         {
             CATCH_CHECK(string_type(json) == J_STR("1"));
             CATCH_CHECK(string_type(empty) == J_STR("0"));
+        }
+        else
+        {
+            CATCH_CHECK_THROWS_JSON(string_type(json), "JSON type is not a string: ({})", json);
         }
     }
 


### PR DESCRIPTION
Rather than allowing conversion of any JSON type to a string by way of
Json::serialize(), only allow creating a string from string and numeric
types. Coversting e.g. a JSON object to a string should explicitly use
Json::serialize().