### PR TITLE
Add fly::Json operators to transfer ownership of stored value

### DIFF
--- a/fly/types/json/json.cpp
+++ b/fly/types/json/json.cpp
@@ -203,6 +203,33 @@ Json::operator JsonTraits::null_type() const noexcept(false)
 }
 
 //==================================================================================================
+Json::operator JsonTraits::string_type() &&noexcept(false)
+{
+    auto storage = std::move(get<JsonTraits::string_type>("JSON type is not a string"));
+    m_value = nullptr;
+
+    return storage;
+}
+
+//==================================================================================================
+Json::operator JsonTraits::object_type() &&noexcept(false)
+{
+    auto storage = std::move(get<JsonTraits::object_type>("JSON type is not an object"));
+    m_value = nullptr;
+
+    return storage;
+}
+
+//==================================================================================================
+Json::operator JsonTraits::array_type() &&noexcept(false)
+{
+    auto storage = std::move(get<JsonTraits::array_type>("JSON type is not an array"));
+    m_value = nullptr;
+
+    return storage;
+}
+
+//==================================================================================================
 Json::reference Json::at(size_type index)
 {
     auto &storage = get<JsonTraits::array_type>("JSON type invalid for operator[index]");

--- a/fly/types/json/json.hpp
+++ b/fly/types/json/json.hpp
@@ -408,12 +408,21 @@ public:
      *         converted to the target string type.
      */
     template <typename T, enable_if<JsonTraits::is_string<T>> = 0>
-    explicit operator T() const noexcept(false);
+    explicit operator T() const &noexcept(false);
+
+    /**
+     * String move-conversion operator. If the Json instance is a string, transfers ownership of
+     * the stored value to the caller. The Json instance is set to a null value.
+     *
+     * @return The Json instance's stored string value.
+     *
+     * @throws JsonException If the Json instance is not a string.
+     */
+    explicit operator JsonTraits::string_type() &&noexcept(false);
 
     /**
      * Object conversion operator. Converts the Json instance to an object. The SFINAE declaration
-     * allows conversion to any object-like type (e.g. std::map, std::multimap) from the Json
-     * instance.
+     * allows conversion to any object-like type (e.g. std::map, std::multimap).
      *
      * @tparam T The object-like type.
      *
@@ -423,13 +432,22 @@ public:
      *         converted to the target object's value type.
      */
     template <typename T, enable_if<JsonTraits::is_object<T>> = 0>
-    explicit operator T() const noexcept(false);
+    explicit operator T() const &noexcept(false);
+
+    /**
+     * Object move-conversion operator. If the Json instance is an object, transfers ownership of
+     * the stored value to the caller. The Json instance is set to a null value.
+     *
+     * @return The Json instance's stored object value.
+     *
+     * @throws JsonException If the Json instance is not an object.
+     */
+    explicit operator JsonTraits::object_type() &&noexcept(false);
 
     /**
      * Array conversion operator. Converts the Json instance to an array. The SFINAE declaration
-     * allows conversion to any array-like type (e.g. std::list, std::vector) from the Json
-     * instance. This excludes std::array, which due to being an aggregate type, has its own
-     * explicit conversion operator.
+     * allows conversion to any array-like type (e.g. std::list, std::vector). This excludes
+     * std::array, which due to being an aggregate type, has its own explicit conversion operator.
      *
      * @tparam T The array-like type.
      *
@@ -439,7 +457,17 @@ public:
      *         converted to the target array's value type.
      */
     template <typename T, enable_if<JsonTraits::is_array<T>> = 0>
-    explicit operator T() const noexcept(false);
+    explicit operator T() const &noexcept(false);
+
+    /**
+     * Array move-conversion operator. If the Json instance is an array, transfers ownership of
+     * the stored value to the caller. The Json instance is set to a null value.
+     *
+     * @return The Json instance's stored array value.
+     *
+     * @throws JsonException If the Json instance is not an array.
+     */
+    explicit operator JsonTraits::array_type() &&noexcept(false);
 
     /**
      * Array conversion operator. Converts the Json instance to a std::array. If the Json instance
@@ -1598,7 +1626,7 @@ Json::Json(T value) noexcept : m_value(static_cast<JsonTraits::float_type>(value
 
 //==================================================================================================
 template <typename T, enable_if<JsonTraits::is_string<T>>>
-Json::operator T() const noexcept(false)
+Json::operator T() const &noexcept(false)
 {
     auto visitor = [this](const auto &storage) -> T
     {
@@ -1633,7 +1661,7 @@ Json::operator T() const noexcept(false)
 
 //==================================================================================================
 template <typename T, enable_if<JsonTraits::is_object<T>>>
-Json::operator T() const noexcept(false)
+Json::operator T() const &noexcept(false)
 {
     const auto &storage = get<JsonTraits::object_type>("JSON type is not an object");
     T result;
@@ -1650,7 +1678,7 @@ Json::operator T() const noexcept(false)
 
 //==================================================================================================
 template <typename T, enable_if<JsonTraits::is_array<T>>>
-Json::operator T() const noexcept(false)
+Json::operator T() const &noexcept(false)
 {
     const auto &storage = get<JsonTraits::array_type>("JSON type is not an array");
     T result {};

--- a/test/types/json/json_conversion.cpp
+++ b/test/types/json/json_conversion.cpp
@@ -251,3 +251,74 @@ CATCH_JSON_STRING_TEST_CASE("JsonConversion")
         }
     }
 }
+
+CATCH_JSON_TEST_CASE("JsonMoveConversion")
+{
+    using json_type = TestType;
+
+    fly::Json json = fly::test::create_json<json_type>();
+    fly::Json empty = json_type();
+
+    CATCH_SECTION("Transfer a JSON instance to a string")
+    {
+        if constexpr (std::is_same_v<json_type, fly::JsonTraits::string_type>)
+        {
+            auto json_value = fly::JsonTraits::string_type(std::move(json));
+            CATCH_CHECK(json_value == "abcdef");
+            CATCH_CHECK(json.is_null());
+
+            auto empty_value = fly::JsonTraits::string_type(std::move(empty));
+            CATCH_CHECK(empty_value == "");
+            CATCH_CHECK(empty.is_null());
+        }
+        else
+        {
+            CATCH_CHECK_THROWS_JSON(
+                fly::JsonTraits::string_type(std::move(json)),
+                "JSON type is not a string: ({})",
+                json);
+        }
+    }
+
+    CATCH_SECTION("Transfer a JSON instance to an object")
+    {
+        if constexpr (std::is_same_v<json_type, fly::JsonTraits::object_type>)
+        {
+            auto json_value = fly::JsonTraits::object_type(std::move(json));
+            CATCH_CHECK(json_value == fly::JsonTraits::object_type {{"a", 1}, {"b", 2}});
+            CATCH_CHECK(json.is_null());
+
+            auto empty_value = fly::JsonTraits::object_type(std::move(empty));
+            CATCH_CHECK(empty_value == fly::JsonTraits::object_type {});
+            CATCH_CHECK(empty.is_null());
+        }
+        else
+        {
+            CATCH_CHECK_THROWS_JSON(
+                fly::JsonTraits::object_type(std::move(json)),
+                "JSON type is not an object: ({})",
+                json);
+        }
+    }
+
+    CATCH_SECTION("Transfer a JSON instance to an array")
+    {
+        if constexpr (std::is_same_v<json_type, fly::JsonTraits::array_type>)
+        {
+            auto json_value = fly::JsonTraits::array_type(std::move(json));
+            CATCH_CHECK(json_value == fly::JsonTraits::array_type {'7', 8, 9, 10});
+            CATCH_CHECK(json.is_null());
+
+            auto empty_value = fly::JsonTraits::array_type(std::move(empty));
+            CATCH_CHECK(empty_value == fly::JsonTraits::array_type {});
+            CATCH_CHECK(empty.is_null());
+        }
+        else
+        {
+            CATCH_CHECK_THROWS_JSON(
+                fly::JsonTraits::array_type(std::move(json)),
+                "JSON type is not an array: ({})",
+                json);
+        }
+    }
+}


### PR DESCRIPTION
For JSON strings, objects, and arrays, add ref-value qualified operators
to transfer ownership of the stored value.

The move-conversion operators are defined only for the exact JSON types
(e.g. fly::JsonTraits::string_type). It makes less sense to define these
operators for e.g. other string types because then it is no longer just
a move operation.