### PR TITLE
Simplify JSON container constructors

### DIFF
--- a/fly/types/json/json.hpp
+++ b/fly/types/json/json.hpp
@@ -211,7 +211,7 @@ public:
      * @throws JsonException If the string-like value is not valid.
      */
     template <JsonStringLike T>
-    Json(T &&value) noexcept(false);
+    Json(T value) noexcept(false);
 
     /**
      * Object constructor. Intializes the Json instance to an object's values. The SFINAE
@@ -225,7 +225,7 @@ public:
      * @throws JsonException If an object key is not a valid string.
      */
     template <JsonObject T>
-    Json(T &&value) noexcept(false);
+    Json(T value) noexcept(false);
 
     /**
      * Array constructor. Intializes the Json instance to an array's values. The SFINAE declaration
@@ -238,7 +238,7 @@ public:
      * @throws JsonException If an string-like value in the array is not valid.
      */
     template <JsonArray T>
-    Json(T &&value) noexcept(false);
+    Json(T value) noexcept(false);
 
     /**
      * Boolean constructor. Intializes the Json instance to a boolean value. The SFINAE declaration
@@ -1548,56 +1548,29 @@ private:
 
 //==================================================================================================
 template <JsonStringLike T>
-Json::Json(T &&value) noexcept(false)
+Json::Json(T value) noexcept(false) : m_value(convert_to_string(std::move(value)))
 {
-    if constexpr (std::is_lvalue_reference_v<T>)
-    {
-        m_value = convert_to_string(value);
-    }
-    else
-    {
-        m_value = convert_to_string(std::forward<T>(value));
-    }
 }
 
 //==================================================================================================
 template <JsonObject T>
-Json::Json(T &&value) noexcept(false)
+Json::Json(T value) noexcept(false) : m_value(json_object_type())
 {
-    if constexpr (std::is_lvalue_reference_v<T>)
+    for (auto &it : value)
     {
-        m_value.emplace<json_object_type>();
-
-        for (const auto &it : value)
-        {
-            insert(it.first, it.second);
-        }
-    }
-    else
-    {
-        merge(std::forward<T>(value));
+        insert(std::move(it.first), std::move(it.second));
     }
 }
 
 //==================================================================================================
 template <JsonArray T>
-Json::Json(T &&value) noexcept(false) : m_value(json_array_type())
+Json::Json(T value) noexcept(false) : m_value(json_array_type())
 {
     reserve(detail::json_array_size(value));
 
-    if constexpr (std::is_lvalue_reference_v<T>)
+    for (auto &it : value)
     {
-        for (const auto &it : value)
-        {
-            push_back(it);
-        }
-    }
-    else
-    {
-        for (auto &it : value)
-        {
-            push_back(std::move(it));
-        }
+        push_back(std::move(it));
     }
 }
 

--- a/test/types/json/json_modifiers.cpp
+++ b/test/types/json/json_modifiers.cpp
@@ -515,12 +515,12 @@ CATCH_JSON_TEST_CASE("JsonModifiers")
                 T2 {FLY_JSON_STR("50"), FLY_JSON_STR("60"), FLY_JSON_STR("70"), FLY_JSON_STR("80")};
 
             CATCH_CHECK_NOTHROW(json.swap(test1));
-            CATCH_CHECK(json == T1 {10, 20, 30, 40});
+            CATCH_CHECK(T1(json) == T1 {10, 20, 30, 40});
             CATCH_CHECK(test1 == T1 {1, 2});
 
             CATCH_CHECK_NOTHROW(json.swap(test2));
             CATCH_CHECK(
-                json ==
+                T2(json) ==
                 T2 {FLY_JSON_STR("50"),
                     FLY_JSON_STR("60"),
                     FLY_JSON_STR("70"),
@@ -533,7 +533,7 @@ CATCH_JSON_TEST_CASE("JsonModifiers")
                     FLY_JSON_STR("40")});
 
             CATCH_CHECK_NOTHROW(json.swap(test1));
-            CATCH_CHECK(json == T1 {1, 2});
+            CATCH_CHECK(T1(json) == T1 {1, 2});
             CATCH_CHECK(test1 == T1 {50, 60, 70, 80});
         };
 


### PR DESCRIPTION
Instead of handling lvalue vs rvalue references of container types, just
define the constructor without any reference type. Callers can decide if
they want to move or copy the containers they pass in.