### PR TITLE
Update code style with options from clang-format 14

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,5 @@
-# Clang-Format 13.0.0
-# https://releases.llvm.org/13.0.0/tools/clang/docs/ClangFormatStyleOptions.html
+# Clang-Format 14.0.0
+# https://releases.llvm.org/14.0.0/tools/clang/docs/ClangFormatStyleOptions.html
 ---
 AccessModifierOffset: -4
 AlignAfterOpenBracket: AlwaysBreak
@@ -12,7 +12,6 @@ AlignEscapedNewlines: Right
 AlignOperands: DontAlign
 AlignTrailingComments: false
 AllowAllArgumentsOnNextLine: false
-AllowAllConstructorInitializersOnNextLine: false
 AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false
@@ -55,7 +54,6 @@ BreakInheritanceList: AfterColon
 BreakStringLiterals: true
 ColumnLimit: 100
 CompactNamespaces: false
-ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
@@ -92,9 +90,26 @@ LambdaBodyIndentation: Signature
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: Inner
 PPIndentWidth: -1
+PackConstructorInitializers: Never
 PointerAlignment: Right
+QualifierAlignment: Custom
+QualifierOrder: ['static', 'constexpr', 'inline', 'type', 'const']
 ReferenceAlignment: Right
 ReflowComments: true
+RemoveBracesLLVM: false
+
+# It would be nice to set this to Always, but it breaks code such as:
+#
+#     template <typename T>
+#     template <typename U>
+#     requires Concept<U>
+#     void Class<T>::function()
+#     {
+#     }
+#
+# By inserting a new line after the requires clause.
+SeparateDefinitionBlocks: Leave
+
 ShortNamespaceLines: 0
 SortIncludes: CaseInsensitive
 SortUsingDeclarations: true
@@ -113,7 +128,7 @@ SpaceBeforeSquareBrackets: false
 SpaceInEmptyBlock: true
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 1
-SpacesInAngles: false
+SpacesInAngles: Never
 SpacesInCStyleCastParentheses: false
 SpacesInConditionalStatement: false
 SpacesInContainerLiterals: false

--- a/bench/coders/benchmark_coders.cpp
+++ b/bench/coders/benchmark_coders.cpp
@@ -21,25 +21,26 @@ public:
     virtual ~Coder() = default;
 
     virtual void
-    encode(const std::filesystem::path &input, const std::filesystem::path &output) = 0;
+    encode(std::filesystem::path const &input, std::filesystem::path const &output) = 0;
 
     virtual void
-    decode(const std::filesystem::path &input, const std::filesystem::path &output) = 0;
+    decode(std::filesystem::path const &input, std::filesystem::path const &output) = 0;
 };
 
 class Huffman final : public Coder
 {
 public:
-    Huffman() : m_encoder(std::make_shared<fly::coders::CoderConfig>())
+    Huffman() :
+        m_encoder(std::make_shared<fly::coders::CoderConfig>())
     {
     }
 
-    void encode(const std::filesystem::path &input, const std::filesystem::path &output) final
+    void encode(std::filesystem::path const &input, std::filesystem::path const &output) final
     {
         FLY_UNUSED(m_encoder.encode_file(input, output));
     }
 
-    void decode(const std::filesystem::path &input, const std::filesystem::path &output) final
+    void decode(std::filesystem::path const &input, std::filesystem::path const &output) final
     {
         FLY_UNUSED(m_decoder.decode_file(input, output));
     }
@@ -52,12 +53,12 @@ private:
 class Base64 final : public Coder
 {
 public:
-    void encode(const std::filesystem::path &input, const std::filesystem::path &output) final
+    void encode(std::filesystem::path const &input, std::filesystem::path const &output) final
     {
         FLY_UNUSED(m_coder.encode_file(input, output));
     }
 
-    void decode(const std::filesystem::path &input, const std::filesystem::path &output) final
+    void decode(std::filesystem::path const &input, std::filesystem::path const &output) final
     {
         FLY_UNUSED(m_coder.decode_file(input, output));
     }
@@ -69,8 +70,8 @@ private:
 template <typename CoderType, typename Encode>
 void run_enwik8_impl(
     CoderTable &table,
-    const std::filesystem::path &input,
-    const std::filesystem::path &output)
+    std::filesystem::path const &input,
+    std::filesystem::path const &output)
 {
     static constexpr std::size_t s_iterations = 11;
 
@@ -84,7 +85,7 @@ void run_enwik8_impl(
             std::filesystem::remove(output);
         }
 
-        const auto start = std::chrono::steady_clock::now();
+        auto const start = std::chrono::steady_clock::now();
 
         if constexpr (std::is_same_v<Encode, std::true_type>)
         {
@@ -95,27 +96,27 @@ void run_enwik8_impl(
             coder.decode(input, output);
         }
 
-        const auto end = std::chrono::steady_clock::now();
+        auto const end = std::chrono::steady_clock::now();
 
-        const auto duration = std::chrono::duration<double>(end - start);
+        auto const duration = std::chrono::duration<double>(end - start);
         results.push_back(duration.count());
     }
 
     std::sort(results.rbegin(), results.rend());
 
-    const auto input_size = std::filesystem::file_size(input);
-    const auto output_size = std::filesystem::file_size(output);
+    auto const input_size = std::filesystem::file_size(input);
+    auto const output_size = std::filesystem::file_size(output);
 
-    const auto duration = results[s_iterations / 2];
-    const auto speed = input_size / duration / 1024.0 / 1024.0;
-    const auto ratio = static_cast<double>(output_size) / input_size;
+    auto const duration = results[s_iterations / 2];
+    auto const speed = input_size / duration / 1024.0 / 1024.0;
+    auto const ratio = static_cast<double>(output_size) / input_size;
 
     std::string direction(std::is_same_v<Encode, std::true_type> ? "Encode" : "Decode");
     table.append_row(std::move(direction), duration * 1000, speed, ratio * 100.0);
 }
 
 template <typename CoderType>
-void run_enwik8_test(std::string &&name, const std::filesystem::path &file)
+void run_enwik8_test(std::string &&name, std::filesystem::path const &file)
 {
     CoderTable table(
         std::move(name) + ": " + file.filename().string(),
@@ -134,8 +135,8 @@ void run_enwik8_test(std::string &&name, const std::filesystem::path &file)
 
 CATCH_TEST_CASE("Coders", "[bench]")
 {
-    const auto here = std::filesystem::path(__FILE__).parent_path();
-    const auto file = here / "data" / "enwik8";
+    auto const here = std::filesystem::path(__FILE__).parent_path();
+    auto const file = here / "data" / "enwik8";
 
     if (!std::filesystem::exists(file))
     {

--- a/bench/json/benchmark_json.cpp
+++ b/bench/json/benchmark_json.cpp
@@ -23,14 +23,14 @@ class JsonParserBase
 {
 public:
     virtual ~JsonParserBase() = default;
-    virtual void parse(const std::filesystem::path &path) = 0;
+    virtual void parse(std::filesystem::path const &path) = 0;
 };
 
 // libfly - https://github.com/trflynn89/libfly
 class LibflyJsonParser : public JsonParserBase
 {
 public:
-    void parse(const std::filesystem::path &path) override
+    void parse(std::filesystem::path const &path) override
     {
         FLY_UNUSED(m_parser.parse_file(path));
     }
@@ -43,12 +43,12 @@ private:
 class BoostJsonParser : public JsonParserBase
 {
 public:
-    void parse(const std::filesystem::path &path) override
+    void parse(std::filesystem::path const &path) override
     {
         boost::json::error_code error_code;
         m_parser.reset();
 
-        const std::string contents = fly::test::PathUtil::read_file(path);
+        std::string const contents = fly::test::PathUtil::read_file(path);
         m_parser.write(contents.data(), contents.size(), error_code);
 
         m_parser.finish(error_code);
@@ -63,7 +63,7 @@ private:
 class NLohmannJsonParser : public JsonParserBase
 {
 public:
-    void parse(const std::filesystem::path &path) override
+    void parse(std::filesystem::path const &path) override
     {
         std::ifstream stream(path);
         auto ignored = nlohmann::json::parse(stream);
@@ -77,8 +77,8 @@ CATCH_TEST_CASE("JSON", "[bench]")
 {
     static constexpr std::size_t s_iterations = 11;
 
-    const auto here = std::filesystem::path(__FILE__).parent_path();
-    const auto root = here.parent_path().parent_path();
+    auto const here = std::filesystem::path(__FILE__).parent_path();
+    auto const root = here.parent_path().parent_path();
 
     static std::vector<std::filesystem::path> s_test_files {
         root / "test" / "parser" / "json" / "unicode" / "all_unicode.json",
@@ -93,7 +93,7 @@ CATCH_TEST_CASE("JSON", "[bench]")
 #endif
     parsers.emplace("libfly", std::make_unique<LibflyJsonParser>());
 
-    for (const auto &file : s_test_files)
+    for (auto const &file : s_test_files)
     {
         JsonTable table(
             "JSON: " + file.filename().string(),
@@ -105,19 +105,19 @@ CATCH_TEST_CASE("JSON", "[bench]")
 
             for (std::size_t i = 0; i < s_iterations; ++i)
             {
-                const auto start = std::chrono::steady_clock::now();
+                auto const start = std::chrono::steady_clock::now();
                 parser.second->parse(file);
-                const auto end = std::chrono::steady_clock::now();
+                auto const end = std::chrono::steady_clock::now();
 
-                const auto duration = std::chrono::duration<double>(end - start);
+                auto const duration = std::chrono::duration<double>(end - start);
                 results.push_back(duration.count());
             }
 
             std::sort(results.rbegin(), results.rend());
 
-            const auto size = std::filesystem::file_size(file);
-            const auto duration = results[s_iterations / 2];
-            const auto speed = size / duration / 1024.0 / 1024.0;
+            auto const size = std::filesystem::file_size(file);
+            auto const duration = results[s_iterations / 2];
+            auto const speed = size / duration / 1024.0 / 1024.0;
 
             table.append_row(parser.first, duration * 1000, speed);
         }

--- a/bench/main.cpp
+++ b/bench/main.cpp
@@ -34,7 +34,8 @@ public:
 class SilentReporter final : public Catch::StreamingReporterBase
 {
 public:
-    explicit SilentReporter(const Catch::ReporterConfig &config) : StreamingReporterBase(config)
+    explicit SilentReporter(Catch::ReporterConfig const &config) :
+        StreamingReporterBase(config)
     {
     }
 
@@ -45,17 +46,17 @@ public:
         return "Catch2 silent reporter for libfly benchmarking";
     }
 
-    void assertionStarting(const Catch::AssertionInfo &) override
+    void assertionStarting(Catch::AssertionInfo const &) override
     {
     }
 
-    void assertionEnded(const Catch::AssertionStats &) override
+    void assertionEnded(Catch::AssertionStats const &) override
     {
     }
 
-    void testCaseStarting(const Catch::TestCaseInfo &info) override
+    void testCaseStarting(Catch::TestCaseInfo const &info) override
     {
-        const auto style = fly::logger::Styler(fly::logger::Style::Bold, fly::logger::Color::Cyan);
+        auto const style = fly::logger::Styler(fly::logger::Style::Bold, fly::logger::Color::Cyan);
         m_stream << style << fly::String::format("[{:=>13}{}{:=<13}]\n\n", ' ', info.name, ' ');
     }
 };

--- a/bench/string/benchmark_string.cpp
+++ b/bench/string/benchmark_string.cpp
@@ -139,7 +139,7 @@ void run_format_test(std::string &&name)
 
         for (std::size_t i = 0; i < s_iterations; ++i)
         {
-            const auto start = std::chrono::steady_clock::now();
+            auto const start = std::chrono::steady_clock::now();
 
             if constexpr (std::is_same_v<WithFloats, std::true_type>)
             {
@@ -150,15 +150,15 @@ void run_format_test(std::string &&name)
                 formatter.second->format_without_floats();
             }
 
-            const auto end = std::chrono::steady_clock::now();
+            auto const end = std::chrono::steady_clock::now();
 
-            const auto duration = std::chrono::duration<double>(end - start);
+            auto const duration = std::chrono::duration<double>(end - start);
             results.push_back(duration.count());
         }
 
         std::sort(results.rbegin(), results.rend());
 
-        const auto duration = results[s_iterations / 2];
+        auto const duration = results[s_iterations / 2];
         table.append_row(formatter.first, duration * 1000 * 1000);
     }
 

--- a/bench/util/table.hpp
+++ b/bench/util/table.hpp
@@ -86,7 +86,7 @@ public:
      *
      * @return The same stream object.
      */
-    friend std::ostream &operator<<(std::ostream &stream, const Table &table)
+    friend std::ostream &operator<<(std::ostream &stream, Table const &table)
     {
         table.print_table(stream);
         return stream;
@@ -129,7 +129,7 @@ private:
      * @param stream The stream to print the values into.
      * @param row The values to print.
      */
-    void print_row(std::ostream &stream, const Row &row) const;
+    void print_row(std::ostream &stream, Row const &row) const;
 
     /**
      * Print a horizontal row separator of the given width and with the given style onto a stream.
@@ -167,7 +167,7 @@ private:
      *
      * @return An array holding the sizes.
      */
-    RowSizedArray<std::size_t> column_widths_for_row(const Row &row);
+    RowSizedArray<std::size_t> column_widths_for_row(Row const &row);
 
     /**
      * Helper to determine if a numeric value is zero (if integral), or close enough to zero (if
@@ -182,22 +182,22 @@ private:
     template <typename T>
     static bool is_zero(T value);
 
-    static constexpr const fly::logger::Color s_border_color {fly::logger::Color::Cyan};
-    static constexpr const fly::logger::Style s_border_style {fly::logger::Style::Bold};
+    static constexpr fly::logger::Color s_border_color {fly::logger::Color::Cyan};
+    static constexpr fly::logger::Style s_border_style {fly::logger::Style::Bold};
 
-    static constexpr const fly::logger::Color s_title_color {fly::logger::Color::Green};
-    static constexpr const fly::logger::Style s_title_style {fly::logger::Style::Bold};
+    static constexpr fly::logger::Color s_title_color {fly::logger::Color::Green};
+    static constexpr fly::logger::Style s_title_style {fly::logger::Style::Bold};
 
-    static constexpr const fly::logger::Color s_header_color {fly::logger::Color::Red};
-    static constexpr const fly::logger::Style s_header_style {fly::logger::Style::Italic};
+    static constexpr fly::logger::Color s_header_color {fly::logger::Color::Red};
+    static constexpr fly::logger::Style s_header_style {fly::logger::Style::Italic};
 
-    static constexpr const fly::logger::Color s_data_color {fly::logger::Color::Yellow};
-    static constexpr const fly::logger::Style s_data_style {fly::logger::Style::Default};
+    static constexpr fly::logger::Color s_data_color {fly::logger::Color::Yellow};
+    static constexpr fly::logger::Style s_data_style {fly::logger::Style::Default};
 
-    static constexpr const std::size_t s_precision = 3;
+    static constexpr std::size_t s_precision = 3;
 
-    const std::string m_title;
-    const RowSizedArray<std::string> m_headers;
+    std::string const m_title;
+    RowSizedArray<std::string> const m_headers;
     std::vector<Row> m_data;
     RowSizedArray<std::size_t> m_column_widths;
 };
@@ -221,7 +221,7 @@ void Table<Args...>::append_row(Args... args)
     m_data.emplace_back(std::make_tuple(std::forward<Args>(args)...));
 
     // Potentially resize each column's width based on the widths of the new row.
-    const RowSizedArray<std::size_t> widths = column_widths_for_row(m_data.back());
+    RowSizedArray<std::size_t> const widths = column_widths_for_row(m_data.back());
 
     for (std::size_t i = 0; i < widths.size(); ++i)
     {
@@ -238,7 +238,7 @@ void Table<Args...>::print_table(std::ostream &stream) const
 
     // Compute the entire width of the table. There are 1 + the number of columns vertical
     // separators ('|'), plus the width of each column (with 2 padding spacers each).
-    const std::size_t table_width = (m_column_widths.size() + 1) +
+    std::size_t const table_width = (m_column_widths.size() + 1) +
         std::accumulate(m_column_widths.begin(), m_column_widths.end(), 0_zu) +
         (2 * m_column_widths.size());
 
@@ -257,14 +257,14 @@ void Table<Args...>::print_table(std::ostream &stream) const
 template <class... Args>
 void Table<Args...>::print_title(std::ostream &stream, std::size_t table_width) const
 {
-    const auto style = fly::logger::Styler(s_title_style, s_title_color);
+    auto const style = fly::logger::Styler(s_title_style, s_title_color);
 
     print_row_separator(stream, table_width, s_border_style);
     print_column_separator(stream, s_border_style);
 
     // Compute the width available for the title. The title can consume the same width of the table,
     // except for the 2 vertical separators (and their padding) for the table's outside borders.
-    const std::size_t title_width = table_width - 4;
+    std::size_t const title_width = table_width - 4;
 
     auto title = std::string_view(m_title).substr(0, title_width);
     stream << style << fly::String::format(" {:^{}} ", title, title_width);
@@ -281,7 +281,7 @@ void Table<Args...>::print_headers(std::ostream &stream, std::size_t table_width
     {
         print_column_separator(stream, index == 0 ? s_border_style : fly::logger::Style::Default);
 
-        const auto style = fly::logger::Styler(s_header_style, s_header_color);
+        auto const style = fly::logger::Styler(s_header_style, s_header_color);
         stream << style;
 
         stream << fly::String::format(" {:^{}} ", m_headers[index], m_column_widths[index]);
@@ -293,14 +293,14 @@ void Table<Args...>::print_headers(std::ostream &stream, std::size_t table_width
 
 //==================================================================================================
 template <class... Args>
-void Table<Args...>::print_row(std::ostream &stream, const Row &row) const
+void Table<Args...>::print_row(std::ostream &stream, Row const &row) const
 {
     std::size_t index = 0;
 
-    auto print_value = [this, &stream, &index](const auto &value) {
+    auto print_value = [this, &stream, &index](auto const &value) {
         print_column_separator(stream, index == 0 ? s_border_style : fly::logger::Style::Default);
 
-        const auto style = fly::logger::Styler(s_data_style, s_data_color);
+        auto const style = fly::logger::Styler(s_data_style, s_data_color);
         stream << style;
 
         if constexpr (std::is_floating_point_v<std::remove_cvref_t<decltype(value)>>)
@@ -316,7 +316,7 @@ void Table<Args...>::print_row(std::ostream &stream, const Row &row) const
         ++index;
     };
 
-    std::apply([&print_value](const auto &...e) { (print_value(e), ...); }, row);
+    std::apply([&print_value](auto const &...e) { (print_value(e), ...); }, row);
     print_column_separator(stream, s_border_style) << '\n';
 }
 
@@ -343,12 +343,12 @@ Table<Args...>::print_column_separator(std::ostream &stream, fly::logger::Style 
 
 //==================================================================================================
 template <class... Args>
-auto Table<Args...>::column_widths_for_row(const Row &row) -> RowSizedArray<std::size_t>
+auto Table<Args...>::column_widths_for_row(Row const &row) -> RowSizedArray<std::size_t>
 {
     RowSizedArray<std::size_t> widths;
     std::size_t index = 0;
 
-    auto size_of_value = [&widths, &index](const auto &value) {
+    auto size_of_value = [&widths, &index](auto const &value) {
         using T = std::decay_t<decltype(value)>;
 
         if constexpr (fly::StandardStringLike<T>)
@@ -364,11 +364,11 @@ auto Table<Args...>::column_widths_for_row(const Row &row) -> RowSizedArray<std:
             }
             else
             {
-                const std::size_t negative = value < 0 ? 1 : 0;
-                const std::size_t digits = static_cast<std::size_t>(
+                std::size_t const negative = value < 0 ? 1 : 0;
+                std::size_t const digits = static_cast<std::size_t>(
                     std::abs(static_cast<std::int64_t>(std::log10(std::abs(value)))) + 1);
-                const std::size_t commas = (digits - 1) / 3;
-                const std::size_t decimal = std::is_floating_point_v<T> ? s_precision + 1 : 0;
+                std::size_t const commas = (digits - 1) / 3;
+                std::size_t const decimal = std::is_floating_point_v<T> ? s_precision + 1 : 0;
 
                 widths[index] = negative + digits + commas + decimal;
             }
@@ -381,7 +381,7 @@ auto Table<Args...>::column_widths_for_row(const Row &row) -> RowSizedArray<std:
         ++index;
     };
 
-    std::apply([&size_of_value](const auto &...e) { (size_of_value(e), ...); }, row);
+    std::apply([&size_of_value](auto const &...e) { (size_of_value(e), ...); }, row);
     return widths;
 }
 

--- a/fly/coders/base64/base64_coder.cpp
+++ b/fly/coders/base64/base64_coder.cpp
@@ -8,7 +8,7 @@ namespace fly::coders {
 namespace {
 
     // The Base64 symbol table.
-    constexpr const std::array<std::ios::char_type, 64> s_base64_symbols = {
+    constexpr std::array<std::ios::char_type, 64> s_base64_symbols = {
         'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
         'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
 
@@ -22,7 +22,7 @@ namespace {
 
     // A mapping of ASCII codes to their indices in the Base64 symbol table. Invalid values are -1,
     // and the padding symbol is -2.
-    constexpr const std::array<std::ios::char_type, 256> s_base64_codes = {
+    constexpr std::array<std::ios::char_type, 256> s_base64_codes = {
         -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
         -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 62,
         -1, -1, -1, 63, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, -1, -1, -1, -2, -1, -1, -1, 0,
@@ -38,7 +38,7 @@ namespace {
     };
 
     // The Base64 padding symbol for 4-byte encoding alignment.
-    constexpr const std::ios::char_type *s_pad = "===";
+    constexpr std::ios::char_type const *s_pad = "===";
 
     /**
      * Encode a chunk of data into Base64 symbols.
@@ -46,11 +46,11 @@ namespace {
      * @param decoded Buffer holding the contents to encode.
      * @param encoded Buffer to store the encoded contents.
      */
-    void encode_chunk(const std::ios::char_type *decoded, std::ios::char_type *encoded)
+    void encode_chunk(std::ios::char_type const *decoded, std::ios::char_type *encoded)
     {
-        const auto &ch0 = decoded[0];
-        const auto &ch1 = decoded[1];
-        const auto &ch2 = decoded[2];
+        auto const &ch0 = decoded[0];
+        auto const &ch1 = decoded[1];
+        auto const &ch2 = decoded[2];
 
         // First 6 bits of the first symbol.
         encoded[0] = s_base64_symbols[static_cast<std::size_t>((ch0 & 0xfc) >> 2)];
@@ -81,12 +81,12 @@ namespace {
      */
     template <typename AllowPadding>
     std::conditional_t<AllowPadding::value, std::size_t, bool>
-    decode_chunk(const std::ios::char_type *encoded, std::ios::char_type *decoded)
+    decode_chunk(std::ios::char_type const *encoded, std::ios::char_type *decoded)
     {
-        const auto code0 = s_base64_codes[static_cast<std::size_t>(encoded[0])];
-        const auto code1 = s_base64_codes[static_cast<std::size_t>(encoded[1])];
-        const auto code2 = s_base64_codes[static_cast<std::size_t>(encoded[2])];
-        const auto code3 = s_base64_codes[static_cast<std::size_t>(encoded[3])];
+        auto const code0 = s_base64_codes[static_cast<std::size_t>(encoded[0])];
+        auto const code1 = s_base64_codes[static_cast<std::size_t>(encoded[1])];
+        auto const code2 = s_base64_codes[static_cast<std::size_t>(encoded[2])];
+        auto const code3 = s_base64_codes[static_cast<std::size_t>(encoded[3])];
 
         // All 6 bits of the first code, first 2 bits of the second code.
         decoded[0] = static_cast<std::ios::char_type>((code0 << 2) | ((code1 >> 4) & 0x03));
@@ -128,9 +128,9 @@ bool Base64Coder::encode_internal(std::istream &decoded, std::ostream &encoded)
     do
     {
         decoded.read(m_decoded.data(), static_cast<std::streamsize>(m_decoded.size()));
-        const auto bytes = static_cast<std::size_t>(decoded.gcount());
+        auto const bytes = static_cast<std::size_t>(decoded.gcount());
 
-        const std::ios::char_type *decoding = m_decoded.data();
+        std::ios::char_type const *decoding = m_decoded.data();
         std::ios::char_type *encoding = m_encoded.data();
 
         for (std::size_t i = bytes / s_decoded_chunk_size; i > 0; --i)
@@ -144,9 +144,9 @@ bool Base64Coder::encode_internal(std::istream &decoded, std::ostream &encoded)
 
         // If the input stream was not evenly split into 3-byte chunks, add padding to the remaining
         // chunk.
-        if (const auto remainder = bytes % s_decoded_chunk_size; remainder > 0)
+        if (auto const remainder = bytes % s_decoded_chunk_size; remainder > 0)
         {
-            const auto end = static_cast<std::size_t>(decoding - m_decoded.data()) + remainder;
+            auto const end = static_cast<std::size_t>(decoding - m_decoded.data()) + remainder;
             ::memset(m_decoded.data() + end, '\0', end);
 
             encode_chunk(decoding, m_encoded.data());
@@ -165,7 +165,7 @@ bool Base64Coder::decode_internal(std::istream &encoded, std::ostream &decoded)
     do
     {
         encoded.read(m_encoded.data(), static_cast<std::streamsize>(m_encoded.size()));
-        const auto bytes = static_cast<std::size_t>(encoded.gcount());
+        auto const bytes = static_cast<std::size_t>(encoded.gcount());
 
         if ((bytes % s_encoded_chunk_size) != 0)
         {
@@ -177,7 +177,7 @@ bool Base64Coder::decode_internal(std::istream &encoded, std::ostream &decoded)
             break;
         }
 
-        const std::ios::char_type *encoding = m_encoded.data();
+        std::ios::char_type const *encoding = m_encoded.data();
         std::ios::char_type *decoding = m_decoded.data();
 
         // For performance, the decoding loop is potentially broken up depending on whether this is
@@ -199,7 +199,7 @@ bool Base64Coder::decode_internal(std::istream &encoded, std::ostream &decoded)
 
         if (encoded.eof())
         {
-            const std::size_t bytes_read = decode_chunk<std::true_type>(encoding, decoding);
+            std::size_t const bytes_read = decode_chunk<std::true_type>(encoding, decoding);
             decoding += bytes_read;
 
             if (bytes_read == 0)

--- a/fly/coders/base64/base64_coder.hpp
+++ b/fly/coders/base64/base64_coder.hpp
@@ -38,8 +38,8 @@ protected:
     bool decode_internal(std::istream &encoded, std::ostream &decoded) override;
 
 private:
-    static constexpr const std::size_t s_decoded_chunk_size = 3;
-    static constexpr const std::size_t s_encoded_chunk_size = 4;
+    static constexpr std::size_t const s_decoded_chunk_size = 3;
+    static constexpr std::size_t const s_encoded_chunk_size = 4;
 
     std::array<std::ios::char_type, (64 * s_decoded_chunk_size) << 10> m_decoded;
     std::array<std::ios::char_type, (64 * s_encoded_chunk_size) << 10> m_encoded;

--- a/fly/coders/coder.cpp
+++ b/fly/coders/coder.cpp
@@ -12,10 +12,8 @@ namespace fly::coders {
 
 namespace {
 
-    constexpr const std::ios::openmode s_input_mode = std::ios::in | std::ios::binary;
-
-    constexpr const std::ios::openmode s_output_mode =
-        std::ios::out | std::ios::binary | std::ios::trunc;
+    constexpr std::ios::openmode s_input_mode = std::ios::in | std::ios::binary;
+    constexpr std::ios::openmode s_output_mode = std::ios::out | std::ios::binary | std::ios::trunc;
 
     template <typename SizeType>
     void log_encoder_stats(
@@ -23,8 +21,8 @@ namespace {
         SizeType decoded_size,
         SizeType encoded_size)
     {
-        const auto end = std::chrono::steady_clock::now();
-        const auto ratio = (static_cast<double>(decoded_size) - encoded_size) / decoded_size;
+        auto const end = std::chrono::steady_clock::now();
+        auto const ratio = (static_cast<double>(decoded_size) - encoded_size) / decoded_size;
 
         LOGD(
             "Encoded {} bytes to {} bytes ({:.2f}%) in {:.2f} seconds",
@@ -40,7 +38,7 @@ namespace {
         SizeType encoded_size,
         SizeType decoded_size)
     {
-        const auto end = std::chrono::steady_clock::now();
+        auto const end = std::chrono::steady_clock::now();
 
         LOGD(
             "Decoded {} bytes to {} bytes in {:.2f} seconds",
@@ -52,9 +50,9 @@ namespace {
 } // namespace
 
 //==================================================================================================
-bool Encoder::encode_string(const std::string &decoded, std::string &encoded)
+bool Encoder::encode_string(std::string const &decoded, std::string &encoded)
 {
-    const auto start = std::chrono::steady_clock::now();
+    auto const start = std::chrono::steady_clock::now();
     bool successful = false;
 
     std::istringstream input(decoded, s_input_mode);
@@ -76,10 +74,10 @@ bool Encoder::encode_string(const std::string &decoded, std::string &encoded)
 
 //==================================================================================================
 bool Encoder::encode_file(
-    const std::filesystem::path &decoded,
-    const std::filesystem::path &encoded)
+    std::filesystem::path const &decoded,
+    std::filesystem::path const &encoded)
 {
-    const auto start = std::chrono::steady_clock::now();
+    auto const start = std::chrono::steady_clock::now();
     bool successful = false;
     {
         std::ifstream input(decoded, s_input_mode);
@@ -110,9 +108,9 @@ bool BinaryEncoder::encode_internal(std::istream &decoded, std::ostream &encoded
 }
 
 //==================================================================================================
-bool Decoder::decode_string(const std::string &encoded, std::string &decoded)
+bool Decoder::decode_string(std::string const &encoded, std::string &decoded)
 {
-    const auto start = std::chrono::steady_clock::now();
+    auto const start = std::chrono::steady_clock::now();
     bool successful = false;
 
     std::istringstream input(encoded, s_input_mode);
@@ -134,10 +132,10 @@ bool Decoder::decode_string(const std::string &encoded, std::string &decoded)
 
 //==================================================================================================
 bool Decoder::decode_file(
-    const std::filesystem::path &encoded,
-    const std::filesystem::path &decoded)
+    std::filesystem::path const &encoded,
+    std::filesystem::path const &decoded)
 {
-    const auto start = std::chrono::steady_clock::now();
+    auto const start = std::chrono::steady_clock::now();
     bool successful = false;
     {
         std::ifstream input(encoded, s_input_mode);

--- a/fly/coders/coder.hpp
+++ b/fly/coders/coder.hpp
@@ -35,7 +35,7 @@ public:
      *
      * @return True if the input string was successfully encoded.
      */
-    virtual bool encode_string(const std::string &decoded, std::string &encoded);
+    virtual bool encode_string(std::string const &decoded, std::string &encoded);
 
     /**
      * Encode a file.
@@ -46,7 +46,7 @@ public:
      * @return True if the input file was successfully encoded.
      */
     virtual bool
-    encode_file(const std::filesystem::path &decoded, const std::filesystem::path &encoded);
+    encode_file(std::filesystem::path const &decoded, std::filesystem::path const &encoded);
 
 protected:
     /**
@@ -106,7 +106,7 @@ public:
      *
      * @return True if the input string was successfully decoded.
      */
-    bool decode_string(const std::string &encoded, std::string &decoded);
+    bool decode_string(std::string const &encoded, std::string &decoded);
 
     /**
      * Decode a file.
@@ -116,7 +116,7 @@ public:
      *
      * @return True if the input file was successfully decoded.
      */
-    bool decode_file(const std::filesystem::path &encoded, const std::filesystem::path &decoded);
+    bool decode_file(std::filesystem::path const &encoded, std::filesystem::path const &decoded);
 
 protected:
     /**

--- a/fly/coders/coder_config.cpp
+++ b/fly/coders/coder_config.cpp
@@ -5,7 +5,7 @@ namespace fly::coders {
 //==================================================================================================
 std::uint32_t CoderConfig::huffman_encoder_chunk_size() const
 {
-    const auto encoder_chunk_size_kb =
+    auto const encoder_chunk_size_kb =
         get_value<std::uint16_t>("encoder_chunk_size_kb", m_default_huffman_encoder_chunk_size_kb);
 
     return static_cast<std::uint32_t>(encoder_chunk_size_kb) << 10;

--- a/fly/coders/coder_config.hpp
+++ b/fly/coders/coder_config.hpp
@@ -17,7 +17,7 @@ namespace fly::coders {
 class CoderConfig : public fly::config::Config
 {
 public:
-    static constexpr const char *identifier = "coder";
+    static constexpr char const *identifier = "coder";
 
     /**
      * @return Huffman encoder chunk size (in bytes).

--- a/fly/coders/huffman/huffman_decoder.cpp
+++ b/fly/coders/huffman/huffman_decoder.cpp
@@ -11,7 +11,9 @@ using namespace fly::literals::numeric_literals;
 namespace fly::coders {
 
 //==================================================================================================
-HuffmanDecoder::HuffmanDecoder() noexcept : m_huffman_codes_size(0), m_max_code_length(0)
+HuffmanDecoder::HuffmanDecoder() noexcept :
+    m_huffman_codes_size(0),
+    m_max_code_length(0)
 {
 }
 
@@ -185,9 +187,9 @@ bool HuffmanDecoder::decode_codes(fly::BitStreamReader &encoded, length_type &ma
             // enough to maintain the right code length.
             if (m_huffman_codes_size != 0)
             {
-                const HuffmanCode &last = m_huffman_codes[m_huffman_codes_size - 1_u16];
+                HuffmanCode const &last = m_huffman_codes[m_huffman_codes_size - 1_u16];
 
-                const length_type shift = length - last.m_length;
+                length_type const shift = length - last.m_length;
                 code = (last.m_code + 1) << shift;
             }
 
@@ -211,12 +213,12 @@ void HuffmanDecoder::convert_to_prefix_table(length_type max_code_length)
 {
     for (std::uint16_t i = 0; i < m_huffman_codes_size; ++i)
     {
-        const HuffmanCode code = std::move(m_huffman_codes[i]);
-        const length_type shift = max_code_length - code.m_length;
+        HuffmanCode const code = std::move(m_huffman_codes[i]);
+        length_type const shift = max_code_length - code.m_length;
 
         for (code_type j = 0; j < (1_u16 << shift); ++j)
         {
-            const code_type index = (code.m_code << shift) + j;
+            code_type const index = (code.m_code << shift) + j;
             m_prefix_table[index].m_symbol = code.m_symbol;
             m_prefix_table[index].m_length = code.m_length;
         }
@@ -235,7 +237,7 @@ bool HuffmanDecoder::decode_symbols(
 
     while ((bytes < chunk_size) && (encoded.peek_bits(prefix, max_code_length) != 0))
     {
-        const HuffmanCode &code = m_prefix_table[prefix];
+        HuffmanCode const &code = m_prefix_table[prefix];
 
         m_chunk_buffer[bytes++] = code.m_symbol;
         encoded.discard_bits(code.m_length);
@@ -244,7 +246,7 @@ bool HuffmanDecoder::decode_symbols(
     if (bytes > 0)
     {
         decoded.write(
-            reinterpret_cast<const std::ios::char_type *>(m_chunk_buffer.get()),
+            reinterpret_cast<std::ios::char_type const *>(m_chunk_buffer.get()),
             static_cast<std::streamsize>(bytes));
     }
 

--- a/fly/coders/huffman/huffman_encoder.hpp
+++ b/fly/coders/huffman/huffman_encoder.hpp
@@ -30,7 +30,7 @@ public:
      *
      * @param config Reference to coder configuration.
      */
-    explicit HuffmanEncoder(const std::shared_ptr<CoderConfig> &config) noexcept;
+    explicit HuffmanEncoder(std::shared_ptr<CoderConfig> const &config) noexcept;
 
 protected:
     /**
@@ -160,8 +160,8 @@ private:
     void encode_symbols(std::uint32_t chunk_size, fly::BitStreamWriter &encoded);
 
     // Configuration.
-    const std::uint32_t m_chunk_size;
-    const length_type m_max_code_length;
+    std::uint32_t const m_chunk_size;
+    length_type const m_max_code_length;
 
     std::unique_ptr<symbol_type[]> m_chunk_buffer;
 

--- a/fly/coders/huffman/types.cpp
+++ b/fly/coders/huffman/types.cpp
@@ -3,7 +3,11 @@
 namespace fly::coders {
 
 //==================================================================================================
-HuffmanNode::HuffmanNode() noexcept : m_symbol(0), m_frequency(0), m_left(nullptr), m_right(nullptr)
+HuffmanNode::HuffmanNode() noexcept :
+    m_symbol(0),
+    m_frequency(0),
+    m_left(nullptr),
+    m_right(nullptr)
 {
 }
 
@@ -40,13 +44,16 @@ void HuffmanNode::become_intermediate(HuffmanNode *left, HuffmanNode *right)
 }
 
 //==================================================================================================
-bool HuffmanNodeComparator::operator()(const HuffmanNode *left, const HuffmanNode *right)
+bool HuffmanNodeComparator::operator()(HuffmanNode const *left, HuffmanNode const *right)
 {
     return left->m_frequency > right->m_frequency;
 }
 
 //==================================================================================================
-HuffmanCode::HuffmanCode() noexcept : m_symbol(0), m_code(0), m_length(0)
+HuffmanCode::HuffmanCode() noexcept :
+    m_symbol(0),
+    m_code(0),
+    m_length(0)
 {
 }
 
@@ -77,7 +84,7 @@ HuffmanCode &HuffmanCode::operator=(HuffmanCode &&code) noexcept
 }
 
 //==================================================================================================
-bool operator<(const HuffmanCode &left, const HuffmanCode &right)
+bool operator<(HuffmanCode const &left, HuffmanCode const &right)
 {
     if (left.m_length == right.m_length)
     {

--- a/fly/coders/huffman/types.hpp
+++ b/fly/coders/huffman/types.hpp
@@ -65,8 +65,8 @@ struct HuffmanNode
     HuffmanNode *m_right;
 
 private:
-    HuffmanNode(const HuffmanNode &) = delete;
-    HuffmanNode &operator=(const HuffmanNode &) = delete;
+    HuffmanNode(HuffmanNode const &) = delete;
+    HuffmanNode &operator=(HuffmanNode const &) = delete;
 };
 
 /**
@@ -78,7 +78,7 @@ private:
  */
 struct HuffmanNodeComparator
 {
-    bool operator()(const HuffmanNode *left, const HuffmanNode *right);
+    bool operator()(HuffmanNode const *left, HuffmanNode const *right);
 };
 
 /**
@@ -127,15 +127,15 @@ struct HuffmanCode
      *
      * @return True if the first Huffman code is less than the second.
      */
-    friend bool operator<(const HuffmanCode &left, const HuffmanCode &right);
+    friend bool operator<(HuffmanCode const &left, HuffmanCode const &right);
 
     symbol_type m_symbol;
     code_type m_code;
     length_type m_length;
 
 private:
-    HuffmanCode(const HuffmanCode &) = delete;
-    HuffmanCode &operator=(const HuffmanCode &) = delete;
+    HuffmanCode(HuffmanCode const &) = delete;
+    HuffmanCode &operator=(HuffmanCode const &) = delete;
 };
 
 } // namespace fly::coders

--- a/fly/config/config.cpp
+++ b/fly/config/config.cpp
@@ -5,7 +5,7 @@
 namespace fly::config {
 
 //==================================================================================================
-void Config::update(const Json &values)
+void Config::update(Json const &values)
 {
     std::unique_lock<std::shared_timed_mutex> lock(m_values_mutex);
     m_values = values;

--- a/fly/config/config.hpp
+++ b/fly/config/config.hpp
@@ -39,12 +39,12 @@ protected:
      * @return The converted value or the default value.
      */
     template <typename T>
-    T get_value(const std::string &name, T def) const;
+    T get_value(std::string const &name, T def) const;
 
     /**
      * Update this configuration with a new set of parsed values.
      */
-    void update(const Json &);
+    void update(Json const &);
 
 private:
     mutable std::shared_timed_mutex m_values_mutex;
@@ -53,7 +53,7 @@ private:
 
 //==================================================================================================
 template <typename T>
-T Config::get_value(const std::string &name, T def) const
+T Config::get_value(std::string const &name, T def) const
 {
     std::shared_lock<std::shared_timed_mutex> lock(m_values_mutex);
 
@@ -61,7 +61,7 @@ T Config::get_value(const std::string &name, T def) const
     {
         return T(m_values[name]);
     }
-    catch (const JsonException &)
+    catch (JsonException const &)
     {
     }
 

--- a/fly/config/config_manager.hpp
+++ b/fly/config/config_manager.hpp
@@ -118,7 +118,7 @@ private:
     std::unique_ptr<fly::parser::Parser> m_parser;
     fly::Json m_values;
 
-    const std::filesystem::path m_path;
+    std::filesystem::path const m_path;
 
     mutable std::mutex m_configs_mutex;
     ConfigMap m_configs;

--- a/fly/logger/detail/file_sink.cpp
+++ b/fly/logger/detail/file_sink.cpp
@@ -69,7 +69,7 @@ bool FileSink::create_log_file()
         }
     }
 
-    const std::string random = fly::String::generate_random_string(10);
+    std::string const random = fly::String::generate_random_string(10);
     std::string time = fly::system::local_time();
 
     fly::String::replace_all(time, ":", '-');

--- a/fly/logger/detail/file_sink.hpp
+++ b/fly/logger/detail/file_sink.hpp
@@ -68,7 +68,7 @@ private:
     std::shared_ptr<fly::logger::LoggerConfig> m_logger_config;
     std::shared_ptr<fly::coders::CoderConfig> m_coder_config;
 
-    const std::filesystem::path m_log_directory;
+    std::filesystem::path const m_log_directory;
     std::filesystem::path m_log_file;
     std::ofstream m_log_stream;
     std::uint32_t m_log_index {0};

--- a/fly/logger/detail/nix/styler_proxy_impl.cpp
+++ b/fly/logger/detail/nix/styler_proxy_impl.cpp
@@ -36,7 +36,7 @@ StylerProxyImpl::~StylerProxyImpl()
 
 //==================================================================================================
 template <>
-void StylerProxyImpl::stream_value<fly::logger::Style>(const fly::logger::Style &modifier)
+void StylerProxyImpl::stream_value<fly::logger::Style>(fly::logger::Style const &modifier)
 {
     // https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters
     switch (modifier)
@@ -67,7 +67,7 @@ void StylerProxyImpl::stream_value<fly::logger::Style>(const fly::logger::Style 
 
 //==================================================================================================
 template <>
-void StylerProxyImpl::stream_value<fly::logger::Color>(const fly::logger::Color &modifier)
+void StylerProxyImpl::stream_value<fly::logger::Color>(fly::logger::Color const &modifier)
 {
     if (modifier.m_color <= fly::logger::Color::White)
     {
@@ -99,7 +99,7 @@ void StylerProxyImpl::stream_value<fly::logger::Color>(const fly::logger::Color 
 
 //==================================================================================================
 template <>
-void StylerProxyImpl::stream_value<fly::logger::Cursor>(const fly::logger::Cursor &modifier)
+void StylerProxyImpl::stream_value<fly::logger::Cursor>(fly::logger::Cursor const &modifier)
 {
     // https://en.wikipedia.org/wiki/ANSI_escape_code#Terminal_output_sequences
     m_stream << "\x1b[" << static_cast<std::uint32_t>(modifier.m_distance);

--- a/fly/logger/detail/nix/styler_proxy_impl.hpp
+++ b/fly/logger/detail/nix/styler_proxy_impl.hpp
@@ -47,7 +47,7 @@ private:
      * @param modifier The modifier to stream.
      */
     template <typename Modifier>
-    void stream_value(const Modifier &modifier);
+    void stream_value(Modifier const &modifier);
 
     /**
      * Manipulate the stream with ANSI escape sequences of the provided styles and colors.

--- a/fly/logger/detail/registry.cpp
+++ b/fly/logger/detail/registry.cpp
@@ -8,7 +8,7 @@ namespace fly::logger::detail {
 
 namespace {
 
-    constexpr const char *s_default_logger_name = "_libfly_default_";
+    constexpr char const *s_default_logger_name = "_libfly_default_";
 
 } // namespace
 
@@ -75,7 +75,7 @@ bool Registry::register_logger(std::shared_ptr<fly::logger::Logger> logger)
 }
 
 //==================================================================================================
-void Registry::unregister_logger(const std::string &name)
+void Registry::unregister_logger(std::string const &name)
 {
     if (name == s_default_logger_name)
     {
@@ -87,7 +87,7 @@ void Registry::unregister_logger(const std::string &name)
 }
 
 //==================================================================================================
-std::shared_ptr<fly::logger::Logger> Registry::get_logger(const std::string &name)
+std::shared_ptr<fly::logger::Logger> Registry::get_logger(std::string const &name)
 {
     std::lock_guard<std::mutex> lock(m_registry_mutex);
 

--- a/fly/logger/detail/registry.hpp
+++ b/fly/logger/detail/registry.hpp
@@ -54,7 +54,7 @@ public:
      *
      * @param name Name of the logger to unregister.
      */
-    void unregister_logger(const std::string &name);
+    void unregister_logger(std::string const &name);
 
     /**
      * Retrieve a logger from the registry. If the logger is not found, or if the logger instance
@@ -64,7 +64,7 @@ public:
      *
      * @return The logger instance, or null.
      */
-    std::shared_ptr<fly::logger::Logger> get_logger(const std::string &name);
+    std::shared_ptr<fly::logger::Logger> get_logger(std::string const &name);
 
 private:
     /**

--- a/fly/logger/detail/styler_proxy.hpp
+++ b/fly/logger/detail/styler_proxy.hpp
@@ -38,7 +38,7 @@ public:
      * @return A reference to the stored stream.
      */
     template <typename T>
-    friend std::ostream &operator<<(const StylerProxy &proxy, const T &value)
+    friend std::ostream &operator<<(StylerProxy const &proxy, T const &value)
     {
         return proxy.m_stream << value;
     }
@@ -46,8 +46,8 @@ public:
 protected:
     std::ostream &m_stream;
 
-    const bool m_stream_is_stdout;
-    const bool m_stream_is_stderr;
+    bool const m_stream_is_stdout;
+    bool const m_stream_is_stderr;
 };
 
 } // namespace fly::logger::detail

--- a/fly/logger/detail/win/styler_proxy_impl.cpp
+++ b/fly/logger/detail/win/styler_proxy_impl.cpp
@@ -55,7 +55,7 @@ StylerProxyImpl::~StylerProxyImpl()
 template <>
 void StylerProxyImpl::apply_value<WORD, fly::logger::Style>(
     WORD &attributes,
-    const fly::logger::Style &modifier)
+    fly::logger::Style const &modifier)
 {
     // https://docs.microsoft.com/en-us/windows/console/console-screen-buffers#character-attributes
     switch (modifier)
@@ -75,7 +75,7 @@ void StylerProxyImpl::apply_value<WORD, fly::logger::Style>(
 template <>
 void StylerProxyImpl::apply_value<WORD, fly::logger::Color>(
     WORD &attributes,
-    const fly::logger::Color &modifier)
+    fly::logger::Color const &modifier)
 {
     // https://docs.microsoft.com/en-us/windows/console/console-screen-buffers#character-attributes
     auto apply_color = [&attributes, &modifier](bool red, bool green, bool blue) {
@@ -126,9 +126,9 @@ void StylerProxyImpl::apply_value<WORD, fly::logger::Color>(
 template <>
 void StylerProxyImpl::apply_value<COORD, fly::logger::Cursor>(
     COORD &attributes,
-    const fly::logger::Cursor &modifier)
+    fly::logger::Cursor const &modifier)
 {
-    const std::uint8_t &distance = modifier.m_distance;
+    std::uint8_t const &distance = modifier.m_distance;
 
     switch (modifier.m_direction)
     {
@@ -149,7 +149,7 @@ void StylerProxyImpl::apply_value<COORD, fly::logger::Cursor>(
 
 //==================================================================================================
 void StylerProxyImpl::apply_styles_and_colors(
-    const CONSOLE_SCREEN_BUFFER_INFO &console_info,
+    CONSOLE_SCREEN_BUFFER_INFO const &console_info,
     std::stack<fly::logger::Style> &&styles,
     std::stack<fly::logger::Color> &&colors)
 {
@@ -171,7 +171,7 @@ void StylerProxyImpl::apply_styles_and_colors(
 
 //==================================================================================================
 void StylerProxyImpl::apply_cursors(
-    const CONSOLE_SCREEN_BUFFER_INFO &console_info,
+    CONSOLE_SCREEN_BUFFER_INFO const &console_info,
     std::stack<fly::logger::Cursor> &&cursors)
 {
     COORD cursor_position = console_info.dwCursorPosition;

--- a/fly/logger/detail/win/styler_proxy_impl.hpp
+++ b/fly/logger/detail/win/styler_proxy_impl.hpp
@@ -51,7 +51,7 @@ private:
      * @param modifier The modifier to apply.
      */
     template <typename Attributes, typename Modifier>
-    void apply_value(Attributes &attributes, const Modifier &modifier);
+    void apply_value(Attributes &attributes, Modifier const &modifier);
 
     /**
      * Apply the provided styles and colors to the stream.
@@ -61,7 +61,7 @@ private:
      * @param colors The list of colors to apply to the stream.
      */
     void apply_styles_and_colors(
-        const CONSOLE_SCREEN_BUFFER_INFO &console_info,
+        CONSOLE_SCREEN_BUFFER_INFO const &console_info,
         std::stack<fly::logger::Style> &&styles,
         std::stack<fly::logger::Color> &&colors);
 
@@ -72,7 +72,7 @@ private:
      * @param cursors The list of cursor positions to apply to the stream.
      */
     void apply_cursors(
-        const CONSOLE_SCREEN_BUFFER_INFO &console_info,
+        CONSOLE_SCREEN_BUFFER_INFO const &console_info,
         std::stack<fly::logger::Cursor> &&cursors);
 
     HANDLE m_handle {INVALID_HANDLE_VALUE};

--- a/fly/logger/log.cpp
+++ b/fly/logger/log.cpp
@@ -4,8 +4,8 @@ namespace fly::logger {
 
 namespace {
 
-    constexpr const char s_record_separator = '\x1e';
-    constexpr const char s_unit_separator = '\x1f';
+    constexpr char const s_record_separator = '\x1e';
+    constexpr char const s_unit_separator = '\x1f';
 
 } // namespace
 
@@ -39,7 +39,7 @@ Log &Log::operator=(Log &&log) noexcept
 }
 
 //==================================================================================================
-std::ostream &operator<<(std::ostream &stream, const Log &log)
+std::ostream &operator<<(std::ostream &stream, Log const &log)
 {
     stream << log.m_index << s_unit_separator;
     stream << static_cast<std::uint8_t>(log.m_level) << s_unit_separator;

--- a/fly/logger/log.hpp
+++ b/fly/logger/log.hpp
@@ -71,7 +71,7 @@ struct Log
      */
     Log &operator=(Log &&log) noexcept;
 
-    friend std::ostream &operator<<(std::ostream &stream, const Log &log);
+    friend std::ostream &operator<<(std::ostream &stream, Log const &log);
 
     std::uintmax_t m_index {0};
     Level m_level {Level::NumLevels};

--- a/fly/logger/logger.cpp
+++ b/fly/logger/logger.cpp
@@ -149,13 +149,13 @@ Logger *Logger::get_default_logger()
 }
 
 //==================================================================================================
-std::shared_ptr<Logger> Logger::get(const std::string &name)
+std::shared_ptr<Logger> Logger::get(std::string const &name)
 {
     return detail::Registry::instance().get_logger(name);
 }
 
 //==================================================================================================
-const std::string &Logger::name() const
+std::string const &Logger::name() const
 {
     return m_name;
 }
@@ -180,7 +180,7 @@ void Logger::log(Level level, Trace &&trace, std::string &&message)
         return;
     }
 
-    const auto now = std::chrono::steady_clock::now();
+    auto const now = std::chrono::steady_clock::now();
 
     if (m_task_runner)
     {
@@ -208,14 +208,14 @@ void Logger::log_to_sink(
     std::string &&message,
     std::chrono::steady_clock::time_point time)
 {
-    const std::chrono::duration<double, std::milli> elapsed = time - m_start_time;
+    std::chrono::duration<double, std::milli> const elapsed = time - m_start_time;
 
     Log log(std::move(trace), std::move(message), m_config->max_message_size());
     log.m_index = m_index++;
     log.m_level = level;
     log.m_time = elapsed.count();
 
-    const bool accepted = m_sink->stream(std::move(log));
+    bool const accepted = m_sink->stream(std::move(log));
     m_last_task_failed.store(!accepted);
 }
 

--- a/fly/logger/logger.hpp
+++ b/fly/logger/logger.hpp
@@ -269,12 +269,12 @@ public:
      *
      * @return The logger instance, or null.
      */
-    static std::shared_ptr<Logger> get(const std::string &name);
+    static std::shared_ptr<Logger> get(std::string const &name);
 
     /**
      * @return This logger's name.
      */
-    const std::string &name() const;
+    std::string const &name() const;
 
     /**
      * Add a debug log point to the logger.
@@ -423,7 +423,7 @@ private:
         std::string &&message,
         std::chrono::steady_clock::time_point time);
 
-    const std::string m_name;
+    std::string const m_name;
 
     std::shared_ptr<LoggerConfig> m_config;
     std::unique_ptr<Sink> m_sink;
@@ -431,7 +431,7 @@ private:
     std::shared_ptr<fly::task::SequencedTaskRunner> m_task_runner;
     std::atomic_bool m_last_task_failed {true};
 
-    const std::chrono::steady_clock::time_point m_start_time;
+    std::chrono::steady_clock::time_point const m_start_time;
     std::uintmax_t m_index {0};
 };
 

--- a/fly/logger/logger_config.hpp
+++ b/fly/logger/logger_config.hpp
@@ -16,7 +16,7 @@ namespace fly::logger {
 class LoggerConfig : public fly::config::Config
 {
 public:
-    static constexpr const char *identifier = "logger";
+    static constexpr char const *identifier = "logger";
 
     /**
      * @return True if log files should be compressed after reaching the max log file size.

--- a/fly/logger/styler.cpp
+++ b/fly/logger/styler.cpp
@@ -10,7 +10,7 @@
 namespace fly::logger {
 
 //==================================================================================================
-detail::StylerProxy &operator<<(std::ostream &stream, const Styler &styler)
+detail::StylerProxy &operator<<(std::ostream &stream, Styler const &styler)
 {
     // The input styler parameter must be const in order to allow inline streaming of Styler
     // instances. Otherwise, this method would require an lvalue reference.

--- a/fly/logger/styler.hpp
+++ b/fly/logger/styler.hpp
@@ -79,8 +79,8 @@ struct Color
     {
     }
 
-    const std::uint8_t m_color;
-    const Plane m_plane;
+    std::uint8_t const m_color;
+    Plane const m_plane;
 };
 
 /**
@@ -111,8 +111,8 @@ struct Cursor
     {
     }
 
-    const Direction m_direction;
-    const std::uint8_t m_distance;
+    Direction const m_direction;
+    std::uint8_t const m_distance;
 };
 
 /**
@@ -206,7 +206,7 @@ public:
      *
      * @return A reference to the created StylerProxy instance.
      */
-    friend detail::StylerProxy &operator<<(std::ostream &stream, const Styler &styler);
+    friend detail::StylerProxy &operator<<(std::ostream &stream, Styler const &styler);
 
 private:
     /**
@@ -262,7 +262,7 @@ inline namespace literals {
         FLY_CONSTEVAL inline fly::logger::Color operator"" _c()
         {
             // Convert to std::uint8_t via numeric literal to ensure the provided color is valid.
-            const std::uint8_t validated_color = operator"" _u8<Literals...>();
+            std::uint8_t const validated_color = operator"" _u8<Literals...>();
             return fly::logger::Color(validated_color);
         }
 

--- a/fly/net/endpoint.hpp
+++ b/fly/net/endpoint.hpp
@@ -40,7 +40,7 @@ public:
      * @param address The IP address to initialize the endpoint with.
      * @param port The port to initialize the endpoint with.
      */
-    constexpr Endpoint(const IPAddressType &address, port_type port) noexcept;
+    constexpr Endpoint(IPAddressType const &address, port_type port) noexcept;
 
     /**
      * Constructor. Create an endpoint from an IP address and port.
@@ -50,10 +50,10 @@ public:
      */
     constexpr Endpoint(IPAddressType &&address, port_type port) noexcept;
 
-    Endpoint(const Endpoint &) = default;
+    Endpoint(Endpoint const &) = default;
     Endpoint(Endpoint &&) = default;
 
-    Endpoint &operator=(const Endpoint &) = default;
+    Endpoint &operator=(Endpoint const &) = default;
     Endpoint &operator=(Endpoint &&) = default;
 
     /**
@@ -81,7 +81,7 @@ public:
     /**
      * @return The endoint's IP address.
      */
-    constexpr const IPAddressType &address() const;
+    constexpr IPAddressType const &address() const;
 
     /**
      * @return The endoint's IP port.
@@ -93,18 +93,18 @@ public:
      * Comparison operators. Apple's Clang does not fully support the three-way comparison operator,
      * so these must be manually defined.
      */
-    constexpr bool operator==(const Endpoint &endpoint) const;
-    constexpr bool operator!=(const Endpoint &endpoint) const;
-    constexpr bool operator<(const Endpoint &endpoint) const;
-    constexpr bool operator<=(const Endpoint &endpoint) const;
-    constexpr bool operator>(const Endpoint &endpoint) const;
-    constexpr bool operator>=(const Endpoint &endpoint) const;
+    constexpr bool operator==(Endpoint const &endpoint) const;
+    constexpr bool operator!=(Endpoint const &endpoint) const;
+    constexpr bool operator<(Endpoint const &endpoint) const;
+    constexpr bool operator<=(Endpoint const &endpoint) const;
+    constexpr bool operator>(Endpoint const &endpoint) const;
+    constexpr bool operator>=(Endpoint const &endpoint) const;
 #else
     /**
      * Three-way-comparison operator. Defaulted to perform the comparison on the underlying IP
      * address and port.
      */
-    auto operator<=>(const Endpoint &) const = default;
+    auto operator<=>(Endpoint const &) const = default;
 #endif
 
 private:
@@ -114,7 +114,7 @@ private:
 
 //==================================================================================================
 template <IPAddress IPAddressType>
-constexpr Endpoint<IPAddressType>::Endpoint(const IPAddressType &address, port_type port) noexcept :
+constexpr Endpoint<IPAddressType>::Endpoint(IPAddressType const &address, port_type port) noexcept :
     m_address(address),
     m_port(port)
 {
@@ -147,11 +147,11 @@ template <IPAddress IPAddressType>
 constexpr std::optional<Endpoint<IPAddressType>>
 Endpoint<IPAddressType>::from_string(std::string_view endpoint)
 {
-    constexpr const auto s_max16 =
+    constexpr auto const s_max16 =
         static_cast<std::size_t>(std::numeric_limits<std::uint16_t>::max());
-    constexpr const auto s_colon = ':';
+    constexpr auto const s_colon = ':';
 
-    const std::size_t separator = endpoint.find_last_of(s_colon);
+    std::size_t const separator = endpoint.find_last_of(s_colon);
 
     if ((separator == std::string_view::npos) || (separator == 0) || (separator == endpoint.size()))
     {
@@ -163,8 +163,8 @@ Endpoint<IPAddressType>::from_string(std::string_view endpoint)
 
     if constexpr (is_ipv6())
     {
-        constexpr const auto s_left_bracket = '[';
-        constexpr const auto s_right_bracket = ']';
+        constexpr auto const s_left_bracket = '[';
+        constexpr auto const s_right_bracket = ']';
 
         if (address_view.starts_with(s_left_bracket) && address_view.ends_with(s_right_bracket))
         {
@@ -191,7 +191,7 @@ Endpoint<IPAddressType>::from_string(std::string_view endpoint)
 
 //==================================================================================================
 template <IPAddress IPAddressType>
-constexpr const IPAddressType &Endpoint<IPAddressType>::address() const
+constexpr IPAddressType const &Endpoint<IPAddressType>::address() const
 {
     return m_address;
 }
@@ -207,21 +207,21 @@ constexpr port_type Endpoint<IPAddressType>::port() const
 
 //==================================================================================================
 template <IPAddress IPAddressType>
-constexpr bool Endpoint<IPAddressType>::operator==(const Endpoint<IPAddressType> &endpoint) const
+constexpr bool Endpoint<IPAddressType>::operator==(Endpoint<IPAddressType> const &endpoint) const
 {
     return (m_address == endpoint.m_address) && (m_port == endpoint.m_port);
 }
 
 //==================================================================================================
 template <IPAddress IPAddressType>
-constexpr bool Endpoint<IPAddressType>::operator!=(const Endpoint<IPAddressType> &endpoint) const
+constexpr bool Endpoint<IPAddressType>::operator!=(Endpoint<IPAddressType> const &endpoint) const
 {
     return !(*this == endpoint);
 }
 
 //==================================================================================================
 template <IPAddress IPAddressType>
-constexpr bool Endpoint<IPAddressType>::operator<(const Endpoint<IPAddressType> &endpoint) const
+constexpr bool Endpoint<IPAddressType>::operator<(Endpoint<IPAddressType> const &endpoint) const
 {
     if (m_address < endpoint.m_address)
     {
@@ -233,21 +233,21 @@ constexpr bool Endpoint<IPAddressType>::operator<(const Endpoint<IPAddressType> 
 
 //==================================================================================================
 template <IPAddress IPAddressType>
-constexpr bool Endpoint<IPAddressType>::operator<=(const Endpoint<IPAddressType> &endpoint) const
+constexpr bool Endpoint<IPAddressType>::operator<=(Endpoint<IPAddressType> const &endpoint) const
 {
     return !(endpoint < *this);
 }
 
 //==================================================================================================
 template <IPAddress IPAddressType>
-constexpr bool Endpoint<IPAddressType>::operator>(const Endpoint<IPAddressType> &endpoint) const
+constexpr bool Endpoint<IPAddressType>::operator>(Endpoint<IPAddressType> const &endpoint) const
 {
     return !(*this <= endpoint);
 }
 
 //==================================================================================================
 template <IPAddress IPAddressType>
-constexpr bool Endpoint<IPAddressType>::operator>=(const Endpoint<IPAddressType> &endpoint) const
+constexpr bool Endpoint<IPAddressType>::operator>=(Endpoint<IPAddressType> const &endpoint) const
 {
     return !(*this < endpoint);
 }
@@ -269,7 +269,7 @@ struct fly::Formatter<fly::net::Endpoint<fly::net::IPv4Address>>
      * @param context The context holding the formatting state.
      */
     template <typename FormatContext>
-    void format(const fly::net::Endpoint<fly::net::IPv4Address> &endpoint, FormatContext &context)
+    void format(fly::net::Endpoint<fly::net::IPv4Address> const &endpoint, FormatContext &context)
     {
         fly::String::format_to(context.out(), "{}:{}", endpoint.address(), endpoint.port());
     }
@@ -288,7 +288,7 @@ struct fly::Formatter<fly::net::Endpoint<fly::net::IPv6Address>>
      * @param context The context holding the formatting state.
      */
     template <typename FormatContext>
-    void format(const fly::net::Endpoint<fly::net::IPv6Address> &endpoint, FormatContext &context)
+    void format(fly::net::Endpoint<fly::net::IPv6Address> const &endpoint, FormatContext &context)
     {
         fly::String::format_to(context.out(), "[{}]:{}", endpoint.address(), endpoint.port());
     }

--- a/fly/net/ipv4_address.hpp
+++ b/fly/net/ipv4_address.hpp
@@ -37,7 +37,7 @@ public:
      *
      * @param address The 4-part array of octets to initialize the IPv4 address from.
      */
-    explicit constexpr IPv4Address(const address_type &address) noexcept;
+    explicit constexpr IPv4Address(address_type const &address) noexcept;
 
     /**
      * Constructor. Create an IPv4 address from a network-order 32-bit value.
@@ -46,10 +46,10 @@ public:
      */
     explicit constexpr IPv4Address(int_type address) noexcept;
 
-    IPv4Address(const IPv4Address &) = default;
+    IPv4Address(IPv4Address const &) = default;
     IPv4Address(IPv4Address &&) = default;
 
-    IPv4Address &operator=(const IPv4Address &) = default;
+    IPv4Address &operator=(IPv4Address const &) = default;
     IPv4Address &operator=(IPv4Address &&) = default;
 
     /**
@@ -95,14 +95,14 @@ public:
      * Three-way-comparison operator. Defaulted to perform the comparison on the network-order IPv4
      * address.
      */
-    auto operator<=>(const IPv4Address &) const = default;
+    auto operator<=>(IPv4Address const &) const = default;
 
 private:
     int_type m_address {0};
 };
 
 //==================================================================================================
-constexpr IPv4Address::IPv4Address(const address_type &address) noexcept
+constexpr IPv4Address::IPv4Address(address_type const &address) noexcept
 {
     m_address |= static_cast<int_type>(address[0]);
     m_address |= static_cast<int_type>(address[1] << 8);
@@ -111,7 +111,8 @@ constexpr IPv4Address::IPv4Address(const address_type &address) noexcept
 }
 
 //==================================================================================================
-constexpr IPv4Address::IPv4Address(int_type address) noexcept : m_address(address)
+constexpr IPv4Address::IPv4Address(int_type address) noexcept :
+    m_address(address)
 {
 }
 
@@ -136,8 +137,8 @@ constexpr IPv4Address IPv4Address::in_addr_loopback()
 //==================================================================================================
 constexpr std::optional<IPv4Address> IPv4Address::from_string(std::string_view address)
 {
-    constexpr const auto s_max32 = static_cast<std::uint64_t>(std::numeric_limits<int_type>::max());
-    constexpr const auto s_decimal = '.';
+    constexpr auto const s_max32 = static_cast<std::uint64_t>(std::numeric_limits<int_type>::max());
+    constexpr auto const s_decimal = '.';
 
     fly::Lexer lexer(std::move(address));
 
@@ -146,7 +147,7 @@ constexpr std::optional<IPv4Address> IPv4Address::from_string(std::string_view a
 
     do
     {
-        if (const auto segment = lexer.consume_number(); segment && (*segment <= s_max32))
+        if (auto const segment = lexer.consume_number(); segment && (*segment <= s_max32))
         {
             parts[index++] = static_cast<int_type>(*segment);
         }
@@ -219,9 +220,9 @@ struct fly::Formatter<fly::net::IPv4Address>
      * @param context The context holding the formatting state.
      */
     template <typename FormatContext>
-    void format(const fly::net::IPv4Address &address, FormatContext &context)
+    void format(fly::net::IPv4Address const &address, FormatContext &context)
     {
-        const auto network_order = address.network_order();
+        auto const network_order = address.network_order();
 
         fly::String::format_to(
             context.out(),

--- a/fly/net/ipv6_address.hpp
+++ b/fly/net/ipv6_address.hpp
@@ -37,7 +37,7 @@ public:
      *
      * @param address The 16-part array of octets to initialize the IPv6 address from.
      */
-    explicit constexpr IPv6Address(const address_type &address) noexcept;
+    explicit constexpr IPv6Address(address_type const &address) noexcept;
 
     /**
      * Constructor. Create an IPv6 address from a 16-part array of octets. The array should be
@@ -53,12 +53,12 @@ public:
      *
      * @param address The 16-part array of octets to initialize the IPv6 address from.
      */
-    explicit constexpr IPv6Address(const address_type::value_type (&address)[16]) noexcept;
+    explicit constexpr IPv6Address(address_type::value_type const (&address)[16]) noexcept;
 
-    IPv6Address(const IPv6Address &) = default;
+    IPv6Address(IPv6Address const &) = default;
     IPv6Address(IPv6Address &&) = default;
 
-    IPv6Address &operator=(const IPv6Address &) = default;
+    IPv6Address &operator=(IPv6Address const &) = default;
     IPv6Address &operator=(IPv6Address &&) = default;
 
     /**
@@ -98,17 +98,17 @@ public:
      * Comparison operators. Apple's Clang does not fully support the three-way comparison operator,
      * so these must be manually defined.
      */
-    constexpr bool operator==(const IPv6Address &address) const;
-    constexpr bool operator!=(const IPv6Address &address) const;
-    constexpr bool operator<(const IPv6Address &address) const;
-    constexpr bool operator<=(const IPv6Address &address) const;
-    constexpr bool operator>(const IPv6Address &address) const;
-    constexpr bool operator>=(const IPv6Address &address) const;
+    constexpr bool operator==(IPv6Address const &address) const;
+    constexpr bool operator!=(IPv6Address const &address) const;
+    constexpr bool operator<(IPv6Address const &address) const;
+    constexpr bool operator<=(IPv6Address const &address) const;
+    constexpr bool operator>(IPv6Address const &address) const;
+    constexpr bool operator>=(IPv6Address const &address) const;
 #else
     /**
      * Three-way-comparison operator. Defaulted to perform the comparison on the IPv6 array data.
      */
-    auto operator<=>(const IPv6Address &) const = default;
+    auto operator<=>(IPv6Address const &) const = default;
 #endif
 
 private:
@@ -117,17 +117,19 @@ private:
 };
 
 //==================================================================================================
-constexpr IPv6Address::IPv6Address(const address_type &address) noexcept : m_address {address}
+constexpr IPv6Address::IPv6Address(address_type const &address) noexcept :
+    m_address {address}
 {
 }
 
 //==================================================================================================
-constexpr IPv6Address::IPv6Address(address_type &&address) noexcept : m_address {std::move(address)}
+constexpr IPv6Address::IPv6Address(address_type &&address) noexcept :
+    m_address {std::move(address)}
 {
 }
 
 //==================================================================================================
-constexpr IPv6Address::IPv6Address(const address_type::value_type (&address)[16]) noexcept
+constexpr IPv6Address::IPv6Address(address_type::value_type const (&address)[16]) noexcept
 {
     std::copy(std::begin(address), std::end(address), m_address.begin());
 }
@@ -151,9 +153,9 @@ constexpr IPv6Address IPv6Address::in_addr_loopback()
 //==================================================================================================
 constexpr std::optional<IPv6Address> IPv6Address::from_string(std::string_view address)
 {
-    constexpr const auto s_max16 =
+    constexpr auto const s_max16 =
         static_cast<std::uint64_t>(std::numeric_limits<std::uint16_t>::max());
-    constexpr const auto s_colon = ':';
+    constexpr auto const s_colon = ':';
 
     fly::Lexer lexer(std::move(address));
     address_type parts {};
@@ -175,7 +177,7 @@ constexpr std::optional<IPv6Address> IPv6Address::from_string(std::string_view a
                 index_after_short_form = index;
             }
         }
-        else if (const auto segment = lexer.consume_hex_number(); segment && (*segment <= s_max16))
+        else if (auto const segment = lexer.consume_hex_number(); segment && (*segment <= s_max16))
         {
             parts[index++] = static_cast<address_type::value_type>((*segment >> 8) & 0xff);
             parts[index++] = static_cast<address_type::value_type>(*segment & 0xff);
@@ -192,8 +194,8 @@ constexpr std::optional<IPv6Address> IPv6Address::from_string(std::string_view a
     }
     else if (index_after_short_form)
     {
-        const auto start = static_cast<std::ptrdiff_t>(s_address_size - index);
-        const auto end = static_cast<std::ptrdiff_t>(*index_after_short_form);
+        auto const start = static_cast<std::ptrdiff_t>(s_address_size - index);
+        auto const end = static_cast<std::ptrdiff_t>(*index_after_short_form);
 
         std::rotate(parts.rbegin(), parts.rbegin() + start, parts.rend() - end);
     }
@@ -210,37 +212,37 @@ constexpr void IPv6Address::copy(address_type::value_type (&address)[16]) const
 #if defined(FLY_MACOS)
 
 //==================================================================================================
-constexpr bool IPv6Address::operator==(const IPv6Address &address) const
+constexpr bool IPv6Address::operator==(IPv6Address const &address) const
 {
     return m_address == address.m_address;
 }
 
 //==================================================================================================
-constexpr bool IPv6Address::operator!=(const IPv6Address &address) const
+constexpr bool IPv6Address::operator!=(IPv6Address const &address) const
 {
     return m_address != address.m_address;
 }
 
 //==================================================================================================
-constexpr bool IPv6Address::operator<(const IPv6Address &address) const
+constexpr bool IPv6Address::operator<(IPv6Address const &address) const
 {
     return m_address < address.m_address;
 }
 
 //==================================================================================================
-constexpr bool IPv6Address::operator<=(const IPv6Address &address) const
+constexpr bool IPv6Address::operator<=(IPv6Address const &address) const
 {
     return m_address <= address.m_address;
 }
 
 //==================================================================================================
-constexpr bool IPv6Address::operator>(const IPv6Address &address) const
+constexpr bool IPv6Address::operator>(IPv6Address const &address) const
 {
     return m_address > address.m_address;
 }
 
 //==================================================================================================
-constexpr bool IPv6Address::operator>=(const IPv6Address &address) const
+constexpr bool IPv6Address::operator>=(IPv6Address const &address) const
 {
     return m_address >= address.m_address;
 }
@@ -262,7 +264,7 @@ struct fly::Formatter<fly::net::IPv6Address>
      * @param context The context holding the formatting state.
      */
     template <typename FormatContext>
-    void format(const fly::net::IPv6Address &address, FormatContext &context)
+    void format(fly::net::IPv6Address const &address, FormatContext &context)
     {
         static constexpr std::size_t s_address_size =
             std::tuple_size_v<fly::net::IPv6Address::address_type>;
@@ -278,7 +280,7 @@ struct fly::Formatter<fly::net::IPv6Address>
 
         for (std::size_t i = 0; i < s_address_size;)
         {
-            const std::uint16_t segment = join_segments(i);
+            std::uint16_t const segment = join_segments(i);
 
             if ((segment == 0) && !used_short_form)
             {

--- a/fly/net/network_config.hpp
+++ b/fly/net/network_config.hpp
@@ -16,7 +16,7 @@ namespace fly::net {
 class NetworkConfig : public fly::config::Config
 {
 public:
-    static constexpr const char *identifier = "network";
+    static constexpr char const *identifier = "network";
 
     /**
      * @return Sleep time for socket polling sequence.

--- a/fly/net/socket/detail/base_socket.cpp
+++ b/fly/net/socket/detail/base_socket.cpp
@@ -34,7 +34,7 @@ BaseSocket<EndpointType>::BaseSocket(
 //==================================================================================================
 template <fly::net::IPEndpoint EndpointType>
 BaseSocket<EndpointType>::BaseSocket(
-    const std::shared_ptr<fly::net::SocketService> &service,
+    std::shared_ptr<fly::net::SocketService> const &service,
     std::shared_ptr<fly::net::NetworkConfig> config,
     socket_type handle) noexcept :
     BaseSocket(std::move(config), handle, fly::net::IOMode::Asynchronous)
@@ -159,7 +159,7 @@ void BaseSocket<EndpointType>::close()
 
 //==================================================================================================
 template <fly::net::IPEndpoint EndpointType>
-bool BaseSocket<EndpointType>::bind(const EndpointType &endpoint, BindMode option) const
+bool BaseSocket<EndpointType>::bind(EndpointType const &endpoint, BindMode option) const
 {
     return fly::net::detail::bind(m_socket_handle, endpoint, option);
 }

--- a/fly/net/socket/detail/base_socket.hpp
+++ b/fly/net/socket/detail/base_socket.hpp
@@ -99,7 +99,7 @@ public:
      *
      * @return True if the binding was successful.
      */
-    bool bind(const EndpointType &endpoint, BindMode mode) const;
+    bool bind(EndpointType const &endpoint, BindMode mode) const;
 
     /**
      * Bind this socket to a local endpoint.
@@ -134,7 +134,7 @@ protected:
      * @param handle Native socket handle opened by the concrete socket type.
      */
     BaseSocket(
-        const std::shared_ptr<fly::net::SocketService> &service,
+        std::shared_ptr<fly::net::SocketService> const &service,
         std::shared_ptr<fly::net::NetworkConfig> config,
         socket_type handle) noexcept;
 
@@ -175,8 +175,8 @@ protected:
     std::size_t packet_size() const;
 
 private:
-    BaseSocket(const BaseSocket &) = delete;
-    BaseSocket &operator=(const BaseSocket &) = delete;
+    BaseSocket(BaseSocket const &) = delete;
+    BaseSocket &operator=(BaseSocket const &) = delete;
 
     std::weak_ptr<fly::net::SocketService> m_weak_socket_service;
 

--- a/fly/net/socket/detail/socket_operations.hpp
+++ b/fly/net/socket/detail/socket_operations.hpp
@@ -105,7 +105,7 @@ std::optional<EndpointType> remote_endpoint(fly::net::socket_type handle);
  * @return True if the operation was successful.
  */
 template <fly::net::IPEndpoint EndpointType>
-bool bind(fly::net::socket_type handle, const EndpointType &endpoint, fly::net::BindMode mode);
+bool bind(fly::net::socket_type handle, EndpointType const &endpoint, fly::net::BindMode mode);
 
 /**
  * Configure a socket to be used to accept incoming connections.
@@ -139,7 +139,7 @@ accept(fly::net::socket_type handle, EndpointType &endpoint, bool &would_block);
  * @return The connection state (disconnected, connecting, or connected).
  */
 template <fly::net::IPEndpoint EndpointType>
-fly::net::ConnectedState connect(fly::net::socket_type handle, const EndpointType &endpoint);
+fly::net::ConnectedState connect(fly::net::socket_type handle, EndpointType const &endpoint);
 
 /**
  * Transmit a message to a connected remote socket.
@@ -166,7 +166,7 @@ std::size_t send(fly::net::socket_type handle, std::string_view message, bool &w
 template <fly::net::IPEndpoint EndpointType>
 std::size_t send_to(
     fly::net::socket_type handle,
-    const EndpointType &endpoint,
+    EndpointType const &endpoint,
     std::string_view message,
     std::size_t packet_size,
     bool &would_block);

--- a/fly/net/socket/listen_socket.cpp
+++ b/fly/net/socket/listen_socket.cpp
@@ -29,7 +29,7 @@ ListenSocket<EndpointType>::ListenSocket(
 //==================================================================================================
 template <IPEndpoint EndpointType>
 ListenSocket<EndpointType>::ListenSocket(
-    const std::shared_ptr<SocketService> &service,
+    std::shared_ptr<SocketService> const &service,
     std::shared_ptr<NetworkConfig> config) noexcept :
     BaseSocket(service, std::move(config), detail::socket<EndpointType, TcpSocket<EndpointType>>())
 {
@@ -47,7 +47,7 @@ ListenSocket<EndpointType>::ListenSocket(ListenSocket &&socket) noexcept :
 //==================================================================================================
 template <IPEndpoint EndpointType>
 auto ListenSocket<EndpointType>::create_socket(
-    const std::shared_ptr<SocketService> &service,
+    std::shared_ptr<SocketService> const &service,
     std::shared_ptr<NetworkConfig> config) -> std::shared_ptr<ListenSocket>
 {
     // ListenSocket's constructor for socket-service-based sockets is private, thus cannot be used
@@ -55,7 +55,7 @@ auto ListenSocket<EndpointType>::create_socket(
     struct ListenSocketImpl final : public ListenSocket
     {
         ListenSocketImpl(
-            const std::shared_ptr<SocketService> &service,
+            std::shared_ptr<SocketService> const &service,
             std::shared_ptr<NetworkConfig> config) noexcept :
             ListenSocket(service, std::move(config))
         {

--- a/fly/net/socket/listen_socket.hpp
+++ b/fly/net/socket/listen_socket.hpp
@@ -113,7 +113,7 @@ private:
      * @return The created socket.
      */
     static std::shared_ptr<ListenSocket> create_socket(
-        const std::shared_ptr<SocketService> &service,
+        std::shared_ptr<SocketService> const &service,
         std::shared_ptr<NetworkConfig> config);
 
     /**
@@ -124,7 +124,7 @@ private:
      * @param config Reference to network configuration.
      */
     ListenSocket(
-        const std::shared_ptr<SocketService> &service,
+        std::shared_ptr<SocketService> const &service,
         std::shared_ptr<NetworkConfig> config) noexcept;
 
     /**

--- a/fly/net/socket/socket_service.cpp
+++ b/fly/net/socket/socket_service.cpp
@@ -48,7 +48,7 @@ SocketService::~SocketService() noexcept
 void SocketService::remove_socket(socket_type handle)
 {
     auto task = [handle](std::shared_ptr<SocketService> self) {
-        auto compare_handles = [handle](const Request &request) {
+        auto compare_handles = [handle](Request const &request) {
             return handle == request.m_handle;
         };
 
@@ -100,22 +100,22 @@ void SocketService::poll()
     std::set<socket_type> writable;
     std::set<socket_type> readable;
 
-    for (const auto &request : m_write_requests)
+    for (auto const &request : m_write_requests)
     {
         writable.insert(request.m_handle);
     }
-    for (const auto &request : m_read_requests)
+    for (auto const &request : m_read_requests)
     {
         readable.insert(request.m_handle);
     }
 
     detail::select(m_config->socket_io_wait_time(), writable, readable);
 
-    auto invoke = [](const std::set<socket_type> &ready, std::vector<Request> &pending) {
+    auto invoke = [](std::set<socket_type> const &ready, std::vector<Request> &pending) {
         for (socket_type handle : ready)
         {
             auto it =
-                std::find_if(pending.begin(), pending.end(), [handle](const Request &request) {
+                std::find_if(pending.begin(), pending.end(), [handle](Request const &request) {
                     return handle == request.m_handle;
                 });
 

--- a/fly/net/socket/socket_service.hpp
+++ b/fly/net/socket/socket_service.hpp
@@ -78,7 +78,7 @@ public:
      * @param callback The callback to invoke when the socket is ready for writing.
      */
     template <Socket SocketType, SocketNotification<SocketType> Callback>
-    void notify_when_writable(const std::shared_ptr<SocketType> &socket, Callback &&callback);
+    void notify_when_writable(std::shared_ptr<SocketType> const &socket, Callback &&callback);
 
     /**
      * Monitor a socket handle for readiness to be read from.
@@ -99,7 +99,7 @@ public:
      * @param callback The callback to invoke when the socket is ready for reading.
      */
     template <Socket SocketType, SocketNotification<SocketType> Callback>
-    void notify_when_readable(const std::shared_ptr<SocketType> &socket, Callback &&callback);
+    void notify_when_readable(std::shared_ptr<SocketType> const &socket, Callback &&callback);
 
 private:
     using Notification = std::function<void()>;
@@ -159,7 +159,7 @@ private:
      * @return The wrapped callback.
      */
     template <Socket SocketType, SocketNotification<SocketType> Callback>
-    Notification wrap_callback(const std::shared_ptr<SocketType> &socket, Callback &&callback);
+    Notification wrap_callback(std::shared_ptr<SocketType> const &socket, Callback &&callback);
 
     /**
      * Check if any sockets are ready for IO. Trigger the callback for all ready sockets. Upon
@@ -185,7 +185,7 @@ std::shared_ptr<SocketType> SocketService::create_socket()
 //==================================================================================================
 template <Socket SocketType, SocketNotification<SocketType> Callback>
 void SocketService::notify_when_writable(
-    const std::shared_ptr<SocketType> &socket,
+    std::shared_ptr<SocketType> const &socket,
     Callback &&callback)
 {
     notify_when_writable(socket->handle(), wrap_callback(socket, std::forward<Callback>(callback)));
@@ -194,7 +194,7 @@ void SocketService::notify_when_writable(
 //==================================================================================================
 template <Socket SocketType, SocketNotification<SocketType> Callback>
 void SocketService::notify_when_readable(
-    const std::shared_ptr<SocketType> &socket,
+    std::shared_ptr<SocketType> const &socket,
     Callback &&callback)
 {
     notify_when_readable(socket->handle(), wrap_callback(socket, std::forward<Callback>(callback)));
@@ -202,7 +202,7 @@ void SocketService::notify_when_readable(
 
 //==================================================================================================
 template <Socket SocketType, SocketNotification<SocketType> Callback>
-auto SocketService::wrap_callback(const std::shared_ptr<SocketType> &socket, Callback &&callback)
+auto SocketService::wrap_callback(std::shared_ptr<SocketType> const &socket, Callback &&callback)
     -> Notification
 {
     // Further wrap the callback in a structure to allow perfect forwarding into the lambda below.

--- a/fly/net/socket/tcp_socket.cpp
+++ b/fly/net/socket/tcp_socket.cpp
@@ -26,7 +26,7 @@ TcpSocket<EndpointType>::TcpSocket(std::shared_ptr<NetworkConfig> config, IOMode
 //==================================================================================================
 template <IPEndpoint EndpointType>
 TcpSocket<EndpointType>::TcpSocket(
-    const std::shared_ptr<SocketService> &service,
+    std::shared_ptr<SocketService> const &service,
     std::shared_ptr<NetworkConfig> config) noexcept :
     BaseSocket(service, std::move(config), detail::socket<EndpointType, TcpSocket<EndpointType>>())
 {
@@ -46,7 +46,7 @@ TcpSocket<EndpointType>::TcpSocket(
 //==================================================================================================
 template <IPEndpoint EndpointType>
 TcpSocket<EndpointType>::TcpSocket(
-    const std::shared_ptr<SocketService> &service,
+    std::shared_ptr<SocketService> const &service,
     std::shared_ptr<NetworkConfig> config,
     socket_type socket_handle) noexcept :
     BaseSocket(service, std::move(config), socket_handle),
@@ -65,7 +65,7 @@ TcpSocket<EndpointType>::TcpSocket(TcpSocket &&socket) noexcept :
 //==================================================================================================
 template <IPEndpoint EndpointType>
 auto TcpSocket<EndpointType>::create_socket(
-    const std::shared_ptr<SocketService> &service,
+    std::shared_ptr<SocketService> const &service,
     std::shared_ptr<NetworkConfig> config) -> std::shared_ptr<TcpSocket>
 {
     // TcpSocket's constructor for socket-service-based sockets is private, thus cannot be used with
@@ -73,7 +73,7 @@ auto TcpSocket<EndpointType>::create_socket(
     struct TcpSocketImpl final : public TcpSocket
     {
         TcpSocketImpl(
-            const std::shared_ptr<SocketService> &service,
+            std::shared_ptr<SocketService> const &service,
             std::shared_ptr<NetworkConfig> config) noexcept :
             TcpSocket(service, std::move(config))
         {
@@ -86,7 +86,7 @@ auto TcpSocket<EndpointType>::create_socket(
 //==================================================================================================
 template <IPEndpoint EndpointType>
 auto TcpSocket<EndpointType>::create_socket(
-    const std::shared_ptr<SocketService> &service,
+    std::shared_ptr<SocketService> const &service,
     std::shared_ptr<NetworkConfig> config,
     socket_type socket_handle) -> std::shared_ptr<TcpSocket>
 {
@@ -95,7 +95,7 @@ auto TcpSocket<EndpointType>::create_socket(
     struct TcpSocketImpl final : public TcpSocket
     {
         TcpSocketImpl(
-            const std::shared_ptr<SocketService> &service,
+            std::shared_ptr<SocketService> const &service,
             std::shared_ptr<NetworkConfig> config,
             socket_type socket_handle) noexcept :
             TcpSocket(service, std::move(config), socket_handle)
@@ -124,9 +124,9 @@ std::optional<EndpointType> TcpSocket<EndpointType>::remote_endpoint() const
 
 //==================================================================================================
 template <IPEndpoint EndpointType>
-ConnectedState TcpSocket<EndpointType>::connect(const EndpointType &endpoint)
+ConnectedState TcpSocket<EndpointType>::connect(EndpointType const &endpoint)
 {
-    const auto state = detail::connect(handle(), endpoint);
+    auto const state = detail::connect(handle(), endpoint);
 
     switch (state)
     {
@@ -163,11 +163,11 @@ ConnectedState TcpSocket<EndpointType>::connect(std::string_view hostname, port_
 //==================================================================================================
 template <IPEndpoint EndpointType>
 ConnectedState
-TcpSocket<EndpointType>::connect_async(const EndpointType &endpoint, ConnectCompletion &&callback)
+TcpSocket<EndpointType>::connect_async(EndpointType const &endpoint, ConnectCompletion &&callback)
 {
     if (auto service = socket_service(); service && callback)
     {
-        const auto state = connect(endpoint);
+        auto const state = connect(endpoint);
 
         if (state == ConnectedState::Connecting)
         {
@@ -277,7 +277,7 @@ template <IPEndpoint EndpointType>
 std::string TcpSocket<EndpointType>::receive()
 {
     bool would_block = false;
-    const std::string received = detail::recv(handle(), packet_size(), would_block);
+    std::string const received = detail::recv(handle(), packet_size(), would_block);
 
     if (received.size() == 0)
     {
@@ -320,7 +320,7 @@ void TcpSocket<EndpointType>::ready_to_send(
 {
     bool would_block = false;
 
-    const std::size_t current_sent = detail::send(handle(), message, would_block);
+    std::size_t const current_sent = detail::send(handle(), message, would_block);
     bytes_sent += current_sent;
 
     if (current_sent == message.size())
@@ -355,7 +355,7 @@ void TcpSocket<EndpointType>::ready_to_receive(ReceiveCompletion &&callback, std
 {
     bool would_block = false;
 
-    const std::string current_received = detail::recv(handle(), packet_size(), would_block);
+    std::string const current_received = detail::recv(handle(), packet_size(), would_block);
     received += current_received;
 
     if (!current_received.empty())

--- a/fly/net/socket/tcp_socket.hpp
+++ b/fly/net/socket/tcp_socket.hpp
@@ -83,7 +83,7 @@ public:
      *
      * @return The connection state (disconnected, connecting, or connected).
      */
-    ConnectedState connect(const EndpointType &endpoint);
+    ConnectedState connect(EndpointType const &endpoint);
 
     /**
      * Connect to a remote socket. If this socket was opened in an asynchronous IO processing mode,
@@ -113,7 +113,7 @@ public:
      *
      * @return The connection state (disconnected, connecting, or connected).
      */
-    ConnectedState connect_async(const EndpointType &endpoint, ConnectCompletion &&callback);
+    ConnectedState connect_async(EndpointType const &endpoint, ConnectCompletion &&callback);
 
     /**
      * Asynchronously connect to a remote socket. May only be used if this socket was created
@@ -219,7 +219,7 @@ private:
      * @return The created socket.
      */
     static std::shared_ptr<TcpSocket> create_socket(
-        const std::shared_ptr<SocketService> &service,
+        std::shared_ptr<SocketService> const &service,
         std::shared_ptr<NetworkConfig> config);
 
     /**
@@ -233,7 +233,7 @@ private:
      * @return The created socket.
      */
     static std::shared_ptr<TcpSocket> create_socket(
-        const std::shared_ptr<SocketService> &service,
+        std::shared_ptr<SocketService> const &service,
         std::shared_ptr<NetworkConfig> config,
         socket_type handle);
 
@@ -245,7 +245,7 @@ private:
      * @param config Reference to network configuration.
      */
     TcpSocket(
-        const std::shared_ptr<SocketService> &service,
+        std::shared_ptr<SocketService> const &service,
         std::shared_ptr<NetworkConfig> config) noexcept;
 
     /**
@@ -267,12 +267,12 @@ private:
      * @param handle Native socket handle opened by the calling listening socket.
      */
     TcpSocket(
-        const std::shared_ptr<SocketService> &service,
+        std::shared_ptr<SocketService> const &service,
         std::shared_ptr<NetworkConfig> config,
         socket_type handle) noexcept;
 
-    TcpSocket(const TcpSocket &) = delete;
-    TcpSocket &operator=(const TcpSocket &) = delete;
+    TcpSocket(TcpSocket const &) = delete;
+    TcpSocket &operator=(TcpSocket const &) = delete;
 
     /**
      * When the socket service indicates the socket is available for writing, attempt to transmit

--- a/fly/net/socket/udp_socket.cpp
+++ b/fly/net/socket/udp_socket.cpp
@@ -26,7 +26,7 @@ UdpSocket<EndpointType>::UdpSocket(std::shared_ptr<NetworkConfig> config, IOMode
 //==================================================================================================
 template <IPEndpoint EndpointType>
 UdpSocket<EndpointType>::UdpSocket(
-    const std::shared_ptr<SocketService> &service,
+    std::shared_ptr<SocketService> const &service,
     std::shared_ptr<NetworkConfig> config) noexcept :
     BaseSocket(service, std::move(config), detail::socket<EndpointType, UdpSocket<EndpointType>>())
 {
@@ -34,14 +34,15 @@ UdpSocket<EndpointType>::UdpSocket(
 
 //==================================================================================================
 template <IPEndpoint EndpointType>
-UdpSocket<EndpointType>::UdpSocket(UdpSocket &&socket) noexcept : BaseSocket(std::move(socket))
+UdpSocket<EndpointType>::UdpSocket(UdpSocket &&socket) noexcept :
+    BaseSocket(std::move(socket))
 {
 }
 
 //==================================================================================================
 template <IPEndpoint EndpointType>
 auto UdpSocket<EndpointType>::create_socket(
-    const std::shared_ptr<SocketService> &service,
+    std::shared_ptr<SocketService> const &service,
     std::shared_ptr<NetworkConfig> config) -> std::shared_ptr<UdpSocket>
 {
     // UdpSocket's constructor for socket-service-based sockets is private, thus cannot be used with
@@ -49,7 +50,7 @@ auto UdpSocket<EndpointType>::create_socket(
     struct UdpSocketImpl final : public UdpSocket
     {
         UdpSocketImpl(
-            const std::shared_ptr<SocketService> &service,
+            std::shared_ptr<SocketService> const &service,
             std::shared_ptr<NetworkConfig> config) noexcept :
             UdpSocket(service, std::move(config))
         {
@@ -68,7 +69,7 @@ UdpSocket<EndpointType> &UdpSocket<EndpointType>::operator=(UdpSocket &&socket) 
 
 //==================================================================================================
 template <IPEndpoint EndpointType>
-size_t UdpSocket<EndpointType>::send(const EndpointType &endpoint, std::string_view message)
+size_t UdpSocket<EndpointType>::send(EndpointType const &endpoint, std::string_view message)
 {
     bool would_block = false;
 
@@ -105,7 +106,7 @@ UdpSocket<EndpointType>::send(std::string_view hostname, port_type port, std::st
 //==================================================================================================
 template <IPEndpoint EndpointType>
 bool UdpSocket<EndpointType>::send_async(
-    const EndpointType &endpoint,
+    EndpointType const &endpoint,
     std::string_view message,
     SendCompletion &&callback)
 {
@@ -150,7 +151,7 @@ std::string UdpSocket<EndpointType>::receive()
     EndpointType endpoint;
     bool would_block = false;
 
-    const std::string received = detail::recv_from(handle(), endpoint, packet_size(), would_block);
+    std::string const received = detail::recv_from(handle(), endpoint, packet_size(), would_block);
 
     if (received.size() == 0)
     {
@@ -186,7 +187,7 @@ bool UdpSocket<EndpointType>::receive_async(ReceiveCompletion &&callback)
 //==================================================================================================
 template <IPEndpoint EndpointType>
 void UdpSocket<EndpointType>::ready_to_send(
-    const EndpointType &endpoint,
+    EndpointType const &endpoint,
     std::string_view message,
     SendCompletion &&callback,
     std::size_t bytes_sent,
@@ -194,7 +195,7 @@ void UdpSocket<EndpointType>::ready_to_send(
 {
     bool would_block = false;
 
-    const std::size_t current_sent =
+    std::size_t const current_sent =
         detail::send_to(handle(), endpoint, message, packet_size(), would_block);
     bytes_sent += current_sent;
 
@@ -236,7 +237,7 @@ void UdpSocket<EndpointType>::ready_to_receive(ReceiveCompletion &&callback, std
     EndpointType endpoint;
     bool would_block = false;
 
-    const std::string current_received =
+    std::string const current_received =
         detail::recv_from(handle(), endpoint, packet_size(), would_block);
     received += current_received;
 

--- a/fly/net/socket/udp_socket.hpp
+++ b/fly/net/socket/udp_socket.hpp
@@ -71,7 +71,7 @@ public:
      *
      * @return The number of bytes transmitted.
      */
-    std::size_t send(const EndpointType &endpoint, std::string_view message);
+    std::size_t send(EndpointType const &endpoint, std::string_view message);
 
     /**
      * Transmit a message to a specific remote endpoint. If an error occurs on the socket, the
@@ -101,7 +101,7 @@ public:
      * @return True if the socket service and the provided callback are valid.
      */
     bool
-    send_async(const EndpointType &endpoint, std::string_view message, SendCompletion &&callback);
+    send_async(EndpointType const &endpoint, std::string_view message, SendCompletion &&callback);
 
     /**
      * Asynchronously transmit a message to a specific remote endpoint. May only be used if this
@@ -163,7 +163,7 @@ private:
      * @return The created socket.
      */
     static std::shared_ptr<UdpSocket> create_socket(
-        const std::shared_ptr<SocketService> &service,
+        std::shared_ptr<SocketService> const &service,
         std::shared_ptr<NetworkConfig> config);
 
     /**
@@ -174,7 +174,7 @@ private:
      * @param config Reference to network configuration.
      */
     UdpSocket(
-        const std::shared_ptr<SocketService> &service,
+        std::shared_ptr<SocketService> const &service,
         std::shared_ptr<NetworkConfig> config) noexcept;
 
     /**
@@ -191,7 +191,7 @@ private:
      * @param total_bytes The total number of bytes expected to be transmitted.
      */
     void ready_to_send(
-        const EndpointType &endpoint,
+        EndpointType const &endpoint,
         std::string_view message,
         SendCompletion &&callback,
         std::size_t bytes_sent,
@@ -209,8 +209,8 @@ private:
      */
     void ready_to_receive(ReceiveCompletion &&callback, std::string received);
 
-    UdpSocket(const UdpSocket &) = delete;
-    UdpSocket &operator=(const UdpSocket &) = delete;
+    UdpSocket(UdpSocket const &) = delete;
+    UdpSocket &operator=(UdpSocket const &) = delete;
 
     using BaseSocket::packet_size;
     using BaseSocket::socket_service;

--- a/fly/parser/ini_parser.cpp
+++ b/fly/parser/ini_parser.cpp
@@ -40,7 +40,7 @@ std::optional<fly::Json> IniParser::parse_internal()
                         auto it = values.insert_or_assign(*std::move(section), json_object_type());
                         current = it.first;
                     }
-                    catch (const JsonException &ex)
+                    catch (JsonException const &ex)
                     {
                         ILOG("{}", ex.what());
                         return std::nullopt;
@@ -67,7 +67,7 @@ std::optional<fly::Json> IniParser::parse_internal()
                             std::move(value->first),
                             std::move(value->second));
                     }
-                    catch (const JsonException &ex)
+                    catch (JsonException const &ex)
                     {
                         ILOG("{}", ex.what());
                         return std::nullopt;
@@ -88,7 +88,7 @@ std::optional<fly::Json> IniParser::parse_internal()
 //==================================================================================================
 bool IniParser::getline(std::string &result)
 {
-    static constexpr const int s_new_line = 0x0a;
+    static constexpr int const s_new_line = 0x0a;
 
     result.clear();
     int ch;
@@ -118,7 +118,7 @@ std::optional<std::string> IniParser::on_section(std::string &section)
 
 //==================================================================================================
 std::optional<std::pair<std::string, std::string>>
-IniParser::on_name_value_pair(const std::string &name_value)
+IniParser::on_name_value_pair(std::string const &name_value)
 {
     static constexpr std::uint32_t s_size = 2;
 

--- a/fly/parser/ini_parser.hpp
+++ b/fly/parser/ini_parser.hpp
@@ -68,7 +68,7 @@ private:
      * @return If successful, the parsed name/value pair. Otherwise, an uninitialized value.
      */
     std::optional<std::pair<std::string, std::string>>
-    on_name_value_pair(const std::string &name_value);
+    on_name_value_pair(std::string const &name_value);
 
     /**
      * If the given string begins and ends with the given character, remove that character from each

--- a/fly/parser/json_parser.cpp
+++ b/fly/parser/json_parser.cpp
@@ -19,7 +19,7 @@ namespace {
 } // namespace
 
 //==================================================================================================
-JsonParser::JsonParser(const Features features) noexcept :
+JsonParser::JsonParser(Features features) noexcept :
     Parser(),
     m_allow_comments(is_feature_enabled(features, Features::AllowComments)),
     m_allow_trailing_comma(is_feature_enabled(features, Features::AllowTrailingComma)),
@@ -36,7 +36,7 @@ std::optional<fly::Json> JsonParser::parse_internal()
     {
         json = parse_json();
     }
-    catch (const JsonException &ex)
+    catch (JsonException const &ex)
     {
         JLOG("{}", ex.what());
         return std::nullopt;
@@ -95,7 +95,7 @@ std::optional<fly::Json> JsonParser::parse_json()
 //==================================================================================================
 std::optional<fly::Json> JsonParser::parse_object()
 {
-    static constexpr const Token s_end_token = Token::CloseBrace;
+    static constexpr Token const s_end_token = Token::CloseBrace;
 
     fly::Json object = fly::json_object_type();
     ParseState state;
@@ -133,7 +133,7 @@ std::optional<fly::Json> JsonParser::parse_object()
 //==================================================================================================
 std::optional<fly::Json> JsonParser::parse_array()
 {
-    static constexpr const Token s_end_token = Token::CloseBracket;
+    static constexpr Token const s_end_token = Token::CloseBracket;
 
     fly::Json array = fly::json_array_type();
     ParseState state;
@@ -170,7 +170,7 @@ JsonParser::ParseState JsonParser::state_for_object_or_array(Token end_token)
         return ParseState::Invalid;
     }
 
-    const Token token = peek<Token>();
+    Token const token = peek<Token>();
 
     if (token == end_token)
     {
@@ -219,7 +219,7 @@ std::optional<fly::json_string_type> JsonParser::parse_quoted_string()
 //==================================================================================================
 std::optional<fly::Json> JsonParser::parse_value()
 {
-    const fly::json_string_type value = consume_value();
+    fly::json_string_type const value = consume_value();
 
     if (value == FLY_JSON_STR("true"))
     {
@@ -271,7 +271,7 @@ JsonParser::ParseState JsonParser::consume_token(Token token)
 {
     consume_whitespace();
 
-    if (const Token parsed = get<Token>(); parsed != token)
+    if (Token const parsed = get<Token>(); parsed != token)
     {
         JLOG("Unexpected character {}, was expecting {}", parsed, token);
         return ParseState::Invalid;
@@ -413,19 +413,19 @@ JsonParser::ParseState JsonParser::consume_comment()
 }
 
 //==================================================================================================
-JsonParser::NumberType JsonParser::validate_number(const fly::json_string_type &value) const
+JsonParser::NumberType JsonParser::validate_number(fly::json_string_type const &value) const
 {
-    const fly::JsonStringType::view_type value_view = value;
+    fly::JsonStringType::view_type const value_view = value;
 
-    const bool is_signed = !value_view.empty() && (value_view[0] == '-');
-    const auto signless = value_view.substr(is_signed ? 1 : 0);
+    bool const is_signed = !value_view.empty() && (value_view[0] == '-');
+    auto const signless = value_view.substr(is_signed ? 1 : 0);
 
     if (signless.empty())
     {
         return NumberType::Invalid;
     }
 
-    const bool is_octal =
+    bool const is_octal =
         (signless.size() > 1) && (signless[0] == '0') && fly::JsonStringType::is_digit(signless[1]);
 
     if (!fly::JsonStringType::is_digit(signless[0]) || is_octal)
@@ -433,9 +433,9 @@ JsonParser::NumberType JsonParser::validate_number(const fly::json_string_type &
         return NumberType::Invalid;
     }
 
-    const fly::json_string_type::size_type d = signless.find('.');
-    const fly::json_string_type::size_type e1 = signless.find('e');
-    const fly::json_string_type::size_type e2 = signless.find('E');
+    fly::json_string_type::size_type const d = signless.find('.');
+    fly::json_string_type::size_type const e1 = signless.find('e');
+    fly::json_string_type::size_type const e2 = signless.find('E');
 
     if (d != fly::json_string_type::npos)
     {

--- a/fly/parser/json_parser.hpp
+++ b/fly/parser/json_parser.hpp
@@ -80,7 +80,7 @@ public:
      *
      * @param features The extra features to allow.
      */
-    explicit JsonParser(const Features features) noexcept;
+    explicit JsonParser(Features features) noexcept;
 
 protected:
     /**
@@ -212,7 +212,7 @@ private:
      *
      * @return The interpreted JSON value type.
      */
-    NumberType validate_number(const fly::json_string_type &value) const;
+    NumberType validate_number(fly::json_string_type const &value) const;
 
     /**
      * Check if a symbol is a whitespace symbol.
@@ -223,9 +223,9 @@ private:
      */
     bool is_whitespace(Token token) const;
 
-    const bool m_allow_comments {false};
-    const bool m_allow_trailing_comma {false};
-    const bool m_allow_any_type {false};
+    bool const m_allow_comments {false};
+    bool const m_allow_trailing_comma {false};
+    bool const m_allow_any_type {false};
 };
 
 /**

--- a/fly/parser/parser.cpp
+++ b/fly/parser/parser.cpp
@@ -7,23 +7,23 @@ namespace fly::parser {
 
 namespace {
 
-    constexpr const std::istream::char_type *s_utf8_byte_order_mark = "\xef\xbb\xbf";
-    constexpr const std::size_t s_utf8_byte_order_mark_size = 3;
+    constexpr std::istream::char_type const *s_utf8_byte_order_mark = "\xef\xbb\xbf";
+    constexpr std::size_t s_utf8_byte_order_mark_size = 3;
 
-    constexpr const std::istream::char_type *s_utf16_be_byte_order_mark = "\xfe\xff";
-    constexpr const std::size_t s_utf16_be_byte_order_mark_size = 2;
+    constexpr std::istream::char_type const *s_utf16_be_byte_order_mark = "\xfe\xff";
+    constexpr std::size_t s_utf16_be_byte_order_mark_size = 2;
 
-    constexpr const std::istream::char_type *s_utf16_le_byte_order_mark = "\xff\xfe";
-    constexpr const std::size_t s_utf16_le_byte_order_mark_size = 2;
+    constexpr std::istream::char_type const *s_utf16_le_byte_order_mark = "\xff\xfe";
+    constexpr std::size_t s_utf16_le_byte_order_mark_size = 2;
 
-    constexpr const std::istream::char_type *s_utf32_be_byte_order_mark = "\x00\x00\xfe\xff";
-    constexpr const std::size_t s_utf32_be_byte_order_mark_size = 4;
+    constexpr std::istream::char_type const *s_utf32_be_byte_order_mark = "\x00\x00\xfe\xff";
+    constexpr std::size_t s_utf32_be_byte_order_mark_size = 4;
 
-    constexpr const std::istream::char_type *s_utf32_le_byte_order_mark = "\xff\xfe\x00\x00";
-    constexpr const std::size_t s_utf32_le_byte_order_mark_size = 4;
+    constexpr std::istream::char_type const *s_utf32_le_byte_order_mark = "\xff\xfe\x00\x00";
+    constexpr std::size_t s_utf32_le_byte_order_mark_size = 4;
 
     template <std::size_t Size>
-    bool check_bom(std::istream &stream, const std::istream::char_type *bom)
+    bool check_bom(std::istream &stream, std::istream::char_type const *bom)
     {
         if (static_cast<std::istream::char_type>(stream.peek()) == bom[0])
         {
@@ -45,7 +45,7 @@ namespace {
 } // namespace
 
 //==================================================================================================
-std::optional<fly::Json> Parser::parse_file(const std::filesystem::path &path)
+std::optional<fly::Json> Parser::parse_file(std::filesystem::path const &path)
 {
     std::ifstream stream(path);
 

--- a/fly/parser/parser.hpp
+++ b/fly/parser/parser.hpp
@@ -53,7 +53,7 @@ public:
      * @return If successful, the parsed values. Otherwise, an uninitialized value.
      */
     template <typename StringType>
-    std::optional<fly::Json> parse_string(const StringType &contents);
+    std::optional<fly::Json> parse_string(StringType const &contents);
 
     /**
      * Parse a file and retrieve the parsed values.
@@ -75,7 +75,7 @@ public:
      *
      * @return If successful, the parsed values. Otherwise, an uninitialized value.
      */
-    std::optional<fly::Json> parse_file(const std::filesystem::path &path);
+    std::optional<fly::Json> parse_file(std::filesystem::path const &path);
 
 protected:
     /**
@@ -181,7 +181,7 @@ private:
 
 //==================================================================================================
 template <typename StringType>
-std::optional<fly::Json> Parser::parse_string(const StringType &contents)
+std::optional<fly::Json> Parser::parse_string(StringType const &contents)
 {
     using char_type = typename StringType::value_type;
 
@@ -203,7 +203,7 @@ std::optional<std::string> Parser::ensure_utf8(std::istream &stream) const
 {
     using char_type = typename StringType::value_type;
 
-    static constexpr const std::uint8_t s_char_size = sizeof(char_type);
+    static constexpr std::uint8_t const s_char_size = sizeof(char_type);
     StringType contents;
 
     while (stream)
@@ -212,7 +212,7 @@ std::optional<std::string> Parser::ensure_utf8(std::istream &stream) const
 
         for (std::uint8_t i = 0; stream && (i < s_char_size); ++i)
         {
-            const std::uint8_t shift = 8 * (s_char_size - i - 1);
+            std::uint8_t const shift = 8 * (s_char_size - i - 1);
             character |= static_cast<char_type>(stream.get() & 0xff) << shift;
         }
 
@@ -241,9 +241,8 @@ inline SymbolType Parser::peek()
 template <typename SymbolType>
 inline SymbolType Parser::get()
 {
-    static constexpr const std::ios::int_type s_new_line = 0x0a;
-
-    const std::ios::int_type symbol = m_stream_buffer->sbumpc();
+    static constexpr std::ios::int_type const s_new_line = 0x0a;
+    std::ios::int_type const symbol = m_stream_buffer->sbumpc();
 
     if (symbol == s_new_line)
     {

--- a/fly/path/mac/path_monitor_impl.hpp
+++ b/fly/path/mac/path_monitor_impl.hpp
@@ -59,7 +59,7 @@ protected:
     void poll(std::chrono::milliseconds timeout) override;
 
     std::unique_ptr<PathMonitor::PathInfo>
-    create_path_info(const std::filesystem::path &path) const override;
+    create_path_info(std::filesystem::path const &path) const override;
 
 private:
     /**
@@ -69,8 +69,8 @@ private:
     struct PathInfoImpl : PathMonitor::PathInfo
     {
         PathInfoImpl(
-            const PathMonitorImpl *path_monitor,
-            const std::filesystem::path &path) noexcept;
+            PathMonitorImpl const *path_monitor,
+            std::filesystem::path const &path) noexcept;
         ~PathInfoImpl() override;
 
         /**
@@ -120,8 +120,8 @@ private:
         void *info,
         std::size_t event_size,
         void *event_paths,
-        const FSEventStreamEventFlags event_flags[],
-        const FSEventStreamEventId event_ids[]);
+        FSEventStreamEventFlags const event_flags[],
+        FSEventStreamEventId const event_ids[]);
 
     /**
      * Convert an FSEventStreamEventFlags event mask to a PathEvent list.
@@ -130,7 +130,7 @@ private:
      *
      * @return A PathEvent list that matches the FSEventStreamEventFlags mask.
      */
-    static std::vector<PathEvent> convert_to_events(const FSEventStreamEventFlags &flags);
+    static std::vector<PathEvent> convert_to_events(FSEventStreamEventFlags const &flags);
 
     /**
      * Handle a single path event received in the FSEventStreamCallback. Find a monitored path that

--- a/fly/path/nix/path_monitor_impl.cpp
+++ b/fly/path/nix/path_monitor_impl.cpp
@@ -14,9 +14,9 @@ namespace fly::path {
 
 namespace {
 
-    const int s_init_flags = IN_NONBLOCK;
+    constexpr int s_init_flags = IN_NONBLOCK;
 
-    const int s_change_flags = IN_CREATE | IN_DELETE | IN_MOVED_TO | IN_MOVED_FROM | IN_MODIFY;
+    constexpr int s_change_flags = IN_CREATE | IN_DELETE | IN_MOVED_TO | IN_MOVED_FROM | IN_MODIFY;
 
 } // namespace
 
@@ -75,7 +75,7 @@ void PathMonitorImpl::poll(std::chrono::milliseconds timeout)
 
 //==================================================================================================
 std::unique_ptr<PathMonitor::PathInfo>
-PathMonitorImpl::create_path_info(const std::filesystem::path &path) const
+PathMonitorImpl::create_path_info(std::filesystem::path const &path) const
 {
     return std::make_unique<PathInfoImpl>(m_monitor_descriptor, path);
 }
@@ -94,7 +94,7 @@ bool PathMonitorImpl::read_events()
     }
     else
     {
-        const inotify_event *event;
+        inotify_event const *event;
 
         for (std::uint8_t *event_data = m_event_data.data();
              event_data < (m_event_data.data() + size);
@@ -113,24 +113,24 @@ bool PathMonitorImpl::read_events()
 }
 
 //==================================================================================================
-void PathMonitorImpl::handle_event(const inotify_event *event) const
+void PathMonitorImpl::handle_event(inotify_event const *event) const
 {
     auto path_it = std::find_if(
         m_path_info.begin(),
         m_path_info.end(),
-        [&event](const PathInfoMap::value_type &value) -> bool {
-            const auto *info = static_cast<PathInfoImpl *>(value.second.get());
+        [&event](PathInfoMap::value_type const &value) -> bool {
+            auto const *info = static_cast<PathInfoImpl *>(value.second.get());
             return info->m_watch_descriptor == event->wd;
         });
 
     if (path_it != m_path_info.end())
     {
-        const auto *info = static_cast<PathInfoImpl *>(path_it->second.get());
+        auto const *info = static_cast<PathInfoImpl *>(path_it->second.get());
         PathEvent path_event = convert_to_event(event->mask);
 
         if (path_event != PathEvent::None)
         {
-            const std::filesystem::path file(event->name);
+            std::filesystem::path const file(event->name);
 
             auto file_it = info->m_file_handlers.find(file);
             PathEventCallback callback = nullptr;
@@ -179,7 +179,7 @@ PathEvent PathMonitorImpl::convert_to_event(std::uint32_t mask) const
 //==================================================================================================
 PathMonitorImpl::PathInfoImpl::PathInfoImpl(
     int monitor_descriptor,
-    const std::filesystem::path &path) noexcept :
+    std::filesystem::path const &path) noexcept :
     PathMonitorImpl::PathInfo(),
     m_monitor_descriptor(monitor_descriptor),
     m_watch_descriptor(-1)

--- a/fly/path/nix/path_monitor_impl.hpp
+++ b/fly/path/nix/path_monitor_impl.hpp
@@ -56,7 +56,7 @@ protected:
     void poll(std::chrono::milliseconds timeout) override;
 
     std::unique_ptr<PathMonitor::PathInfo>
-    create_path_info(const std::filesystem::path &path) const override;
+    create_path_info(std::filesystem::path const &path) const override;
 
 private:
     /**
@@ -65,7 +65,7 @@ private:
      */
     struct PathInfoImpl : PathMonitor::PathInfo
     {
-        PathInfoImpl(int monitor_descriptor, const std::filesystem::path &path) noexcept;
+        PathInfoImpl(int monitor_descriptor, std::filesystem::path const &path) noexcept;
         ~PathInfoImpl() override;
 
         /**
@@ -90,7 +90,7 @@ private:
      *
      * @param event The inotify event to handle.
      */
-    void handle_event(const inotify_event *event) const;
+    void handle_event(inotify_event const *event) const;
 
     /**
      * Convert an inotify event mask to a PathEvent.

--- a/fly/path/path_config.hpp
+++ b/fly/path/path_config.hpp
@@ -15,7 +15,7 @@ namespace fly::path {
 class PathConfig : public fly::config::Config
 {
 public:
-    static constexpr const char *identifier = "path";
+    static constexpr char const *identifier = "path";
 
     /**
      * @return Delay between path monitor poll intervals.

--- a/fly/path/path_monitor.cpp
+++ b/fly/path/path_monitor.cpp
@@ -43,7 +43,7 @@ bool PathMonitor::start()
 }
 
 //==================================================================================================
-bool PathMonitor::add_path(const std::filesystem::path &path, PathEventCallback callback)
+bool PathMonitor::add_path(std::filesystem::path const &path, PathEventCallback callback)
 {
     std::error_code error;
 
@@ -72,7 +72,7 @@ bool PathMonitor::add_path(const std::filesystem::path &path, PathEventCallback 
 }
 
 //==================================================================================================
-bool PathMonitor::remove_path(const std::filesystem::path &path)
+bool PathMonitor::remove_path(std::filesystem::path const &path)
 {
     std::lock_guard<std::mutex> lock(m_mutex);
 
@@ -96,7 +96,7 @@ void PathMonitor::remove_all_paths()
 }
 
 //==================================================================================================
-bool PathMonitor::add_file(const std::filesystem::path &file, PathEventCallback callback)
+bool PathMonitor::add_file(std::filesystem::path const &file, PathEventCallback callback)
 {
     std::error_code error;
 
@@ -129,7 +129,7 @@ bool PathMonitor::add_file(const std::filesystem::path &file, PathEventCallback 
 }
 
 //==================================================================================================
-bool PathMonitor::remove_file(const std::filesystem::path &file)
+bool PathMonitor::remove_file(std::filesystem::path const &file)
 {
     bool prune_path = false;
     {
@@ -161,7 +161,7 @@ bool PathMonitor::remove_file(const std::filesystem::path &file)
 }
 
 //==================================================================================================
-PathMonitor::PathInfo *PathMonitor::get_or_create_path_info(const std::filesystem::path &path)
+PathMonitor::PathInfo *PathMonitor::get_or_create_path_info(std::filesystem::path const &path)
 {
     PathInfo *info = nullptr;
 

--- a/fly/path/path_monitor.hpp
+++ b/fly/path/path_monitor.hpp
@@ -71,7 +71,7 @@ public:
      *
      * @return True if the directory could be added.
      */
-    bool add_path(const std::filesystem::path &path, PathEventCallback callback);
+    bool add_path(std::filesystem::path const &path, PathEventCallback callback);
 
     /**
      * Stop monitoring for changes to all files under a directory.
@@ -80,7 +80,7 @@ public:
      *
      * @return True if the directory was removed.
      */
-    bool remove_path(const std::filesystem::path &path);
+    bool remove_path(std::filesystem::path const &path);
 
     /**
      * Stop monitoring all paths.
@@ -96,7 +96,7 @@ public:
      *
      * @return True if the file could be added.
      */
-    bool add_file(const std::filesystem::path &file, PathEventCallback callback);
+    bool add_file(std::filesystem::path const &file, PathEventCallback callback);
 
     /**
      * Stop monitoring for changes to a single file. If there are no more files monitored in the
@@ -107,7 +107,7 @@ public:
      *
      * @return True if the file was removed.
      */
-    bool remove_file(const std::filesystem::path &file);
+    bool remove_file(std::filesystem::path const &file);
 
 protected:
     /**
@@ -154,7 +154,7 @@ protected:
      *
      * @return Up-casted pointer to the PathInfo struct.
      */
-    virtual std::unique_ptr<PathInfo> create_path_info(const std::filesystem::path &path) const = 0;
+    virtual std::unique_ptr<PathInfo> create_path_info(std::filesystem::path const &path) const = 0;
 
     /**
      * Check if the path monitor implementation is valid.
@@ -189,7 +189,7 @@ private:
      *
      * @return Shared pointer to the PathInfo struct.
      */
-    PathInfo *get_or_create_path_info(const std::filesystem::path &path);
+    PathInfo *get_or_create_path_info(std::filesystem::path const &path);
 
     /**
      * Queue a task to poll monitored paths. When the task is completed, it re-arms itself (if the
@@ -261,7 +261,7 @@ struct fly::Formatter<std::filesystem::path> : public fly::Formatter<std::string
      * @param context The context holding the formatting state.
      */
     template <typename FormatContext>
-    void format(const std::filesystem::path &path, FormatContext &context)
+    void format(std::filesystem::path const &path, FormatContext &context)
     {
         fly::Formatter<std::string>::format(path.string(), context);
     }

--- a/fly/path/win/path_monitor_impl.cpp
+++ b/fly/path/win/path_monitor_impl.cpp
@@ -12,16 +12,16 @@ namespace fly::path {
 
 namespace {
 
-    constexpr const DWORD s_access_flags = FILE_LIST_DIRECTORY;
+    constexpr DWORD s_access_flags = FILE_LIST_DIRECTORY;
 
-    constexpr const DWORD s_share_flags = FILE_SHARE_WRITE | FILE_SHARE_READ | FILE_SHARE_DELETE;
+    constexpr DWORD s_share_flags = FILE_SHARE_WRITE | FILE_SHARE_READ | FILE_SHARE_DELETE;
 
-    constexpr const DWORD s_disposition_flags = OPEN_EXISTING;
+    constexpr DWORD s_disposition_flags = OPEN_EXISTING;
 
-    constexpr const DWORD s_attribute_flags = FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED;
+    constexpr DWORD s_attribute_flags = FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED;
 
-    constexpr const DWORD s_change_flags = FILE_NOTIFY_CHANGE_FILE_NAME |
-        FILE_NOTIFY_CHANGE_DIR_NAME | FILE_NOTIFY_CHANGE_LAST_WRITE | FILE_NOTIFY_CHANGE_CREATION;
+    constexpr DWORD s_change_flags = FILE_NOTIFY_CHANGE_FILE_NAME | FILE_NOTIFY_CHANGE_DIR_NAME |
+        FILE_NOTIFY_CHANGE_LAST_WRITE | FILE_NOTIFY_CHANGE_CREATION;
 
 } // namespace
 
@@ -47,7 +47,7 @@ void PathMonitorImpl::poll(std::chrono::milliseconds timeout)
     {
         std::lock_guard<std::mutex> lock(m_mutex);
 
-        for (const PathInfoMap::value_type &value : m_path_info)
+        for (PathInfoMap::value_type const &value : m_path_info)
         {
             auto *info = static_cast<PathInfoImpl *>(value.second.get());
             DWORD bytes = 0;
@@ -64,7 +64,7 @@ void PathMonitorImpl::poll(std::chrono::milliseconds timeout)
         }
     }
 
-    for (const auto &path_to_remove : paths_to_remove)
+    for (auto const &path_to_remove : paths_to_remove)
     {
         remove_path(path_to_remove);
     }
@@ -74,16 +74,16 @@ void PathMonitorImpl::poll(std::chrono::milliseconds timeout)
 
 //==================================================================================================
 std::unique_ptr<PathMonitor::PathInfo>
-PathMonitorImpl::create_path_info(const std::filesystem::path &path) const
+PathMonitorImpl::create_path_info(std::filesystem::path const &path) const
 {
     return std::make_unique<PathInfoImpl>(path);
 }
 
 //==================================================================================================
-void PathMonitorImpl::handle_events(const PathInfoImpl *info, const std::filesystem::path &path)
+void PathMonitorImpl::handle_events(PathInfoImpl const *info, std::filesystem::path const &path)
     const
 {
-    const FILE_NOTIFY_INFORMATION *file_info = info->m_file_info.data();
+    FILE_NOTIFY_INFORMATION const *file_info = info->m_file_info.data();
 
     while (file_info != nullptr)
     {
@@ -91,11 +91,11 @@ void PathMonitorImpl::handle_events(const PathInfoImpl *info, const std::filesys
 
         if (path_event != PathEvent::None)
         {
-            const std::wstring wide_file(
+            std::wstring const wide_file(
                 file_info->FileName,
                 file_info->FileNameLength / sizeof(wchar_t));
 
-            const std::filesystem::path file(wide_file);
+            std::filesystem::path const file(wide_file);
 
             auto it = info->m_file_handlers.find(file);
             PathEventCallback callback = nullptr;
@@ -124,8 +124,8 @@ void PathMonitorImpl::handle_events(const PathInfoImpl *info, const std::filesys
         }
         else
         {
-            file_info = reinterpret_cast<const FILE_NOTIFY_INFORMATION *>(
-                reinterpret_cast<const BYTE *>(file_info) + file_info->NextEntryOffset);
+            file_info = reinterpret_cast<FILE_NOTIFY_INFORMATION const *>(
+                reinterpret_cast<BYTE const *>(file_info) + file_info->NextEntryOffset);
         }
     }
 }
@@ -159,7 +159,7 @@ PathEvent PathMonitorImpl::convert_to_event(DWORD action) const
 }
 
 //==================================================================================================
-PathMonitorImpl::PathInfoImpl::PathInfoImpl(const std::filesystem::path &path) noexcept
+PathMonitorImpl::PathInfoImpl::PathInfoImpl(std::filesystem::path const &path) noexcept
 {
     m_handle = ::CreateFileW(
         path.wstring().c_str(),
@@ -197,9 +197,9 @@ bool PathMonitorImpl::PathInfoImpl::is_valid() const
 }
 
 //==================================================================================================
-bool PathMonitorImpl::PathInfoImpl::refresh(const std::filesystem::path &path)
+bool PathMonitorImpl::PathInfoImpl::refresh(std::filesystem::path const &path)
 {
-    static const auto s_file_info_size =
+    static auto const s_file_info_size =
         static_cast<DWORD>(m_file_info.size() * sizeof(FILE_NOTIFY_INFORMATION));
 
     BOOL success = ::ReadDirectoryChangesW(

--- a/fly/path/win/path_monitor_impl.hpp
+++ b/fly/path/win/path_monitor_impl.hpp
@@ -48,7 +48,7 @@ protected:
     void poll(std::chrono::milliseconds timeout) override;
 
     std::unique_ptr<PathMonitor::PathInfo>
-    create_path_info(const std::filesystem::path &path) const override;
+    create_path_info(std::filesystem::path const &path) const override;
 
 private:
     /**
@@ -58,7 +58,7 @@ private:
      */
     struct PathInfoImpl : public PathMonitor::PathInfo
     {
-        explicit PathInfoImpl(const std::filesystem::path &path) noexcept;
+        explicit PathInfoImpl(std::filesystem::path const &path) noexcept;
         ~PathInfoImpl() override;
 
         /**
@@ -72,7 +72,7 @@ private:
          *
          * @param path Name of the monitored path.
          */
-        bool refresh(const std::filesystem::path &path);
+        bool refresh(std::filesystem::path const &path);
 
         bool m_valid {false};
         HANDLE m_handle {INVALID_HANDLE_VALUE};
@@ -86,7 +86,7 @@ private:
      * @param info The path's entry in the PathInfo map.
      * @param path Name of the path.
      */
-    void handle_events(const PathInfoImpl *info, const std::filesystem::path &path) const;
+    void handle_events(PathInfoImpl const *info, std::filesystem::path const &path) const;
 
     /**
      * Convert a FILE_NOTIFY_INFORMATION event to a PathEvent.

--- a/fly/system/mac/mach_api.mm
+++ b/fly/system/mac/mach_api.mm
@@ -6,7 +6,7 @@ namespace fly::system::detail {
 
 namespace {
 
-    bool check_kernel_status(const char *caller, const kern_return_t &status)
+    bool check_kernel_status(char const *caller, kern_return_t const &status)
     {
         if (status != KERN_SUCCESS)
         {

--- a/fly/system/mac/system_monitor_impl.mm
+++ b/fly/system/mac/system_monitor_impl.mm
@@ -10,7 +10,7 @@ namespace fly::system {
 
 namespace {
 
-    std::uint64_t time_value_to_microseconds(const time_value_t &time_value)
+    std::uint64_t time_value_to_microseconds(time_value_t const &time_value)
     {
         return (static_cast<std::uint64_t>(time_value.seconds) * 1'000'000) +
             static_cast<std::uint64_t>(time_value.microseconds);
@@ -42,17 +42,17 @@ void SystemMonitorImpl::update_system_cpu_usage()
         return;
     }
 
-    const auto user = static_cast<std::uint64_t>(cpu_load.cpu_ticks[CPU_STATE_USER]);
-    const auto system = static_cast<std::uint64_t>(cpu_load.cpu_ticks[CPU_STATE_SYSTEM]);
-    const auto idle = static_cast<std::uint64_t>(cpu_load.cpu_ticks[CPU_STATE_IDLE]);
-    const auto nice = static_cast<std::uint64_t>(cpu_load.cpu_ticks[CPU_STATE_NICE]);
+    auto const user = static_cast<std::uint64_t>(cpu_load.cpu_ticks[CPU_STATE_USER]);
+    auto const system = static_cast<std::uint64_t>(cpu_load.cpu_ticks[CPU_STATE_SYSTEM]);
+    auto const idle = static_cast<std::uint64_t>(cpu_load.cpu_ticks[CPU_STATE_IDLE]);
+    auto const nice = static_cast<std::uint64_t>(cpu_load.cpu_ticks[CPU_STATE_NICE]);
 
     if ((user >= m_prev_system_user_time) && (system >= m_prev_system_system_time) &&
         (idle >= m_prev_system_idle_time) && (nice >= m_prev_system_nice_time))
     {
-        const std::uint64_t active = (user - m_prev_system_user_time) +
+        std::uint64_t const active = (user - m_prev_system_user_time) +
             (system - m_prev_system_system_time) + (nice - m_prev_system_nice_time);
-        const std::uint64_t total = active + (idle - m_prev_system_idle_time);
+        std::uint64_t const total = active + (idle - m_prev_system_idle_time);
 
         m_system_cpu_usage.store(100.0 * active / total);
     }
@@ -72,16 +72,16 @@ void SystemMonitorImpl::update_process_cpu_usage()
         return;
     }
 
-    const auto now = std::chrono::steady_clock::now();
-    const auto user = time_value_to_microseconds(thread_times.user_time);
-    const auto system = time_value_to_microseconds(thread_times.system_time);
+    auto const now = std::chrono::steady_clock::now();
+    auto const user = time_value_to_microseconds(thread_times.user_time);
+    auto const system = time_value_to_microseconds(thread_times.system_time);
 
     if ((m_prev_process_user_time != 0) && (now > m_prev_time) &&
         (user >= m_prev_process_user_time) && (system >= m_prev_process_system_time))
     {
-        const std::uint64_t cpu =
+        std::uint64_t const cpu =
             (user - m_prev_process_user_time) + (system - m_prev_process_system_time);
-        const auto time = std::chrono::duration_cast<std::chrono::microseconds>(now - m_prev_time);
+        auto const time = std::chrono::duration_cast<std::chrono::microseconds>(now - m_prev_time);
 
         m_process_cpu_usage.store(100.0 * cpu / time.count() / m_system_cpu_count.load());
     }
@@ -112,8 +112,8 @@ void SystemMonitorImpl::update_system_memory_usage()
         return;
     }
 
-    const auto total_memory = static_cast<std::uint64_t>(basic_info.max_mem);
-    const auto free_memory = static_cast<std::uint64_t>(vm_info.free_count) * page_size;
+    auto const total_memory = static_cast<std::uint64_t>(basic_info.max_mem);
+    auto const free_memory = static_cast<std::uint64_t>(vm_info.free_count) * page_size;
 
     m_total_system_memory.store(total_memory);
     m_system_memory_usage.store(total_memory - free_memory);

--- a/fly/system/nix/system_monitor_impl.cpp
+++ b/fly/system/nix/system_monitor_impl.cpp
@@ -16,8 +16,8 @@ namespace fly::system {
 
 namespace {
 
-    const char *s_proc_stat_file = "/proc/stat";
-    const char *s_self_status_file = "/proc/self/status";
+    char const *s_proc_stat_file = "/proc/stat";
+    char const *s_self_status_file = "/proc/self/status";
 
 } // namespace
 
@@ -89,9 +89,9 @@ void SystemMonitorImpl::update_system_cpu_usage()
     if ((user >= m_prev_system_user_time) && (nice >= m_prev_system_nice_time) &&
         (system >= m_prev_system_system_time) && (idle >= m_prev_system_idle_time))
     {
-        const auto active = (user - m_prev_system_user_time) + (nice - m_prev_system_nice_time) +
+        auto const active = (user - m_prev_system_user_time) + (nice - m_prev_system_nice_time) +
             (system - m_prev_system_system_time);
-        const auto total = active + (idle - m_prev_system_idle_time);
+        auto const total = active + (idle - m_prev_system_idle_time);
 
         m_system_cpu_usage.store(100.0 * active / total);
     }
@@ -117,9 +117,9 @@ void SystemMonitorImpl::update_process_cpu_usage()
     if ((now > m_prev_time) && (sample.tms_stime >= m_prev_process_system_time) &&
         (sample.tms_utime >= m_prev_process_user_time))
     {
-        const auto cpu = (sample.tms_stime - m_prev_process_system_time) +
+        auto const cpu = (sample.tms_stime - m_prev_process_system_time) +
             (sample.tms_utime - m_prev_process_user_time);
-        const auto time = now - m_prev_time;
+        auto const time = now - m_prev_time;
 
         m_process_cpu_usage.store(100.0 * cpu / time / m_system_cpu_count.load());
     }
@@ -136,8 +136,8 @@ void SystemMonitorImpl::update_system_memory_usage()
 
     if (::sysinfo(&info) == 0)
     {
-        const auto total_memory = static_cast<std::uint64_t>(info.totalram) * info.mem_unit;
-        const auto free_memory = static_cast<std::uint64_t>(info.freeram) * info.mem_unit;
+        auto const total_memory = static_cast<std::uint64_t>(info.totalram) * info.mem_unit;
+        auto const free_memory = static_cast<std::uint64_t>(info.freeram) * info.mem_unit;
 
         m_total_system_memory.store(total_memory);
         m_system_memory_usage.store(total_memory - free_memory);

--- a/fly/system/system.cpp
+++ b/fly/system/system.cpp
@@ -36,10 +36,10 @@ std::string get_error_string(int code)
 void set_signal_handler(SignalHandler handler)
 {
 #if defined(FLY_WINDOWS)
-    static constexpr const std::array<int, 6>
+    static constexpr std::array<int, 6> const
         s_signals {SIGINT, SIGTERM, SIGILL, SIGFPE, SIGABRT, SIGSEGV};
 #else
-    static constexpr const std::array<int, 8>
+    static constexpr std::array<int, 8> const
         s_signals {SIGINT, SIGTERM, SIGILL, SIGFPE, SIGABRT, SIGSEGV, SIGSYS, SIGBUS};
 #endif
 

--- a/fly/system/system_config.hpp
+++ b/fly/system/system_config.hpp
@@ -15,7 +15,7 @@ namespace fly::system {
 class SystemConfig : public fly::config::Config
 {
 public:
-    static constexpr const char *identifier = "system";
+    static constexpr char const *identifier = "system";
 
     /**
      * @return Delay between system monitor poll intervals.

--- a/fly/system/win/system_impl.cpp
+++ b/fly/system/win/system_impl.cpp
@@ -11,7 +11,7 @@ namespace fly::system {
 void print_backtrace()
 {
     void *trace[10];
-    const USHORT trace_size = ::CaptureStackBackTrace(0, 10, trace, nullptr);
+    USHORT const trace_size = ::CaptureStackBackTrace(0, 10, trace, nullptr);
 
     for (USHORT i = 0; i < trace_size; ++i)
     {

--- a/fly/system/win/system_monitor_impl.cpp
+++ b/fly/system/win/system_monitor_impl.cpp
@@ -12,7 +12,7 @@ namespace fly::system {
 
 namespace {
 
-    const LPCWSTR s_cpu_path = L"\\Processor(_Total)\\% Processor Time";
+    LPCWSTR const s_cpu_path = L"\\Processor(_Total)\\% Processor Time";
 
 } // namespace
 
@@ -109,9 +109,9 @@ void SystemMonitorImpl::update_process_cpu_usage()
         ::memcpy(&system, &fsystem, sizeof(FILETIME));
         ::memcpy(&user, &fuser, sizeof(FILETIME));
 
-        const ULONGLONG cpu = (system.QuadPart - m_prev_process_system_time) +
+        ULONGLONG const cpu = (system.QuadPart - m_prev_process_system_time) +
             (user.QuadPart - m_prev_process_user_time);
-        const ULONGLONG time = now.QuadPart - m_prev_time;
+        ULONGLONG const time = now.QuadPart - m_prev_time;
 
         m_process_cpu_usage.store(100.0 * cpu / time / m_system_cpu_count.load());
 

--- a/fly/task/task_manager.cpp
+++ b/fly/task/task_manager.cpp
@@ -8,7 +8,7 @@ namespace fly::task {
 
 namespace {
 
-    const std::chrono::milliseconds s_delay(10);
+    constexpr std::chrono::milliseconds s_delay(10);
 
 } // namespace
 
@@ -19,7 +19,8 @@ std::shared_ptr<TaskManager> TaskManager::create(std::uint32_t thread_count)
     // is used to expose the private constructor locally.
     struct TaskManagerImpl final : public TaskManager
     {
-        explicit TaskManagerImpl(std::uint32_t thread_count) noexcept : TaskManager(thread_count)
+        explicit TaskManagerImpl(std::uint32_t thread_count) noexcept :
+            TaskManager(thread_count)
         {
         }
     };

--- a/fly/types/bit_stream/bit_stream_reader.cpp
+++ b/fly/types/bit_stream/bit_stream_reader.cpp
@@ -13,7 +13,7 @@ BitStreamReader::BitStreamReader(std::istream &stream) noexcept :
     byte_type magic = 0;
 
     // Cannot use read_byte because the remainder bits are not known yet.
-    const byte_type bytes_read = fill(m_header, detail::s_byte_type_size);
+    byte_type const bytes_read = fill(m_header, detail::s_byte_type_size);
 
     if (bytes_read == 1_u8)
     {
@@ -59,14 +59,14 @@ byte_type BitStreamReader::header() const
 //==================================================================================================
 void BitStreamReader::refill_buffer()
 {
-    const byte_type bits_to_fill = detail::s_most_significant_bit_position - m_position;
+    byte_type const bits_to_fill = detail::s_most_significant_bit_position - m_position;
     buffer_type buffer = 0;
 
-    const byte_type bytes_read = fill(buffer, bits_to_fill / detail::s_bits_per_byte);
+    byte_type const bytes_read = fill(buffer, bits_to_fill / detail::s_bits_per_byte);
 
     if (bytes_read > 0)
     {
-        const byte_type bits_read = bytes_read * detail::s_bits_per_byte;
+        byte_type const bits_read = bytes_read * detail::s_bits_per_byte;
         m_position += bits_read;
 
         // It is undefined behavior to bit-shift by the size of the value being shifted, i.e. when

--- a/fly/types/bit_stream/bit_stream_reader.hpp
+++ b/fly/types/bit_stream/bit_stream_reader.hpp
@@ -150,14 +150,14 @@ byte_type BitStreamReader::read_bits(DataType &bits, byte_type size)
     if constexpr (detail::BitStreamBuffer<DataType>)
     {
         // See peek_bits for why buffer_type reads must be split.
-        const byte_type size_high = size / 2;
-        const byte_type size_low = size - size_high;
+        byte_type const size_high = size / 2;
+        byte_type const size_low = size - size_high;
         std::uint32_t bits_high, bits_low;
 
-        const byte_type bits_read_high = peek_bits(bits_high, size_high);
+        byte_type const bits_read_high = peek_bits(bits_high, size_high);
         discard_bits(bits_read_high);
 
-        const byte_type bits_read_low = peek_bits(bits_low, size_low);
+        byte_type const bits_read_low = peek_bits(bits_low, size_low);
         discard_bits(bits_read_low);
 
         bits = (static_cast<DataType>(bits_high) << size_low) | bits_low;
@@ -165,7 +165,7 @@ byte_type BitStreamReader::read_bits(DataType &bits, byte_type size)
     }
     else
     {
-        const byte_type bits_read = peek_bits(bits, size);
+        byte_type const bits_read = peek_bits(bits, size);
         discard_bits(bits_read);
 
         return bits_read;
@@ -201,7 +201,7 @@ byte_type BitStreamReader::peek_bits(DataType &bits, byte_type size)
     {
         peeked = m_position;
 
-        const DataType buffer = static_cast<DataType>(m_buffer);
+        DataType const buffer = static_cast<DataType>(m_buffer);
         lshift = size - m_position;
 
         // Fill the input bits with the remainder of byte buffer.
@@ -217,8 +217,8 @@ byte_type BitStreamReader::peek_bits(DataType &bits, byte_type size)
         lshift -= size;
     }
 
-    const byte_type rshift = m_position - peeked - size;
-    const DataType buffer = static_cast<DataType>(m_buffer >> rshift);
+    byte_type const rshift = m_position - peeked - size;
+    DataType const buffer = static_cast<DataType>(m_buffer >> rshift);
 
     bits |= (buffer & bit_mask<DataType>(size)) << lshift;
     peeked += size;
@@ -238,7 +238,7 @@ byte_type BitStreamReader::fill(DataType &buffer, byte_type bytes)
 {
     if (m_stream)
     {
-        const std::streamsize bytes_read = m_stream_buffer->sgetn(
+        std::streamsize const bytes_read = m_stream_buffer->sgetn(
             reinterpret_cast<std::ios::char_type *>(&buffer),
             static_cast<std::streamsize>(bytes));
 

--- a/fly/types/bit_stream/bit_stream_writer.cpp
+++ b/fly/types/bit_stream/bit_stream_writer.cpp
@@ -28,17 +28,17 @@ void BitStreamWriter::write_byte(byte_type byte)
 //==================================================================================================
 bool BitStreamWriter::finish()
 {
-    const byte_type bits_in_buffer = detail::s_most_significant_bit_position - m_position;
+    byte_type const bits_in_buffer = detail::s_most_significant_bit_position - m_position;
 
     if (bits_in_buffer > 0)
     {
-        const byte_type bits_to_flush = bits_in_buffer + (m_position % detail::s_bits_per_byte);
+        byte_type const bits_to_flush = bits_in_buffer + (m_position % detail::s_bits_per_byte);
 
         flush(m_buffer, bits_to_flush / detail::s_bits_per_byte);
         m_position = detail::s_most_significant_bit_position;
         m_buffer = 0;
 
-        const byte_type remainder = (bits_to_flush - bits_in_buffer);
+        byte_type const remainder = (bits_to_flush - bits_in_buffer);
         flush_header(remainder);
     }
 
@@ -50,7 +50,7 @@ void BitStreamWriter::flush_header(byte_type remainder)
 {
     m_stream_buffer->pubseekpos(0);
 
-    const byte_type header =
+    byte_type const header =
         (detail::s_magic << detail::s_magic_shift) | (remainder << detail::s_remainder_shift);
     flush(header, detail::s_byte_type_size);
 }

--- a/fly/types/bit_stream/bit_stream_writer.hpp
+++ b/fly/types/bit_stream/bit_stream_writer.hpp
@@ -91,7 +91,7 @@ private:
      * @param bytes The number of bytes to flush.
      */
     template <detail::BitStreamInteger DataType>
-    void flush(const DataType &buffer, byte_type bytes);
+    void flush(DataType const &buffer, byte_type bytes);
 
     std::ostream &m_stream;
 };
@@ -104,7 +104,7 @@ void BitStreamWriter::write_bits(DataType bits, byte_type size)
     // two chunks.
     if (size > m_position)
     {
-        const byte_type rshift = size - m_position;
+        byte_type const rshift = size - m_position;
 
         // Fill the remainder of the byte buffer with as many bits as are available, and flush it
         // onto the stream.
@@ -116,7 +116,7 @@ void BitStreamWriter::write_bits(DataType bits, byte_type size)
         size = rshift;
     }
 
-    const byte_type lshift = m_position - size;
+    byte_type const lshift = m_position - size;
 
     m_buffer |= static_cast<buffer_type>(bits) << lshift;
     m_position = lshift;
@@ -124,14 +124,14 @@ void BitStreamWriter::write_bits(DataType bits, byte_type size)
 
 //==================================================================================================
 template <detail::BitStreamInteger DataType>
-void BitStreamWriter::flush(const DataType &buffer, byte_type bytes)
+void BitStreamWriter::flush(DataType const &buffer, byte_type bytes)
 {
     if (m_stream)
     {
-        const DataType data = endian_swap_if_non_native<std::endian::big>(buffer);
+        DataType const data = endian_swap_if_non_native<std::endian::big>(buffer);
 
         m_stream_buffer->sputn(
-            reinterpret_cast<const std::ios::char_type *>(&data),
+            reinterpret_cast<std::ios::char_type const *>(&data),
             static_cast<std::streamsize>(bytes));
     }
 }

--- a/fly/types/bit_stream/detail/bit_stream.hpp
+++ b/fly/types/bit_stream/detail/bit_stream.hpp
@@ -58,7 +58,7 @@ protected:
      * @return The created mask.
      */
     template <detail::BitStreamInteger DataType>
-    DataType bit_mask(const DataType bits);
+    DataType bit_mask(DataType const bits);
 
     std::streambuf *m_stream_buffer;
 
@@ -68,7 +68,7 @@ protected:
 
 //==================================================================================================
 template <detail::BitStreamInteger DataType>
-inline DataType BitStream::bit_mask(const DataType bits)
+inline DataType BitStream::bit_mask(DataType const bits)
 {
     static constexpr auto s_filled = std::numeric_limits<DataType>::max();
     static constexpr auto s_digits = std::numeric_limits<DataType>::digits;

--- a/fly/types/bit_stream/detail/constants.hpp
+++ b/fly/types/bit_stream/detail/constants.hpp
@@ -6,21 +6,21 @@
 
 namespace fly::detail {
 
-constexpr const byte_type s_magic = 0x1a;
-constexpr const byte_type s_magic_mask = 0x1f;
-constexpr const byte_type s_magic_shift = 0x03;
+constexpr byte_type const s_magic = 0x1a;
+constexpr byte_type const s_magic_mask = 0x1f;
+constexpr byte_type const s_magic_shift = 0x03;
 
 static_assert(s_magic <= s_magic_mask, "Magic header has exceeded 5 bits");
 
-constexpr const byte_type s_remainder_mask = 0x07;
-constexpr const byte_type s_remainder_shift = 0x00;
+constexpr byte_type const s_remainder_mask = 0x07;
+constexpr byte_type const s_remainder_shift = 0x00;
 
-constexpr const byte_type s_byte_type_size = sizeof(byte_type);
-constexpr const byte_type s_buffer_type_size = sizeof(buffer_type);
+constexpr byte_type const s_byte_type_size = sizeof(byte_type);
+constexpr byte_type const s_buffer_type_size = sizeof(buffer_type);
 
-constexpr const byte_type s_bits_per_word = std::numeric_limits<word_type>::digits;
-constexpr const byte_type s_bits_per_byte = std::numeric_limits<byte_type>::digits;
+constexpr byte_type const s_bits_per_word = std::numeric_limits<word_type>::digits;
+constexpr byte_type const s_bits_per_byte = std::numeric_limits<byte_type>::digits;
 
-constexpr const byte_type s_most_significant_bit_position = s_buffer_type_size * s_bits_per_byte;
+constexpr byte_type const s_most_significant_bit_position = s_buffer_type_size * s_bits_per_byte;
 
 } // namespace fly::detail

--- a/fly/types/json/detail/array_util.hpp
+++ b/fly/types/json/detail/array_util.hpp
@@ -15,7 +15,7 @@ namespace fly::detail {
 // std::array
 
 template <typename T, std::size_t N>
-inline std::size_t json_array_size(const std::array<T, N> &array)
+inline std::size_t json_array_size(std::array<T, N> const &array)
 {
     return array.size();
 }
@@ -30,7 +30,7 @@ json_array_append(std::deque<Args...> &array, typename std::deque<Args...>::valu
 }
 
 template <typename... Args>
-inline std::size_t json_array_size(const std::deque<Args...> &array)
+inline std::size_t json_array_size(std::deque<Args...> const &array)
 {
     return array.size();
 }
@@ -44,7 +44,7 @@ inline void json_array_append(
 {
     auto before_end = array.before_begin();
 
-    for (const auto &element : array)
+    for (auto const &element : array)
     {
         FLY_UNUSED(element);
         ++before_end;
@@ -54,11 +54,11 @@ inline void json_array_append(
 }
 
 template <typename... Args>
-inline std::size_t json_array_size(const std::forward_list<Args...> &array)
+inline std::size_t json_array_size(std::forward_list<Args...> const &array)
 {
     std::size_t elements = 0;
 
-    for (const auto &element : array)
+    for (auto const &element : array)
     {
         FLY_UNUSED(element);
         ++elements;
@@ -77,7 +77,7 @@ json_array_append(std::list<Args...> &array, typename std::list<Args...>::value_
 }
 
 template <typename... Args>
-inline std::size_t json_array_size(const std::list<Args...> &array)
+inline std::size_t json_array_size(std::list<Args...> const &array)
 {
     return array.size();
 }
@@ -93,7 +93,7 @@ inline void json_array_append(
 }
 
 template <typename... Args>
-inline std::size_t json_array_size(const std::multiset<Args...> &array)
+inline std::size_t json_array_size(std::multiset<Args...> const &array)
 {
     return array.size();
 }
@@ -108,7 +108,7 @@ json_array_append(std::set<Args...> &array, typename std::set<Args...>::value_ty
 }
 
 template <typename... Args>
-inline std::size_t json_array_size(const std::set<Args...> &array)
+inline std::size_t json_array_size(std::set<Args...> const &array)
 {
     return array.size();
 }
@@ -124,7 +124,7 @@ inline void json_array_append(
 }
 
 template <typename... Args>
-inline std::size_t json_array_size(const std::unordered_multiset<Args...> &array)
+inline std::size_t json_array_size(std::unordered_multiset<Args...> const &array)
 {
     return array.size();
 }
@@ -140,7 +140,7 @@ inline void json_array_append(
 }
 
 template <typename... Args>
-inline std::size_t json_array_size(const std::unordered_set<Args...> &array)
+inline std::size_t json_array_size(std::unordered_set<Args...> const &array)
 {
     return array.size();
 }
@@ -155,7 +155,7 @@ json_array_append(std::vector<Args...> &array, typename std::vector<Args...>::va
 }
 
 template <typename... Args>
-inline std::size_t json_array_size(const std::vector<Args...> &array)
+inline std::size_t json_array_size(std::vector<Args...> const &array)
 {
     return array.size();
 }

--- a/fly/types/json/detail/json_iterator.hpp
+++ b/fly/types/json/detail/json_iterator.hpp
@@ -136,7 +136,7 @@ public:
      *
      * @param iterator The iterator instance to copy.
      */
-    JsonIterator(const NonConstJsonIterator &iterator) noexcept;
+    JsonIterator(NonConstJsonIterator const &iterator) noexcept;
 
     /**
      * Conversion assignment operator. Allows initializing a const or non-const iterator from a
@@ -146,7 +146,7 @@ public:
      *
      * @return A reference to this iterator instance.
      */
-    JsonIterator &operator=(const NonConstJsonIterator &iterator) noexcept;
+    JsonIterator &operator=(NonConstJsonIterator const &iterator) noexcept;
 
     /**
      * Retrieve a reference to the Json instance pointed to by this iterator.
@@ -192,7 +192,7 @@ public:
      * @throws BadJsonComparisonException If the two iterators are not for the same Json instance.
      * @throws NullJsonException If either iterator is empty.
      */
-    bool operator==(const JsonIterator &iterator) const;
+    bool operator==(JsonIterator const &iterator) const;
 
     /**
      * Unequality comparison operator.
@@ -204,7 +204,7 @@ public:
      * @throws BadJsonComparisonException If the two iterators are not for the same Json instance.
      * @throws NullJsonException If either iterator is empty.
      */
-    bool operator!=(const JsonIterator &iterator) const;
+    bool operator!=(JsonIterator const &iterator) const;
 
     /**
      * Less-than comparison operator. Invalid for Json object types.
@@ -217,7 +217,7 @@ public:
      * @throws BadJsonComparisonException If the two iterators are not for the same Json instance.
      * @throws NullJsonException If either iterator is empty.
      */
-    bool operator<(const JsonIterator &iterator) const;
+    bool operator<(JsonIterator const &iterator) const;
 
     /**
      * Less-than-or-equal-to comparison operator. Invalid for Json object types.
@@ -231,7 +231,7 @@ public:
      * @throws BadJsonComparisonException If the two iterators are not for the same Json instance.
      * @throws NullJsonException If either iterator is empty.
      */
-    bool operator<=(const JsonIterator &iterator) const;
+    bool operator<=(JsonIterator const &iterator) const;
 
     /**
      * Greater-than comparison operator. Invalid for Json object types.
@@ -244,7 +244,7 @@ public:
      * @throws BadJsonComparisonException If the two iterators are not for the same Json instance.
      * @throws NullJsonException If either iterator is empty.
      */
-    bool operator>(const JsonIterator &iterator) const;
+    bool operator>(JsonIterator const &iterator) const;
 
     /**
      * Greater-than-or-equal-to comparison operator. Invalid for Json object types.
@@ -258,7 +258,7 @@ public:
      * @throws BadJsonComparisonException If the two iterators are not for the same Json instance.
      * @throws NullJsonException If either iterator is empty.
      */
-    bool operator>=(const JsonIterator &iterator) const;
+    bool operator>=(JsonIterator const &iterator) const;
 
     /**
      * Post-increment operator. Sets the instance pointed to by this iterator to the next instance
@@ -366,7 +366,7 @@ public:
      */
     template <typename J>
     friend JsonIterator<J>
-    operator+(typename JsonIterator<J>::difference_type offset, const JsonIterator<J> &iterator);
+    operator+(typename JsonIterator<J>::difference_type offset, JsonIterator<J> const &iterator);
 
     /**
      * Subtraction operator. Retrieve an iterator pointed at the Json instance some offset earlier
@@ -395,7 +395,7 @@ public:
      * @throws BadJsonComparisonException If the two iterators are not for the same Json instance.
      * @throws NullJsonException If either iterator is empty.
      */
-    difference_type operator-(const JsonIterator &iterator) const;
+    difference_type operator-(JsonIterator const &iterator) const;
 
     /**
      * Retrieve a reference to the key of the Json instance pointed to by this iterator. Only valid
@@ -449,7 +449,7 @@ private:
      * @throws JsonIteratorException If either iterator is empty, or if the two iterators are not
      *         for the same Json instance.
      */
-    void validate_iterator(const JsonIterator &iterator) const;
+    void validate_iterator(JsonIterator const &iterator) const;
 
     /**
      * Verify that the iterator at some offset earlier or later than this iterator does not escape
@@ -464,7 +464,7 @@ private:
      *         the Json instance's valid range.
      */
     template <typename T>
-    void validate_offset(const T &it, difference_type offset) const;
+    void validate_offset(T const &it, difference_type offset) const;
 
     /**
      * Verify that the provided iterator may be dereferenced.
@@ -476,7 +476,7 @@ private:
      * @throws JsonIteratorException If the iterator is empty or past-the-end.
      */
     template <typename T>
-    void validate_dereference(const T &it) const;
+    void validate_dereference(T const &it) const;
 
     pointer m_json {nullptr};
     iterator_type m_iterator;
@@ -484,7 +484,8 @@ private:
 
 //==================================================================================================
 template <fly::SameAs<Json> JsonType>
-JsonIterator<JsonType>::JsonIterator(pointer json, Position position) noexcept(false) : m_json(json)
+JsonIterator<JsonType>::JsonIterator(pointer json, Position position) noexcept(false) :
+    m_json(json)
 {
     auto visitor = [this, &position](auto &value) noexcept(JsonIterable<decltype(value)>) {
         if constexpr (JsonIterable<decltype(value)>)
@@ -513,10 +514,10 @@ JsonIterator<JsonType>::JsonIterator(pointer json, Position position) noexcept(f
 
 //==================================================================================================
 template <fly::SameAs<Json> JsonType>
-JsonIterator<JsonType>::JsonIterator(const NonConstJsonIterator &iterator) noexcept :
+JsonIterator<JsonType>::JsonIterator(NonConstJsonIterator const &iterator) noexcept :
     m_json(iterator.m_json)
 {
-    auto visitor = [this](const auto &it) noexcept {
+    auto visitor = [this](auto const &it) noexcept {
         m_iterator = it;
     };
 
@@ -526,11 +527,11 @@ JsonIterator<JsonType>::JsonIterator(const NonConstJsonIterator &iterator) noexc
 //==================================================================================================
 template <fly::SameAs<Json> JsonType>
 JsonIterator<JsonType> &
-JsonIterator<JsonType>::operator=(const NonConstJsonIterator &iterator) noexcept
+JsonIterator<JsonType>::operator=(NonConstJsonIterator const &iterator) noexcept
 {
     m_json = iterator.m_json;
 
-    auto visitor = [this](const auto &it) noexcept {
+    auto visitor = [this](auto const &it) noexcept {
         m_iterator = it;
     };
 
@@ -544,7 +545,7 @@ auto JsonIterator<JsonType>::operator*() const -> reference
 {
     validate_iterator();
 
-    auto visitor = [this](const auto &it) -> reference {
+    auto visitor = [this](auto const &it) -> reference {
         this->validate_dereference(it);
 
         if constexpr (is_object_iterator<decltype(it)>)
@@ -566,7 +567,7 @@ auto JsonIterator<JsonType>::operator->() const -> pointer
 {
     validate_iterator();
 
-    auto visitor = [this](const auto &it) -> pointer {
+    auto visitor = [this](auto const &it) -> pointer {
         this->validate_dereference(it);
 
         if constexpr (is_object_iterator<decltype(it)>)
@@ -588,7 +589,7 @@ auto JsonIterator<JsonType>::operator[](difference_type offset) const -> referen
 {
     validate_iterator();
 
-    auto visitor = [&](const auto &it) -> reference {
+    auto visitor = [&](auto const &it) -> reference {
         if constexpr (is_array_iterator<decltype(it)>)
         {
             validate_offset(it, offset);
@@ -609,7 +610,7 @@ auto JsonIterator<JsonType>::operator[](difference_type offset) const -> referen
 
 //==================================================================================================
 template <fly::SameAs<Json> JsonType>
-bool JsonIterator<JsonType>::operator==(const JsonIterator &iterator) const
+bool JsonIterator<JsonType>::operator==(JsonIterator const &iterator) const
 {
     validate_iterator(iterator);
     return m_iterator == iterator.m_iterator;
@@ -617,18 +618,18 @@ bool JsonIterator<JsonType>::operator==(const JsonIterator &iterator) const
 
 //==================================================================================================
 template <fly::SameAs<Json> JsonType>
-bool JsonIterator<JsonType>::operator!=(const JsonIterator &iterator) const
+bool JsonIterator<JsonType>::operator!=(JsonIterator const &iterator) const
 {
     return !(*this == iterator);
 }
 
 //==================================================================================================
 template <fly::SameAs<Json> JsonType>
-bool JsonIterator<JsonType>::operator<(const JsonIterator &iterator) const
+bool JsonIterator<JsonType>::operator<(JsonIterator const &iterator) const
 {
     validate_iterator(iterator);
 
-    auto visitor = [this](const auto &it1, const auto &it2) -> bool {
+    auto visitor = [this](auto const &it1, auto const &it2) -> bool {
         if constexpr (is_array_iterator<decltype(it1), decltype(it2)>)
         {
             return it1 < it2;
@@ -644,21 +645,21 @@ bool JsonIterator<JsonType>::operator<(const JsonIterator &iterator) const
 
 //==================================================================================================
 template <fly::SameAs<Json> JsonType>
-bool JsonIterator<JsonType>::operator<=(const JsonIterator &iterator) const
+bool JsonIterator<JsonType>::operator<=(JsonIterator const &iterator) const
 {
     return !(iterator < *this);
 }
 
 //==================================================================================================
 template <fly::SameAs<Json> JsonType>
-bool JsonIterator<JsonType>::operator>(const JsonIterator &iterator) const
+bool JsonIterator<JsonType>::operator>(JsonIterator const &iterator) const
 {
     return !(*this <= iterator);
 }
 
 //==================================================================================================
 template <fly::SameAs<Json> JsonType>
-bool JsonIterator<JsonType>::operator>=(const JsonIterator &iterator) const
+bool JsonIterator<JsonType>::operator>=(JsonIterator const &iterator) const
 {
     return !(*this < iterator);
 }
@@ -758,7 +759,7 @@ auto JsonIterator<JsonType>::operator+(difference_type offset) const -> JsonIter
 template <fly::SameAs<Json> JsonType>
 JsonIterator<JsonType> operator+(
     typename JsonIterator<JsonType>::difference_type offset,
-    const JsonIterator<JsonType> &iterator)
+    JsonIterator<JsonType> const &iterator)
 {
     auto result = iterator;
     result += offset;
@@ -778,11 +779,11 @@ auto JsonIterator<JsonType>::operator-(difference_type offset) const -> JsonIter
 
 //==================================================================================================
 template <fly::SameAs<Json> JsonType>
-auto JsonIterator<JsonType>::operator-(const JsonIterator &iterator) const -> difference_type
+auto JsonIterator<JsonType>::operator-(JsonIterator const &iterator) const -> difference_type
 {
     validate_iterator(iterator);
 
-    auto visitor = [this](const auto &it1, const auto &it2) -> difference_type {
+    auto visitor = [this](auto const &it1, auto const &it2) -> difference_type {
         if constexpr (is_array_iterator<decltype(it1), decltype(it2)>)
         {
             return std::distance(it2, it1);
@@ -802,7 +803,7 @@ const typename json_object_type::key_type &JsonIterator<JsonType>::key() const
 {
     validate_iterator();
 
-    auto visitor = [this](const auto &it) -> const typename json_object_type::key_type & {
+    auto visitor = [this](auto const &it) -> const typename json_object_type::key_type & {
         if constexpr (is_object_iterator<decltype(it)>)
         {
             validate_dereference(it);
@@ -836,7 +837,7 @@ void JsonIterator<JsonType>::validate_iterator() const
 
 //==================================================================================================
 template <fly::SameAs<Json> JsonType>
-void JsonIterator<JsonType>::validate_iterator(const JsonIterator &iterator) const
+void JsonIterator<JsonType>::validate_iterator(JsonIterator const &iterator) const
 {
     validate_iterator();
     iterator.validate_iterator();
@@ -850,19 +851,19 @@ void JsonIterator<JsonType>::validate_iterator(const JsonIterator &iterator) con
 //==================================================================================================
 template <fly::SameAs<Json> JsonType>
 template <typename T>
-void JsonIterator<JsonType>::validate_offset(const T &it, difference_type offset) const
+void JsonIterator<JsonType>::validate_offset(T const &it, difference_type offset) const
 
 {
     difference_type distance = 0;
 
     if (offset >= 0)
     {
-        const JsonIterator end = m_json->end();
+        JsonIterator const end = m_json->end();
         distance = std::distance(it, std::get<T>(end.m_iterator));
     }
     else
     {
-        const JsonIterator begin = m_json->begin();
+        JsonIterator const begin = m_json->begin();
         distance = std::distance(std::get<T>(begin.m_iterator), it);
     }
 
@@ -875,9 +876,9 @@ void JsonIterator<JsonType>::validate_offset(const T &it, difference_type offset
 //==================================================================================================
 template <fly::SameAs<Json> JsonType>
 template <typename T>
-void JsonIterator<JsonType>::validate_dereference(const T &it) const
+void JsonIterator<JsonType>::validate_dereference(T const &it) const
 {
-    const JsonIterator end = m_json->end();
+    JsonIterator const end = m_json->end();
 
     if (it == std::get<T>(end.m_iterator))
     {

--- a/fly/types/json/detail/json_reverse_iterator.hpp
+++ b/fly/types/json/detail/json_reverse_iterator.hpp
@@ -42,14 +42,14 @@ public:
      *
      * @param it The forward iterator to intialize with.
      */
-    explicit JsonReverseIterator(const JsonIterator &it) noexcept;
+    explicit JsonReverseIterator(JsonIterator const &it) noexcept;
 
     /**
      * Constructor to initialize the reverse iterator with an existing reverse iterator.
      *
      * @param it The reverse iterator to intialize with.
      */
-    explicit JsonReverseIterator(const reverse_iterator &it) noexcept;
+    explicit JsonReverseIterator(reverse_iterator const &it) noexcept;
 
     /**
      * Retrieve a reference to the Json instance pointed to by this iterator.
@@ -202,7 +202,7 @@ public:
      * @throws JsonIteratorException If the Json instance is an object.
      * @throws NullJsonException If either iterator is empty.
      */
-    difference_type operator-(const JsonReverseIterator &other) const;
+    difference_type operator-(JsonReverseIterator const &other) const;
 
     /**
      * Retrieve a reference to the key of the Json instance pointed to by this iterator. Only valid
@@ -235,20 +235,21 @@ private:
 
 //==================================================================================================
 template <typename JsonIterator>
-JsonReverseIterator<JsonIterator>::JsonReverseIterator() noexcept : reverse_iterator()
+JsonReverseIterator<JsonIterator>::JsonReverseIterator() noexcept :
+    reverse_iterator()
 {
 }
 
 //==================================================================================================
 template <typename JsonIterator>
-JsonReverseIterator<JsonIterator>::JsonReverseIterator(const JsonIterator &it) noexcept :
+JsonReverseIterator<JsonIterator>::JsonReverseIterator(JsonIterator const &it) noexcept :
     reverse_iterator(it)
 {
 }
 
 //==================================================================================================
 template <typename JsonIterator>
-JsonReverseIterator<JsonIterator>::JsonReverseIterator(const reverse_iterator &it) noexcept :
+JsonReverseIterator<JsonIterator>::JsonReverseIterator(reverse_iterator const &it) noexcept :
     reverse_iterator(it)
 {
 }
@@ -261,7 +262,7 @@ auto JsonReverseIterator<JsonIterator>::operator*() const -> reference
     {
         return reverse_iterator::operator*();
     }
-    catch (const fly::OutOfRangeJsonException &)
+    catch (fly::OutOfRangeJsonException const &)
     {
         throw fly::NullJsonException(json());
     }
@@ -275,7 +276,7 @@ auto JsonReverseIterator<JsonIterator>::operator->() const -> pointer
     {
         return reverse_iterator::operator->();
     }
-    catch (const fly::OutOfRangeJsonException &)
+    catch (fly::OutOfRangeJsonException const &)
     {
         throw fly::NullJsonException(json());
     }
@@ -348,7 +349,7 @@ auto JsonReverseIterator<JsonIterator>::operator-(difference_type offset) const
 
 //==================================================================================================
 template <typename JsonIterator>
-auto JsonReverseIterator<JsonIterator>::operator-(const JsonReverseIterator &other) const
+auto JsonReverseIterator<JsonIterator>::operator-(JsonReverseIterator const &other) const
     -> difference_type
 {
     return reverse_iterator(*this) - reverse_iterator(other);
@@ -363,7 +364,7 @@ const typename json_object_type::key_type &JsonReverseIterator<JsonIterator>::ke
         auto it = --(reverse_iterator::base());
         return it.key();
     }
-    catch (const fly::OutOfRangeJsonException &)
+    catch (fly::OutOfRangeJsonException const &)
     {
         throw fly::NullJsonException(json());
     }
@@ -378,7 +379,7 @@ auto JsonReverseIterator<JsonIterator>::value() const -> reference
         auto it = --(reverse_iterator::base());
         return it.value();
     }
-    catch (const fly::OutOfRangeJsonException &)
+    catch (fly::OutOfRangeJsonException const &)
     {
         throw fly::NullJsonException(json());
     }

--- a/fly/types/json/json.cpp
+++ b/fly/types/json/json.cpp
@@ -10,23 +10,27 @@
 namespace fly {
 
 //==================================================================================================
-Json::Json(json_null_type value) noexcept : m_value(value)
+Json::Json(json_null_type value) noexcept :
+    m_value(value)
 {
 }
 
 //==================================================================================================
-Json::Json(const_reference json) noexcept : m_value(json.m_value)
+Json::Json(const_reference json) noexcept :
+    m_value(json.m_value)
 {
 }
 
 //==================================================================================================
-Json::Json(Json &&json) noexcept : m_value(std::move(json.m_value))
+Json::Json(Json &&json) noexcept :
+    m_value(std::move(json.m_value))
 {
     json.m_value = nullptr;
 }
 
 //==================================================================================================
-Json::Json(std::initializer_list<Json> initializer) noexcept : m_value()
+Json::Json(std::initializer_list<Json> initializer) noexcept :
+    m_value()
 {
     auto object_test = [](const_reference json) {
         return json.is_object_like();
@@ -65,8 +69,8 @@ json_string_type Json::serialize() const
 {
     json_string_type serialized;
 
-    auto serialize_string = [&serialized](const json_string_type &value) {
-        const auto end = value.cend();
+    auto serialize_string = [&serialized](json_string_type const &value) {
+        auto const end = value.cend();
         serialized += FLY_JSON_CHR('"');
 
         for (auto it = value.cbegin(); it != end;)
@@ -77,7 +81,7 @@ json_string_type Json::serialize() const
         serialized += FLY_JSON_CHR('"');
     };
 
-    auto visitor = [&serialized, &serialize_string](const auto &storage) {
+    auto visitor = [&serialized, &serialize_string](auto const &storage) {
         using S = decltype(storage);
 
         if constexpr (JsonNull<S>)
@@ -157,7 +161,7 @@ bool Json::is_object() const
 //==================================================================================================
 bool Json::is_object_like() const
 {
-    const auto *storage = std::get_if<json_array_type>(&m_value);
+    auto const *storage = std::get_if<json_array_type>(&m_value);
 
     return (storage != nullptr) && (storage->size() == 2) && storage->at(0).is_string();
 }
@@ -387,7 +391,7 @@ Json::const_reverse_iterator Json::crend() const
 //==================================================================================================
 bool Json::empty() const
 {
-    auto visitor = [](const auto &storage) -> bool {
+    auto visitor = [](auto const &storage) -> bool {
         using S = decltype(storage);
 
         if constexpr (JsonNull<S>)
@@ -410,7 +414,7 @@ bool Json::empty() const
 //==================================================================================================
 Json::size_type Json::size() const
 {
-    auto visitor = [](const auto &storage) -> size_type {
+    auto visitor = [](auto const &storage) -> size_type {
         using S = decltype(storage);
 
         if constexpr (JsonNull<S>)
@@ -452,7 +456,7 @@ void Json::resize(size_type size)
 //==================================================================================================
 Json::size_type Json::capacity() const
 {
-    auto visitor = [](const auto &storage) -> size_type {
+    auto visitor = [](auto const &storage) -> size_type {
         using S = decltype(storage);
 
         if constexpr (JsonNull<S>)
@@ -540,14 +544,14 @@ void Json::insert(const_iterator first, const_iterator last)
 
     using object_iterator_type = typename const_iterator::object_iterator_type;
 
-    const auto &first_iterator = std::get<object_iterator_type>(first.m_iterator);
-    const auto &last_iterator = std::get<object_iterator_type>(last.m_iterator);
+    auto const &first_iterator = std::get<object_iterator_type>(first.m_iterator);
+    auto const &last_iterator = std::get<object_iterator_type>(last.m_iterator);
 
     object_inserter(first_iterator, last_iterator);
 }
 
 //==================================================================================================
-Json::iterator Json::insert(const_iterator position, const Json &value)
+Json::iterator Json::insert(const_iterator position, Json const &value)
 {
     return array_inserter(position, value);
 }
@@ -559,7 +563,7 @@ Json::iterator Json::insert(const_iterator position, Json &&value)
 }
 
 //==================================================================================================
-Json::iterator Json::insert(const_iterator position, size_type count, const Json &value)
+Json::iterator Json::insert(const_iterator position, size_type count, Json const &value)
 {
     return array_inserter(position, count, value);
 }
@@ -582,8 +586,8 @@ Json::iterator Json::insert(const_iterator position, const_iterator first, const
 
     using array_iterator_type = typename const_iterator::array_iterator_type;
 
-    const auto &first_iterator = std::get<array_iterator_type>(first.m_iterator);
-    const auto &last_iterator = std::get<array_iterator_type>(last.m_iterator);
+    auto const &first_iterator = std::get<array_iterator_type>(first.m_iterator);
+    auto const &last_iterator = std::get<array_iterator_type>(last.m_iterator);
 
     return array_inserter(position, first_iterator, last_iterator);
 }
@@ -595,7 +599,7 @@ Json::iterator Json::insert(const_iterator position, std::initializer_list<Json>
 }
 
 //==================================================================================================
-void Json::push_back(const Json &value)
+void Json::push_back(Json const &value)
 {
     auto &storage = get_or_promote<json_array_type>("JSON type invalid for array insertion");
     storage.push_back(value);
@@ -638,7 +642,7 @@ Json::iterator Json::erase(const_iterator position)
                 throw JsonException("Provided iterator must not be past-the-end");
             }
 
-            const auto &position_iterator = std::get<iterator_type>(position.m_iterator);
+            auto const &position_iterator = std::get<iterator_type>(position.m_iterator);
             it.m_iterator = storage.erase(position_iterator);
 
             return it;
@@ -672,8 +676,8 @@ Json::iterator Json::erase(const_iterator first, const_iterator last)
                 throw JsonException("Provided iterators are for a different Json instance");
             }
 
-            const auto &first_iterator = std::get<iterator_type>(first.m_iterator);
-            const auto &last_iterator = std::get<iterator_type>(last.m_iterator);
+            auto const &first_iterator = std::get<iterator_type>(first.m_iterator);
+            auto const &last_iterator = std::get<iterator_type>(last.m_iterator);
             it.m_iterator = storage.erase(first_iterator, last_iterator);
 
             return it;
@@ -727,7 +731,7 @@ void Json::merge(fly::Json &&other)
 //==================================================================================================
 bool operator==(Json::const_reference json1, Json::const_reference json2)
 {
-    auto visitor = [](const auto &value1, const auto &value2) -> bool {
+    auto visitor = [](auto const &value1, auto const &value2) -> bool {
         using S1 = decltype(value1);
         using S2 = decltype(value2);
 
@@ -736,8 +740,8 @@ bool operator==(Json::const_reference json1, Json::const_reference json2)
         {
             constexpr auto epsilon = std::numeric_limits<json_floating_point_type>::epsilon();
 
-            const auto fvalue1 = static_cast<json_floating_point_type>(value1);
-            const auto fvalue2 = static_cast<json_floating_point_type>(value2);
+            auto const fvalue1 = static_cast<json_floating_point_type>(value1);
+            auto const fvalue2 = static_cast<json_floating_point_type>(value2);
 
             return std::abs(fvalue1 - fvalue2) <= epsilon;
         }
@@ -767,7 +771,7 @@ bool operator!=(Json::const_reference json1, Json::const_reference json2)
 //==================================================================================================
 bool operator<(Json::const_reference json1, Json::const_reference json2)
 {
-    auto visitor = [&json1, &json2](const auto &value1, const auto &value2) -> bool {
+    auto visitor = [&json1, &json2](auto const &value1, auto const &value2) -> bool {
         using S1 = decltype(value1);
         using S2 = decltype(value2);
 
@@ -778,8 +782,8 @@ bool operator<(Json::const_reference json1, Json::const_reference json2)
         else if constexpr (
             (JsonFloatingPoint<S1> && JsonNumber<S2>) || (JsonFloatingPoint<S2> && JsonNumber<S1>))
         {
-            const auto fvalue1 = static_cast<json_floating_point_type>(value1);
-            const auto fvalue2 = static_cast<json_floating_point_type>(value2);
+            auto const fvalue1 = static_cast<json_floating_point_type>(value1);
+            auto const fvalue2 = static_cast<json_floating_point_type>(value2);
 
             return fvalue1 < fvalue2;
         }
@@ -821,14 +825,14 @@ bool operator>=(Json::const_reference json1, Json::const_reference json2)
 //==================================================================================================
 json_string_type Json::validate_string(json_string_type &&value)
 {
-    static constexpr const auto s_null = FLY_JSON_CHR('\0');
-    static constexpr const auto s_space = FLY_JSON_CHR(' ');
-    static constexpr const auto s_quote = FLY_JSON_CHR('"');
-    static constexpr const auto s_reverse_solidus = FLY_JSON_CHR('\\');
+    static constexpr auto const s_null = FLY_JSON_CHR('\0');
+    static constexpr auto const s_space = FLY_JSON_CHR(' ');
+    static constexpr auto const s_quote = FLY_JSON_CHR('"');
+    static constexpr auto const s_reverse_solidus = FLY_JSON_CHR('\\');
 
     for (auto it = value.begin(); it != value.end(); ++it)
     {
-        const auto &ch = *it;
+        auto const &ch = *it;
 
         if (ch == '\\')
         {
@@ -850,7 +854,7 @@ json_string_type Json::validate_string(json_string_type &&value)
 //==================================================================================================
 void Json::read_escaped_character(json_string_type &value, json_string_type::iterator &it)
 {
-    const auto next = it + 1;
+    auto const next = it + 1;
 
     if (next == value.end())
     {
@@ -893,7 +897,7 @@ void Json::read_escaped_character(json_string_type &value, json_string_type::ite
         case 'u':
             if (auto result = JsonStringType::unescape_codepoint(it, value.end()); result)
             {
-                const auto distance = std::distance(it, value.end());
+                auto const distance = std::distance(it, value.end());
 
                 value.replace(next - 1, it, *std::move(result));
                 it = value.end() - distance - 1;
@@ -914,7 +918,7 @@ void Json::read_escaped_character(json_string_type &value, json_string_type::ite
 void Json::write_escaped_character(
     json_string_type &output,
     json_string_type::const_iterator &it,
-    const json_string_type::const_iterator &end)
+    json_string_type::const_iterator const &end)
 {
     switch (*it)
     {

--- a/fly/types/json/json.hpp
+++ b/fly/types/json/json.hpp
@@ -169,11 +169,11 @@ public:
     using difference_type = std::ptrdiff_t;
     using allocator_type = std::allocator<value_type>;
     using reference = value_type &;
-    using const_reference = const value_type &;
+    using const_reference = value_type const &;
     using pointer = typename std::allocator_traits<allocator_type>::pointer;
     using const_pointer = typename std::allocator_traits<allocator_type>::const_pointer;
     using iterator = detail::JsonIterator<Json>;
-    using const_iterator = detail::JsonIterator<const Json>;
+    using const_iterator = detail::JsonIterator<Json const>;
     using reverse_iterator = detail::JsonReverseIterator<iterator>;
     using const_reverse_iterator = detail::JsonReverseIterator<const_iterator>;
 
@@ -919,7 +919,7 @@ public:
      * @throws JsonException If the Json instance is not an object or the key value is invalid.
      */
     template <JsonStringLike Key>
-    std::pair<iterator, bool> insert(Key key, const Json &value);
+    std::pair<iterator, bool> insert(Key key, Json const &value);
 
     /**
      * Insert a moved key-value pair into the Json instance. Only valid if the Json instance is an
@@ -965,7 +965,7 @@ public:
      * @throws JsonException If the Json instance is not an array or the provided position is not
      *         for this Json instance.
      */
-    iterator insert(const_iterator position, const Json &value);
+    iterator insert(const_iterator position, Json const &value);
 
     /**
      * Insert a moved Json value into the Json instance before the provided position. Only valid if
@@ -994,7 +994,7 @@ public:
      * @throws JsonException If the Json instance is not an array or the provided position is not
      *         for this Json instance.
      */
-    iterator insert(const_iterator position, size_type count, const Json &value);
+    iterator insert(const_iterator position, size_type count, Json const &value);
 
     /**
      * Insert all values into the Json instance in the range [first, last) before the provided
@@ -1094,7 +1094,7 @@ public:
      *
      * @throws JsonException If the Json instance is neither an array nor null.
      */
-    void push_back(const Json &value);
+    void push_back(Json const &value);
 
     /**
      * Append a moved Json value to the end of the Json instance. Only valid if the Json instance is
@@ -1486,7 +1486,7 @@ private:
     static void write_escaped_character(
         json_string_type &output,
         json_string_type::const_iterator &it,
-        const json_string_type::const_iterator &end);
+        json_string_type::const_iterator const &end);
 
     /**
      * Helper trait to determine the return type of an object insertion method. If that method
@@ -1546,7 +1546,7 @@ private:
      * @throws JsonException If this Json instance does not hold the provided type.
      */
     template <typename T>
-    T &get(const char *error_message);
+    T &get(char const *error_message);
 
     /**
      * Retrieve a reference to the Json instance's underlying storage if it holds the provided type.
@@ -1562,7 +1562,7 @@ private:
      * @throws JsonException If this Json instance holds neither the provided type nor null.
      */
     template <typename T>
-    T &get_or_promote(const char *error_message);
+    T &get_or_promote(char const *error_message);
 
     /**
      * Retrieve a reference to the Json instance's underlying storage if it holds the provided type.
@@ -1577,20 +1577,22 @@ private:
      * @throws JsonException If this Json instance does not hold the provided type.
      */
     template <typename T>
-    const T &get(const char *error_message) const;
+    T const &get(char const *error_message) const;
 
     json_type m_value {nullptr};
 };
 
 //==================================================================================================
 template <JsonStringLike T>
-Json::Json(T value) noexcept(false) : m_value(convert_to_string(std::move(value)))
+Json::Json(T value) noexcept(false) :
+    m_value(convert_to_string(std::move(value)))
 {
 }
 
 //==================================================================================================
 template <JsonObject T>
-Json::Json(T value) noexcept(false) : m_value(json_object_type())
+Json::Json(T value) noexcept(false) :
+    m_value(json_object_type())
 {
     for (auto &it : value)
     {
@@ -1600,7 +1602,8 @@ Json::Json(T value) noexcept(false) : m_value(json_object_type())
 
 //==================================================================================================
 template <JsonArray T>
-Json::Json(T value) noexcept(false) : m_value(json_array_type())
+Json::Json(T value) noexcept(false) :
+    m_value(json_array_type())
 {
     reserve(detail::json_array_size(value));
 
@@ -1612,25 +1615,29 @@ Json::Json(T value) noexcept(false) : m_value(json_array_type())
 
 //==================================================================================================
 template <JsonBoolean T>
-Json::Json(T value) noexcept : m_value(static_cast<json_boolean_type>(value))
+Json::Json(T value) noexcept :
+    m_value(static_cast<json_boolean_type>(value))
 {
 }
 
 //==================================================================================================
 template <JsonSignedInteger T>
-Json::Json(T value) noexcept : m_value(static_cast<json_signed_integer_type>(value))
+Json::Json(T value) noexcept :
+    m_value(static_cast<json_signed_integer_type>(value))
 {
 }
 
 //==================================================================================================
 template <JsonUnsignedInteger T>
-Json::Json(T value) noexcept : m_value(static_cast<json_unsigned_integer_type>(value))
+Json::Json(T value) noexcept :
+    m_value(static_cast<json_unsigned_integer_type>(value))
 {
 }
 
 //==================================================================================================
 template <JsonFloatingPoint T>
-Json::Json(T value) noexcept : m_value(static_cast<json_floating_point_type>(value))
+Json::Json(T value) noexcept :
+    m_value(static_cast<json_floating_point_type>(value))
 {
 }
 
@@ -1638,7 +1645,7 @@ Json::Json(T value) noexcept : m_value(static_cast<json_floating_point_type>(val
 template <JsonString T>
 Json::operator T() const &noexcept(false)
 {
-    auto visitor = [this](const auto &storage) -> T {
+    auto visitor = [this](auto const &storage) -> T {
         using S = decltype(storage);
 
         if constexpr (JsonString<S>)
@@ -1672,10 +1679,10 @@ Json::operator T() const &noexcept(false)
 template <JsonObject T>
 Json::operator T() const &noexcept(false)
 {
-    const auto &storage = get<json_object_type>("JSON type is not an object");
+    auto const &storage = get<json_object_type>("JSON type is not an object");
     T result;
 
-    for (const auto &it : storage)
+    for (auto const &it : storage)
     {
         // The JSON string will have been validated for Unicode compliance during construction.
         auto key = *std::move(JsonStringType::convert<typename T::key_type>(it.first));
@@ -1689,10 +1696,10 @@ Json::operator T() const &noexcept(false)
 template <JsonArray T>
 Json::operator T() const &noexcept(false)
 {
-    const auto &storage = get<json_array_type>("JSON type is not an array");
+    auto const &storage = get<json_array_type>("JSON type is not an array");
     T result {};
 
-    for (const auto &it : storage)
+    for (auto const &it : storage)
     {
         auto copy = static_cast<typename T::value_type>(it);
         detail::json_array_append(result, std::move(copy));
@@ -1705,7 +1712,7 @@ Json::operator T() const &noexcept(false)
 template <typename T, std::size_t N>
 Json::operator std::array<T, N>() const noexcept(false)
 {
-    const auto &storage = get<json_array_type>("JSON type is not an array");
+    auto const &storage = get<json_array_type>("JSON type is not an array");
     std::array<T, N> result {};
 
     for (std::size_t i = 0; i < std::min(N, storage.size()); ++i)
@@ -1720,7 +1727,7 @@ Json::operator std::array<T, N>() const noexcept(false)
 template <JsonBoolean T>
 Json::operator T() const noexcept
 {
-    auto visitor = [](const auto &storage) noexcept -> T {
+    auto visitor = [](auto const &storage) noexcept -> T {
         using S = decltype(storage);
 
         if constexpr (JsonContainer<S>)
@@ -1748,7 +1755,7 @@ Json::operator T() const noexcept
 template <JsonNumber T>
 Json::operator T() const noexcept(false)
 {
-    auto visitor = [this](const auto &storage) -> T {
+    auto visitor = [this](auto const &storage) -> T {
         using S = decltype(storage);
 
         if constexpr (JsonString<S>)
@@ -1788,8 +1795,8 @@ Json::reference Json::at(T key)
 template <JsonStringLike T>
 Json::const_reference Json::at(T key) const
 {
-    const auto &storage = get<json_object_type>("JSON type invalid for operator[key]");
-    const auto it = storage.find(convert_to_string(std::move(key)));
+    auto const &storage = get<json_object_type>("JSON type invalid for operator[key]");
+    auto const it = storage.find(convert_to_string(std::move(key)));
 
     if (it == storage.end())
     {
@@ -1816,7 +1823,7 @@ Json::const_reference Json::operator[](T key) const
 
 //==================================================================================================
 template <JsonStringLike Key>
-std::pair<Json::iterator, bool> Json::insert(Key key, const Json &value)
+std::pair<Json::iterator, bool> Json::insert(Key key, Json const &value)
 {
     return object_inserter(std::make_pair(convert_to_string(std::move(key)), value));
 }
@@ -1958,7 +1965,7 @@ void Json::merge(T &&other)
 template <JsonStringLike T>
 Json::size_type Json::count(T key) const
 {
-    const auto &storage = get<json_object_type>("JSON type invalid for count(key)");
+    auto const &storage = get<json_object_type>("JSON type invalid for count(key)");
     return storage.count(convert_to_string(std::move(key)));
 }
 
@@ -1978,7 +1985,7 @@ Json::iterator Json::find(T key)
 template <JsonStringLike T>
 Json::const_iterator Json::find(T key) const
 {
-    const auto &storage = get<json_object_type>("JSON type invalid for find(key)");
+    auto const &storage = get<json_object_type>("JSON type invalid for find(key)");
 
     auto it = cend();
     it.m_iterator = storage.find(convert_to_string(std::move(key)));
@@ -1990,7 +1997,7 @@ Json::const_iterator Json::find(T key) const
 template <JsonStringLike T>
 bool Json::contains(T key) const
 {
-    const auto &storage = get<json_object_type>("JSON type invalid for contains(key)");
+    auto const &storage = get<json_object_type>("JSON type invalid for contains(key)");
     return storage.contains(convert_to_string(std::move(key)));
 }
 
@@ -2050,7 +2057,7 @@ Json::iterator Json::array_inserter(const_iterator position, Args &&...args)
         throw JsonException("Provided iterator is for a different Json instance");
     }
 
-    const auto &position_iterator =
+    auto const &position_iterator =
         std::get<typename const_iterator::array_iterator_type>(position.m_iterator);
 
     auto it = end();
@@ -2061,7 +2068,7 @@ Json::iterator Json::array_inserter(const_iterator position, Args &&...args)
 
 //==================================================================================================
 template <typename T>
-inline T &Json::get(const char *error_message)
+inline T &Json::get(char const *error_message)
 {
     auto *storage = std::get_if<T>(&m_value);
 
@@ -2075,7 +2082,7 @@ inline T &Json::get(const char *error_message)
 
 //==================================================================================================
 template <typename T>
-inline T &Json::get_or_promote(const char *error_message)
+inline T &Json::get_or_promote(char const *error_message)
 {
     auto *storage = std::get_if<T>(&m_value);
 
@@ -2094,9 +2101,9 @@ inline T &Json::get_or_promote(const char *error_message)
 
 //==================================================================================================
 template <typename T>
-inline const T &Json::get(const char *error_message) const
+inline T const &Json::get(char const *error_message) const
 {
-    const auto *storage = std::get_if<T>(&m_value);
+    auto const *storage = std::get_if<T>(&m_value);
 
     if (storage == nullptr)
     {
@@ -2124,7 +2131,7 @@ struct fly::Formatter<fly::Json, CharType> :
      * @param context The context holding the formatting state.
      */
     template <typename FormatContext>
-    void format(const fly::Json &json, FormatContext &context)
+    void format(fly::Json const &json, FormatContext &context)
     {
         if constexpr (fly::SameAs<CharType, fly::json_char_type>)
         {
@@ -2151,11 +2158,11 @@ struct std::hash<fly::Json>
      *
      * @return The hashed JSON value.
      */
-    std::size_t operator()(const fly::Json &json) const
+    std::size_t operator()(fly::Json const &json) const
     {
         std::size_t type = json.m_value.index();
 
-        auto visitor = [type](const auto &storage) -> std::size_t {
+        auto visitor = [type](auto const &storage) -> std::size_t {
             using S = decltype(storage);
 
             if constexpr (fly::JsonNull<S>)
@@ -2168,7 +2175,7 @@ struct std::hash<fly::Json>
                 std::hash<typename fly::json_object_type::mapped_type> value_hasher {};
                 std::size_t result = hash_combine(type, storage.size());
 
-                for (const auto &value : storage)
+                for (auto const &value : storage)
                 {
                     result = hash_combine(result, key_hasher(value.first));
                     result = hash_combine(result, value_hasher(value.second));
@@ -2181,7 +2188,7 @@ struct std::hash<fly::Json>
                 std::hash<typename fly::json_array_type::value_type> hasher {};
                 std::size_t result = hash_combine(type, storage.size());
 
-                for (const auto &value : storage)
+                for (auto const &value : storage)
                 {
                     result = hash_combine(result, hasher(value));
                 }

--- a/fly/types/json/json_exception.cpp
+++ b/fly/types/json/json_exception.cpp
@@ -11,33 +11,33 @@ JsonException::JsonException(std::string &&message) noexcept :
 }
 
 //==================================================================================================
-JsonException::JsonException(const Json &json, std::string &&message) noexcept :
+JsonException::JsonException(Json const &json, std::string &&message) noexcept :
     m_message(String::format("JsonException: {}: ({})", message, json))
 {
 }
 
 //==================================================================================================
-JsonException::JsonException(const char *class_name, std::string &&message) noexcept :
+JsonException::JsonException(char const *class_name, std::string &&message) noexcept :
     m_message(String::format("{}: {}", class_name, message))
 {
 }
 
 //==================================================================================================
-const char *JsonException::what() const noexcept
+char const *JsonException::what() const noexcept
 {
     return m_message.c_str();
 }
 
 //==================================================================================================
-JsonIteratorException::JsonIteratorException(const Json &json, std::string &&message) noexcept :
+JsonIteratorException::JsonIteratorException(Json const &json, std::string &&message) noexcept :
     JsonException("JsonIteratorException", String::format("{}: ({})", message, json))
 {
 }
 
 //==================================================================================================
 BadJsonComparisonException::BadJsonComparisonException(
-    const Json &json1,
-    const Json &json2) noexcept :
+    Json const &json1,
+    Json const &json2) noexcept :
     JsonException(
         "BadJsonComparisonException",
         String::format(
@@ -48,7 +48,7 @@ BadJsonComparisonException::BadJsonComparisonException(
 }
 
 //==================================================================================================
-NullJsonException::NullJsonException(const Json &json) noexcept :
+NullJsonException::NullJsonException(Json const &json) noexcept :
     JsonException(
         "NullJsonException",
         String::format("Cannot dereference an empty or past-the-end iterator: ({})", json))
@@ -64,7 +64,7 @@ NullJsonException::NullJsonException() noexcept :
 }
 
 //==================================================================================================
-OutOfRangeJsonException::OutOfRangeJsonException(const Json &json, std::ptrdiff_t offset) noexcept :
+OutOfRangeJsonException::OutOfRangeJsonException(Json const &json, std::ptrdiff_t offset) noexcept :
     JsonException(
         "OutOfRangeJsonException",
         String::format("Offset {} is out-of-range: ({})", offset, json)),

--- a/fly/types/json/json_exception.hpp
+++ b/fly/types/json/json_exception.hpp
@@ -31,12 +31,12 @@ public:
      * @param json The Json instance for which the error was encountered.
      * @param message Message indicating what error was encountered.
      */
-    JsonException(const Json &json, std::string &&message) noexcept;
+    JsonException(Json const &json, std::string &&message) noexcept;
 
     /**
      * @return C-string representing this exception.
      */
-    virtual const char *what() const noexcept override;
+    virtual char const *what() const noexcept override;
 
 protected:
     /**
@@ -45,10 +45,10 @@ protected:
      * @param class_name Name of the subclass.
      * @param message Message indicating what error was encountered.
      */
-    JsonException(const char *class_name, std::string &&message) noexcept;
+    JsonException(char const *class_name, std::string &&message) noexcept;
 
 private:
-    const std::string m_message;
+    std::string const m_message;
 };
 
 /**
@@ -63,7 +63,7 @@ public:
      * @param json The Json instance for which the error was encountered.
      * @param message Message indicating what error was encountered.
      */
-    JsonIteratorException(const Json &json, std::string &&message) noexcept;
+    JsonIteratorException(Json const &json, std::string &&message) noexcept;
 };
 
 /**
@@ -78,7 +78,7 @@ public:
      * @param json1 The first Json instance in the comparison.
      * @param json2 The second Json instance in the comparison.
      */
-    BadJsonComparisonException(const Json &json1, const Json &json2) noexcept;
+    BadJsonComparisonException(Json const &json1, Json const &json2) noexcept;
 };
 
 /**
@@ -97,7 +97,7 @@ public:
      *
      * @param json The Json instance for which the error was encountered.
      */
-    explicit NullJsonException(const Json &json) noexcept;
+    explicit NullJsonException(Json const &json) noexcept;
 };
 
 /**
@@ -113,7 +113,7 @@ public:
      * @param json The Json instance for which the error was encountered.
      * @param offset The iterator offset attempted to be accessed.
      */
-    OutOfRangeJsonException(const Json &json, std::ptrdiff_t offset) noexcept;
+    OutOfRangeJsonException(Json const &json, std::ptrdiff_t offset) noexcept;
 
     /**
      * @return The iterator offset attempted to be accessed.

--- a/fly/types/string/concepts.hpp
+++ b/fly/types/string/concepts.hpp
@@ -52,7 +52,7 @@ concept StandardStringLike = !fly::SameAs<StandardStringType<T>, std::false_type
  * T, and that specialization implements a |format| method.
  */
 template <typename T, typename FormatContext>
-concept Formattable = requires(FormatContext context, const T &value)
+concept Formattable = requires(FormatContext context, T const &value)
 {
     typename FormatContext::template formatter_type<T>;
 

--- a/fly/types/string/detail/classifier.hpp
+++ b/fly/types/string/detail/classifier.hpp
@@ -44,7 +44,7 @@ public:
      * @return The length of the character array.
      */
     template <std::size_t N>
-    static constexpr size_type size(const CharType (&value)[N]);
+    static constexpr size_type size(CharType const (&value)[N]);
 
     /**
      * Checks if the given character is an alphabetic character as classified by the default C
@@ -167,22 +167,22 @@ private:
      */
     static constexpr CharType unify_az_characters(CharType ch);
 
-    static constexpr const auto s_null_terminator = FLY_CHR(CharType, '\0');
-    static constexpr const auto s_zero = FLY_CHR(CharType, '0');
-    static constexpr const auto s_upper_a = FLY_CHR(CharType, 'A');
-    static constexpr const auto s_upper_z = FLY_CHR(CharType, 'Z');
-    static constexpr const auto s_upper_f = FLY_CHR(CharType, 'F');
-    static constexpr const auto s_lower_a = FLY_CHR(CharType, 'a');
-    static constexpr const auto s_lower_z = FLY_CHR(CharType, 'z');
-    static constexpr const auto s_space = FLY_CHR(CharType, ' ');
-    static constexpr const auto s_form_feed = FLY_CHR(CharType, '\f');
-    static constexpr const auto s_line_feed = FLY_CHR(CharType, '\n');
-    static constexpr const auto s_carriage_return = FLY_CHR(CharType, '\r');
-    static constexpr const auto s_horizontal_tab = FLY_CHR(CharType, '\t');
-    static constexpr const auto s_vertical_tab = FLY_CHR(CharType, '\v');
+    static constexpr auto const s_null_terminator = FLY_CHR(CharType, '\0');
+    static constexpr auto const s_zero = FLY_CHR(CharType, '0');
+    static constexpr auto const s_upper_a = FLY_CHR(CharType, 'A');
+    static constexpr auto const s_upper_z = FLY_CHR(CharType, 'Z');
+    static constexpr auto const s_upper_f = FLY_CHR(CharType, 'F');
+    static constexpr auto const s_lower_a = FLY_CHR(CharType, 'a');
+    static constexpr auto const s_lower_z = FLY_CHR(CharType, 'z');
+    static constexpr auto const s_space = FLY_CHR(CharType, ' ');
+    static constexpr auto const s_form_feed = FLY_CHR(CharType, '\f');
+    static constexpr auto const s_line_feed = FLY_CHR(CharType, '\n');
+    static constexpr auto const s_carriage_return = FLY_CHR(CharType, '\r');
+    static constexpr auto const s_horizontal_tab = FLY_CHR(CharType, '\t');
+    static constexpr auto const s_vertical_tab = FLY_CHR(CharType, '\v');
 
-    static constexpr const auto s_case_bit = static_cast<int_type>(0x20);
-    static constexpr const auto s_case_mask = static_cast<int_type>(~s_case_bit);
+    static constexpr auto const s_case_bit = static_cast<int_type>(0x20);
+    static constexpr auto const s_case_mask = static_cast<int_type>(~s_case_bit);
 };
 
 //==================================================================================================
@@ -205,7 +205,7 @@ constexpr auto BasicClassifier<CharType>::size(T &&value) -> size_type
 //==================================================================================================
 template <fly::StandardCharacter CharType>
 template <std::size_t N>
-constexpr auto BasicClassifier<CharType>::size(const CharType (&value)[N]) -> size_type
+constexpr auto BasicClassifier<CharType>::size(CharType const (&value)[N]) -> size_type
 {
     static_assert(N > 0, "Character arrays must have non-zero size");
     return N - ((value[N - 1] == s_null_terminator) ? 1 : 0);
@@ -267,7 +267,7 @@ constexpr bool BasicClassifier<CharType>::is_digit(CharType ch)
 template <fly::StandardCharacter CharType>
 constexpr bool BasicClassifier<CharType>::is_x_digit(CharType ch)
 {
-    const auto alpha = unify_az_characters(ch);
+    auto const alpha = unify_az_characters(ch);
     return is_digit(ch) || ((alpha >= s_upper_a) && (alpha <= s_upper_f));
 }
 

--- a/fly/types/string/detail/converter.hpp
+++ b/fly/types/string/detail/converter.hpp
@@ -24,10 +24,10 @@ namespace fly::detail {
 template <typename T>
 struct Converter
 {
-    static std::optional<T> convert(const std::string &value)
+    static std::optional<T> convert(std::string const &value)
     {
-        const char *begin = value.data();
-        const char *end = begin + value.size();
+        char const *begin = value.data();
+        char const *end = begin + value.size();
 
         T converted {};
         auto result = std::from_chars(begin, end, converted);
@@ -47,7 +47,7 @@ struct Converter
 template <>
 struct Converter<float>
 {
-    static std::optional<float> convert(const std::string &value)
+    static std::optional<float> convert(std::string const &value)
     {
         std::size_t index = 0;
         float result {};
@@ -74,7 +74,7 @@ struct Converter<float>
 template <>
 struct Converter<double>
 {
-    static std::optional<double> convert(const std::string &value)
+    static std::optional<double> convert(std::string const &value)
     {
         std::size_t index = 0;
         double result {};
@@ -101,7 +101,7 @@ struct Converter<double>
 template <>
 struct Converter<long double>
 {
-    static std::optional<long double> convert(const std::string &value)
+    static std::optional<long double> convert(std::string const &value)
     {
         std::size_t index = 0;
         long double result {};

--- a/fly/types/string/detail/format_context.hpp
+++ b/fly/types/string/detail/format_context.hpp
@@ -36,7 +36,7 @@ public:
     template <typename... Parameters>
     constexpr BasicFormatContext(
         OutputIterator out,
-        const BasicFormatParameters<BasicFormatContext, Parameters...> &parameters) noexcept;
+        BasicFormatParameters<BasicFormatContext, Parameters...> const &parameters) noexcept;
 
     /**
      * Get the object holding the format parameter at the specified index. If the index is invalid,
@@ -54,13 +54,13 @@ public:
     OutputIterator &out();
 
 private:
-    BasicFormatContext(const BasicFormatContext &) = delete;
-    BasicFormatContext &operator=(const BasicFormatContext &) = delete;
+    BasicFormatContext(BasicFormatContext const &) = delete;
+    BasicFormatContext &operator=(BasicFormatContext const &) = delete;
 
     OutputIterator m_out;
 
-    const FormatParameter *m_parameters;
-    const std::size_t m_parameters_size;
+    FormatParameter const *m_parameters;
+    std::size_t const m_parameters_size;
 };
 
 //==================================================================================================
@@ -68,7 +68,7 @@ template <typename OutputIterator, fly::StandardCharacter CharType>
 template <typename... Parameters>
 constexpr BasicFormatContext<OutputIterator, CharType>::BasicFormatContext(
     OutputIterator out,
-    const BasicFormatParameters<BasicFormatContext, Parameters...> &parameters) noexcept :
+    BasicFormatParameters<BasicFormatContext, Parameters...> const &parameters) noexcept :
     m_out(std::move(out)),
     m_parameters(parameters.m_parameters.data()),
     m_parameters_size(parameters.m_parameters.size())

--- a/fly/types/string/detail/format_parameters.hpp
+++ b/fly/types/string/detail/format_parameters.hpp
@@ -27,10 +27,10 @@ struct MonoState
 template <typename FormatContext>
 struct UserDefinedValue
 {
-    const void *m_value;
+    void const *m_value;
 
     void (*m_format)(
-        const void *value,
+        void const *value,
         BasicFormatParseContext<typename FormatContext::char_type> &,
         FormatContext &context,
         BasicFormatSpecifier<typename FormatContext::char_type> &&specifier);
@@ -43,11 +43,11 @@ struct UserDefinedValue
 template <typename FormatContext>
 struct StringValue
 {
-    const void *m_value;
+    void const *m_value;
     std::size_t m_size;
 
     void (*m_format)(
-        const void *value,
+        void const *value,
         std::size_t size,
         FormatContext &context,
         BasicFormatSpecifier<typename FormatContext::char_type> &&specifier);
@@ -61,7 +61,7 @@ struct StandardValue
 {
     union
     {
-        const void *m_pointer;
+        void const *m_pointer;
         std::int64_t m_signed_int;
         std::uint64_t m_unsigned_int;
         float m_float;
@@ -89,7 +89,7 @@ struct StandardValue
  */
 template <typename FormatContext, typename T>
 void format_user_defined_value(
-    const void *value,
+    void const *value,
     BasicFormatParseContext<typename FormatContext::char_type> &parse_context,
     FormatContext &context,
     BasicFormatSpecifier<typename FormatContext::char_type> &&specifier);
@@ -107,7 +107,7 @@ void format_user_defined_value(
  */
 template <typename FormatContext, typename T>
 void format_string_value(
-    const void *value,
+    void const *value,
     std::size_t size,
     FormatContext &context,
     BasicFormatSpecifier<typename FormatContext::char_type> &&specifier);
@@ -153,7 +153,7 @@ public:
      * @param value The user-defined value.
      */
     template <fly::FormattableUserDefined T>
-    explicit constexpr BasicFormatParameter(const T &value) noexcept;
+    explicit constexpr BasicFormatParameter(T const &value) noexcept;
 
     /**
      * Constructor. Initialize the format parameter to store a type-erased string from any
@@ -164,7 +164,7 @@ public:
      * @param value The string-like value.
      */
     template <fly::FormattableString T>
-    explicit constexpr BasicFormatParameter(const T &value) noexcept;
+    explicit constexpr BasicFormatParameter(T const &value) noexcept;
 
     /**
      * Constructor. Initialize the format parameter to store a pointer value.
@@ -282,7 +282,7 @@ public:
 private:
     friend FormatContext;
 
-    const std::array<FormatParameter, sizeof...(ParameterTypes)> m_parameters;
+    std::array<FormatParameter, sizeof...(ParameterTypes)> const m_parameters;
 };
 
 /**
@@ -303,7 +303,7 @@ constexpr auto make_format_parameters(ParameterTypes &&...parameters)
 //==================================================================================================
 template <typename FormatContext, typename T>
 inline void format_user_defined_value(
-    const void *value,
+    void const *value,
     BasicFormatParseContext<typename FormatContext::char_type> &parse_context,
     FormatContext &context,
     BasicFormatSpecifier<typename FormatContext::char_type> &&specifier)
@@ -328,13 +328,13 @@ inline void format_user_defined_value(
         }
     }
 
-    formatter.format(*static_cast<const T *>(value), context);
+    formatter.format(*static_cast<T const *>(value), context);
 }
 
 //==================================================================================================
 template <typename FormatContext, typename T>
 inline void format_string_value(
-    const void *value,
+    void const *value,
     std::size_t size,
     FormatContext &context,
     BasicFormatSpecifier<typename FormatContext::char_type> &&specifier)
@@ -343,7 +343,7 @@ inline void format_string_value(
 
     typename FormatContext::template formatter_type<view_type> formatter(std::move(specifier));
 
-    view_type view(static_cast<const T *>(value), size);
+    view_type view(static_cast<T const *>(value), size);
     formatter.format(view, context);
 }
 
@@ -408,7 +408,7 @@ constexpr BasicFormatParameter<FormatContext>::BasicFormatParameter() noexcept :
 //==================================================================================================
 template <typename FormatContext>
 template <fly::FormattableUserDefined T>
-constexpr BasicFormatParameter<FormatContext>::BasicFormatParameter(const T &value) noexcept :
+constexpr BasicFormatParameter<FormatContext>::BasicFormatParameter(T const &value) noexcept :
     m_type(Type::UserDefined),
     m_value {.m_user_defined {&value, format_user_defined_value<FormatContext, T>}}
 {
@@ -417,7 +417,7 @@ constexpr BasicFormatParameter<FormatContext>::BasicFormatParameter(const T &val
 //==================================================================================================
 template <typename FormatContext>
 template <fly::FormattableString T>
-constexpr BasicFormatParameter<FormatContext>::BasicFormatParameter(const T &value) noexcept :
+constexpr BasicFormatParameter<FormatContext>::BasicFormatParameter(T const &value) noexcept :
     m_type(Type::String)
 {
     using U = std::remove_cvref_t<T>;
@@ -437,7 +437,7 @@ constexpr BasicFormatParameter<FormatContext>::BasicFormatParameter(const T &val
     }
 
     m_value.m_string = {
-        static_cast<const void *>(view.data()),
+        static_cast<void const *>(view.data()),
         view.size(),
         format_string_value<FormatContext, standard_character_type>};
 }

--- a/fly/types/string/detail/format_parse_context.hpp
+++ b/fly/types/string/detail/format_parse_context.hpp
@@ -33,8 +33,8 @@ public:
      */
     template <std::size_t N>
     constexpr explicit BasicFormatParseContext(
-        const CharType (&format)[N],
-        const ParameterType *parameters,
+        CharType const (&format)[N],
+        ParameterType const *parameters,
         std::size_t parameters_size) noexcept;
 
     /**
@@ -78,7 +78,7 @@ public:
      *
      * @param error A message describing the error that was encountered.
      */
-    void on_error(const char *error);
+    void on_error(char const *error);
 
     /**
      * If an error was stored from a non-constant-evaluated context, returns whether an error was
@@ -100,12 +100,12 @@ private:
     BasicFormatParseContext(BasicFormatParseContext &&) = delete;
     BasicFormatParseContext &operator=(BasicFormatParseContext &&) = delete;
 
-    BasicFormatParseContext(const BasicFormatParseContext &) = delete;
-    BasicFormatParseContext &operator=(const BasicFormatParseContext &) = delete;
+    BasicFormatParseContext(BasicFormatParseContext const &) = delete;
+    BasicFormatParseContext &operator=(BasicFormatParseContext const &) = delete;
 
     fly::BasicLexer<CharType> m_lexer;
 
-    const ParameterType *m_parameters;
+    ParameterType const *m_parameters;
     std::size_t m_parameters_size;
 
     std::size_t m_next_position {0};
@@ -119,8 +119,8 @@ private:
 template <fly::StandardCharacter CharType>
 template <std::size_t N>
 constexpr BasicFormatParseContext<CharType>::BasicFormatParseContext(
-    const CharType (&format)[N],
-    const ParameterType *parameters,
+    CharType const (&format)[N],
+    ParameterType const *parameters,
     std::size_t parameters_size) noexcept :
     m_lexer(format),
     m_parameters(parameters),
@@ -183,7 +183,7 @@ constexpr auto BasicFormatParseContext<CharType>::view() const -> view_type
 
 //==================================================================================================
 template <fly::StandardCharacter CharType>
-void BasicFormatParseContext<CharType>::on_error(const char *error)
+void BasicFormatParseContext<CharType>::on_error(char const *error)
 {
     m_error = error;
 }

--- a/fly/types/string/detail/format_specifier.hpp
+++ b/fly/types/string/detail/format_specifier.hpp
@@ -126,10 +126,10 @@ struct BasicFormatSpecifier
      */
     explicit constexpr BasicFormatSpecifier(FormatParseContext &context);
 
-    BasicFormatSpecifier(const BasicFormatSpecifier &) = default;
+    BasicFormatSpecifier(BasicFormatSpecifier const &) = default;
     BasicFormatSpecifier(BasicFormatSpecifier &&) = default;
 
-    BasicFormatSpecifier &operator=(const BasicFormatSpecifier &) = default;
+    BasicFormatSpecifier &operator=(BasicFormatSpecifier const &) = default;
     BasicFormatSpecifier &operator=(BasicFormatSpecifier &&) = default;
 
     enum class Alignment : std::uint8_t
@@ -253,8 +253,8 @@ struct BasicFormatSpecifier
      */
     template <typename T>
     friend bool operator==(
-        const BasicFormatSpecifier<T> &specifier1,
-        const BasicFormatSpecifier<T> &specifier2);
+        BasicFormatSpecifier<T> const &specifier1,
+        BasicFormatSpecifier<T> const &specifier2);
 
     std::size_t m_position {0};
 
@@ -451,18 +451,18 @@ private:
         {FLY_CHR(CharType, 'G'), Type::General},
     }};
 
-    static constexpr const auto s_left_brace = FLY_CHR(CharType, '{');
-    static constexpr const auto s_right_brace = FLY_CHR(CharType, '}');
-    static constexpr const auto s_less_than_sign = FLY_CHR(CharType, '<');
-    static constexpr const auto s_greater_than_sign = FLY_CHR(CharType, '>');
-    static constexpr const auto s_caret = FLY_CHR(CharType, '^');
-    static constexpr const auto s_plus_sign = FLY_CHR(CharType, '+');
-    static constexpr const auto s_minus_sign = FLY_CHR(CharType, '-');
-    static constexpr const auto s_space = FLY_CHR(CharType, ' ');
-    static constexpr const auto s_number_sign = FLY_CHR(CharType, '#');
-    static constexpr const auto s_zero = FLY_CHR(CharType, '0');
-    static constexpr const auto s_letter_l = FLY_CHR(CharType, 'L');
-    static constexpr const auto s_decimal = FLY_CHR(CharType, '.');
+    static constexpr auto const s_left_brace = FLY_CHR(CharType, '{');
+    static constexpr auto const s_right_brace = FLY_CHR(CharType, '}');
+    static constexpr auto const s_less_than_sign = FLY_CHR(CharType, '<');
+    static constexpr auto const s_greater_than_sign = FLY_CHR(CharType, '>');
+    static constexpr auto const s_caret = FLY_CHR(CharType, '^');
+    static constexpr auto const s_plus_sign = FLY_CHR(CharType, '+');
+    static constexpr auto const s_minus_sign = FLY_CHR(CharType, '-');
+    static constexpr auto const s_space = FLY_CHR(CharType, ' ');
+    static constexpr auto const s_number_sign = FLY_CHR(CharType, '#');
+    static constexpr auto const s_zero = FLY_CHR(CharType, '0');
+    static constexpr auto const s_letter_l = FLY_CHR(CharType, 'L');
+    static constexpr auto const s_decimal = FLY_CHR(CharType, '.');
 };
 
 /**
@@ -493,7 +493,8 @@ private:
         m_parameter_type = parameter_type;                                                         \
     }                                                                                              \
                                                                                                    \
-    explicit Formatter(FormatSpecifier specifier) noexcept : FormatSpecifier(std::move(specifier)) \
+    explicit Formatter(FormatSpecifier specifier) noexcept :                                       \
+        FormatSpecifier(std::move(specifier))                                                      \
     {                                                                                              \
     }
 
@@ -635,7 +636,7 @@ constexpr auto BasicFormatSpecifier<CharType>::parse_nested_specifier(FormatPars
     -> std::optional<BasicFormatSpecifier>
 {
     // The opening { will have already been consumed, so the starting position is one less.
-    const auto starting_position = context.lexer().position() - 1;
+    auto const starting_position = context.lexer().position() - 1;
 
     BasicFormatSpecifier specifier {};
     specifier.m_position = context.next_position();
@@ -924,7 +925,7 @@ BasicFormatSpecifier<CharType>::resolve_parameter_type(FormatParseContext &conte
 template <fly::StandardCharacter CharType>
 constexpr auto BasicFormatSpecifier<CharType>::type_of(CharType ch) -> std::optional<Type>
 {
-    auto it = std::find_if(s_type_map.begin(), s_type_map.end(), [&ch](const auto &item) {
+    auto it = std::find_if(s_type_map.begin(), s_type_map.end(), [&ch](auto const &item) {
         return item.first == ch;
     });
 
@@ -960,8 +961,8 @@ constexpr bool BasicFormatSpecifier<CharType>::is_numeric() const
 //==================================================================================================
 template <typename T>
 bool operator==(
-    const BasicFormatSpecifier<T> &specifier1,
-    const BasicFormatSpecifier<T> &specifier2)
+    BasicFormatSpecifier<T> const &specifier1,
+    BasicFormatSpecifier<T> const &specifier2)
 {
     return (specifier1.m_position == specifier2.m_position) &&
         (specifier1.m_fill == specifier2.m_fill) &&

--- a/fly/types/string/detail/format_string.hpp
+++ b/fly/types/string/detail/format_string.hpp
@@ -42,7 +42,7 @@ public:
      * Constructor. Parse and validate a C-string literal as a format string.
      */
     template <std::size_t N>
-    FLY_CONSTEVAL BasicFormatString(const CharType (&format)[N]) noexcept;
+    FLY_CONSTEVAL BasicFormatString(CharType const (&format)[N]) noexcept;
 
     BasicFormatString(BasicFormatString &&) = default;
     BasicFormatString &operator=(BasicFormatString &&) = default;
@@ -58,8 +58,8 @@ public:
     std::optional<FormatSpecifier> next_specifier();
 
 private:
-    BasicFormatString(const BasicFormatString &) = delete;
-    BasicFormatString &operator=(const BasicFormatString &) = delete;
+    BasicFormatString(BasicFormatString const &) = delete;
+    BasicFormatString &operator=(BasicFormatString const &) = delete;
 
     /**
      * Upon parsing an un-escaped opening brace, parse a single replacement field in the format
@@ -80,9 +80,9 @@ private:
     template <std::size_t N = 0>
     constexpr void parse_user_defined_specifier(FormatSpecifier &specifier);
 
-    static constexpr const auto s_left_brace = FLY_CHR(CharType, '{');
-    static constexpr const auto s_right_brace = FLY_CHR(CharType, '}');
-    static constexpr const auto s_colon = FLY_CHR(CharType, ':');
+    static constexpr auto const s_left_brace = FLY_CHR(CharType, '{');
+    static constexpr auto const s_right_brace = FLY_CHR(CharType, '}');
+    static constexpr auto const s_colon = FLY_CHR(CharType, ':');
 
     static constexpr std::array<ParameterType, sizeof...(ParameterTypes)> s_parameters {
         infer_parameter_type<ParameterTypes>()...};
@@ -98,7 +98,7 @@ private:
 template <fly::StandardCharacter CharType, typename... ParameterTypes>
 template <std::size_t N>
 FLY_CONSTEVAL BasicFormatString<CharType, ParameterTypes...>::BasicFormatString(
-    const CharType (&format)[N]) noexcept :
+    CharType const (&format)[N]) noexcept :
     m_context(format, s_parameters.data(), s_parameters.size())
 {
     std::optional<CharType> ch;
@@ -158,7 +158,7 @@ template <fly::StandardCharacter CharType, typename... ParameterTypes>
 constexpr auto BasicFormatString<CharType, ParameterTypes...>::parse_specifier() -> FormatSpecifier
 {
     // The opening { will have already been consumed, so the starting position is one less.
-    const auto starting_position = m_context.lexer().position() - 1;
+    auto const starting_position = m_context.lexer().position() - 1;
 
     FormatSpecifier specifier(m_context);
     specifier.m_parse_index = m_context.lexer().position();

--- a/fly/types/string/detail/stream_util.hpp
+++ b/fly/types/string/detail/stream_util.hpp
@@ -77,24 +77,24 @@ public:
     void precision(std::streamsize size);
 
 private:
-    ScopedStreamModifiers(const ScopedStreamModifiers &) = delete;
-    ScopedStreamModifiers &operator=(const ScopedStreamModifiers &) = delete;
+    ScopedStreamModifiers(ScopedStreamModifiers const &) = delete;
+    ScopedStreamModifiers &operator=(ScopedStreamModifiers const &) = delete;
 
     std::ostream &m_stream;
 
-    const std::ios_base::fmtflags m_flags;
+    std::ios_base::fmtflags const m_flags;
     bool m_changed_flags {false};
 
-    const std::locale m_locale;
+    std::locale const m_locale;
     bool m_changed_locale {false};
 
-    const char m_fill;
+    char const m_fill;
     bool m_changed_fill {false};
 
-    const std::streamsize m_width;
+    std::streamsize const m_width;
     bool m_changed_width {false};
 
-    const std::streamsize m_precision;
+    std::streamsize const m_precision;
     bool m_changed_precision {false};
 };
 
@@ -111,11 +111,11 @@ class PositivePaddingFacet : public std::ctype<CharType>
 protected:
     CharType do_widen(char ch) const override;
 
-    const char *do_widen(const char *begin, const char *end, CharType *dest) const override;
+    char const *do_widen(char const *begin, char const *end, CharType *dest) const override;
 
 private:
-    static constexpr const auto s_plus_sign = FLY_CHR(char, '+');
-    static constexpr const auto s_space = FLY_CHR(CharType, ' ');
+    static constexpr auto const s_plus_sign = FLY_CHR(char, '+');
+    static constexpr auto const s_space = FLY_CHR(CharType, ' ');
 };
 
 //==================================================================================================
@@ -206,8 +206,8 @@ CharType PositivePaddingFacet<CharType>::do_widen(char ch) const
 
 //==================================================================================================
 template <fly::StandardCharacter CharType>
-const char *
-PositivePaddingFacet<CharType>::do_widen(const char *begin, const char *end, CharType *dest) const
+char const *
+PositivePaddingFacet<CharType>::do_widen(char const *begin, char const *end, CharType *dest) const
 {
     while (begin != end)
     {

--- a/fly/types/string/detail/unicode.hpp
+++ b/fly/types/string/detail/unicode.hpp
@@ -46,7 +46,7 @@ public:
      * @return True if the string is Unicode compliant.
      */
     template <typename IteratorType>
-    static bool validate_encoding(IteratorType &it, const IteratorType &end);
+    static bool validate_encoding(IteratorType &it, IteratorType const &end);
 
     /**
      * Convert the Unicode encoding of a string to another encoding.
@@ -91,7 +91,7 @@ public:
      */
     template <typename IteratorType>
     static std::optional<codepoint_type>
-    decode_codepoint(IteratorType &it, const IteratorType &end);
+    decode_codepoint(IteratorType &it, IteratorType const &end);
 
     /**
      * Encode a single Unicode codepoint.
@@ -133,7 +133,7 @@ public:
      */
     template <char UnicodePrefix = 'U', typename IteratorType>
     requires fly::UnicodePrefixCharacter<UnicodePrefix>
-    static std::optional<string_type> escape_codepoint(IteratorType &it, const IteratorType &end);
+    static std::optional<string_type> escape_codepoint(IteratorType &it, IteratorType const &end);
 
     /**
      * Unescape a single Unicode codepoint, starting at the character pointed to by provided
@@ -155,7 +155,7 @@ public:
      *         uninitialized value.
      */
     template <typename IteratorType>
-    static std::optional<string_type> unescape_codepoint(IteratorType &it, const IteratorType &end);
+    static std::optional<string_type> unescape_codepoint(IteratorType &it, IteratorType const &end);
 
 private:
     friend BasicUnicode<char>;
@@ -192,7 +192,7 @@ private:
      */
     template <char UnicodePrefix, typename IteratorType>
     requires fly::UnicodePrefixCharacter<UnicodePrefix>
-    static codepoint_type unescape_codepoint(IteratorType &it, const IteratorType &end);
+    static codepoint_type unescape_codepoint(IteratorType &it, IteratorType const &end);
 
     /**
      * Decode a Unicode codepoint from a UTF-8 string.
@@ -206,7 +206,7 @@ private:
      */
     template <typename IteratorType>
     requires fly::SizeOfTypeIs<CharType, 1>
-    static codepoint_type codepoint_from_string(IteratorType &it, const IteratorType &end);
+    static codepoint_type codepoint_from_string(IteratorType &it, IteratorType const &end);
 
     /**
      * Decode a Unicode codepoint from a UTF-16 string.
@@ -220,7 +220,7 @@ private:
      */
     template <typename IteratorType>
     requires fly::SizeOfTypeIs<CharType, 2>
-    static codepoint_type codepoint_from_string(IteratorType &it, const IteratorType &end);
+    static codepoint_type codepoint_from_string(IteratorType &it, IteratorType const &end);
 
     /**
      * Decode a Unicode codepoint from a UTF-32 string.
@@ -234,7 +234,7 @@ private:
      */
     template <typename IteratorType>
     requires fly::SizeOfTypeIs<CharType, 4>
-    static codepoint_type codepoint_from_string(IteratorType &it, const IteratorType &end);
+    static codepoint_type codepoint_from_string(IteratorType &it, IteratorType const &end);
 
     /**
      * Encode a Unicode codepoint into a UTF-8 string.
@@ -307,7 +307,7 @@ private:
      * @return The next byte of the encoded Unicode codepoint.
      */
     template <typename IteratorType>
-    static codepoint_type next_encoded_byte(IteratorType &it, const IteratorType &end);
+    static codepoint_type next_encoded_byte(IteratorType &it, IteratorType const &end);
 
     /**
      * Structure to hold static data required for decoding UTF-8 encoded Unicode codepoints.
@@ -315,19 +315,19 @@ private:
     struct Utf8Data
     {
         // The value of the UTF-8 encoded leading byte.
-        const codepoint_type m_leading_byte;
+        codepoint_type const m_leading_byte;
 
         // A bit-mask of the bits in the UTF-8 encoded leading byte reserved for encoding.
-        const codepoint_type m_encoding_mask;
+        codepoint_type const m_encoding_mask;
 
         // A bit-mask of the bits in the UTF-8 encoded leading byte reserved for codepoint data.
-        const codepoint_type m_codepoint_mask;
+        codepoint_type const m_codepoint_mask;
 
         // The number of bytes required to decode the codepoint.
-        const codepoint_type m_codepoint_size;
+        codepoint_type const m_codepoint_size;
     };
 
-    static constexpr const std::array<Utf8Data, 4> s_utf8_leading_bytes = {{
+    static constexpr std::array<Utf8Data, 4> const s_utf8_leading_bytes = {{
         // Codepoint length 1, range [U+0000, U+007f], leading byte 0b0xxx'xxxx.
         {0b0000'0000, 0b1000'0000, 0b0111'1111, 1},
 
@@ -341,30 +341,30 @@ private:
         {0b1111'0000, 0b1111'1000, 0b0000'0111, 4},
     }};
 
-    static constexpr const Utf8Data s_utf8_continuation_byte =
+    static constexpr Utf8Data const s_utf8_continuation_byte =
         {0b1000'0000, 0b1100'0000, 0b0011'1111, 6};
 
-    static constexpr const codepoint_type s_high_surrogate_min = 0xd800;
-    static constexpr const codepoint_type s_high_surrogate_max = 0xdbff;
-    static constexpr const codepoint_type s_low_surrogate_min = 0xdc00;
-    static constexpr const codepoint_type s_low_surrogate_max = 0xdfff;
-    static constexpr const codepoint_type s_max_codepoint = 0x10ffff;
-    static constexpr const codepoint_type s_invalid_codepoint = 0xffffffff;
+    static constexpr codepoint_type const s_high_surrogate_min = 0xd800;
+    static constexpr codepoint_type const s_high_surrogate_max = 0xdbff;
+    static constexpr codepoint_type const s_low_surrogate_min = 0xdc00;
+    static constexpr codepoint_type const s_low_surrogate_max = 0xdfff;
+    static constexpr codepoint_type const s_max_codepoint = 0x10ffff;
+    static constexpr codepoint_type const s_invalid_codepoint = 0xffffffff;
 
-    static constexpr const auto s_zero = FLY_CHR(CharType, '0');
-    static constexpr const auto s_nine = FLY_CHR(CharType, '9');
-    static constexpr const auto s_lower_a = FLY_CHR(CharType, 'a');
-    static constexpr const auto s_upper_a = FLY_CHR(CharType, 'A');
-    static constexpr const auto s_lower_f = FLY_CHR(CharType, 'f');
-    static constexpr const auto s_upper_f = FLY_CHR(CharType, 'F');
-    static constexpr const auto s_lower_u = FLY_CHR(CharType, 'u');
-    static constexpr const auto s_upper_u = FLY_CHR(CharType, 'U');
+    static constexpr auto const s_zero = FLY_CHR(CharType, '0');
+    static constexpr auto const s_nine = FLY_CHR(CharType, '9');
+    static constexpr auto const s_lower_a = FLY_CHR(CharType, 'a');
+    static constexpr auto const s_upper_a = FLY_CHR(CharType, 'A');
+    static constexpr auto const s_lower_f = FLY_CHR(CharType, 'f');
+    static constexpr auto const s_upper_f = FLY_CHR(CharType, 'F');
+    static constexpr auto const s_lower_u = FLY_CHR(CharType, 'u');
+    static constexpr auto const s_upper_u = FLY_CHR(CharType, 'U');
 };
 
 //==================================================================================================
 template <fly::StandardCharacter CharType>
 template <typename IteratorType>
-bool BasicUnicode<CharType>::validate_encoding(IteratorType &it, const IteratorType &end)
+bool BasicUnicode<CharType>::validate_encoding(IteratorType &it, IteratorType const &end)
 {
     while (it != end)
     {
@@ -401,7 +401,7 @@ bool BasicUnicode<CharType>::convert_encoding_into(view_type value, OutputIterat
     using DesiredUnicodeType = BasicUnicode<typename DesiredStringType::value_type>;
 
     auto it = value.cbegin();
-    const auto end = value.cend();
+    auto const end = value.cend();
 
     while (it != end)
     {
@@ -420,10 +420,10 @@ bool BasicUnicode<CharType>::convert_encoding_into(view_type value, OutputIterat
 //==================================================================================================
 template <fly::StandardCharacter CharType>
 template <typename IteratorType>
-auto BasicUnicode<CharType>::decode_codepoint(IteratorType &it, const IteratorType &end)
+auto BasicUnicode<CharType>::decode_codepoint(IteratorType &it, IteratorType const &end)
     -> std::optional<codepoint_type>
 {
-    const codepoint_type codepoint = codepoint_from_string(it, end);
+    codepoint_type const codepoint = codepoint_from_string(it, end);
 
     if (validate_codepoint(codepoint))
     {
@@ -453,7 +453,7 @@ auto BasicUnicode<CharType>::encode_codepoint(codepoint_type codepoint)
 template <fly::StandardCharacter CharType>
 template <char UnicodePrefix, typename IteratorType>
 requires fly::UnicodePrefixCharacter<UnicodePrefix>
-auto BasicUnicode<CharType>::escape_codepoint(IteratorType &it, const IteratorType &end)
+auto BasicUnicode<CharType>::escape_codepoint(IteratorType &it, IteratorType const &end)
     -> std::optional<string_type>
 {
     if (auto codepoint = decode_codepoint(it, end); codepoint)
@@ -467,10 +467,10 @@ auto BasicUnicode<CharType>::escape_codepoint(IteratorType &it, const IteratorTy
 //==================================================================================================
 template <fly::StandardCharacter CharType>
 template <typename IteratorType>
-auto BasicUnicode<CharType>::unescape_codepoint(IteratorType &it, const IteratorType &end)
+auto BasicUnicode<CharType>::unescape_codepoint(IteratorType &it, IteratorType const &end)
     -> std::optional<string_type>
 {
-    auto escaped_with = [&it, &end](const CharType ch) -> bool {
+    auto escaped_with = [&it, &end](CharType const ch) -> bool {
         if ((it == end) || ((it + 1) == end))
         {
             return false;
@@ -507,7 +507,7 @@ auto BasicUnicode<CharType>::escape_codepoint(codepoint_type codepoint) -> strin
 
     // TODO: Replace this with BasicString::format without actually including formatters.hpp.
     auto to_hex = [&codepoint](std::size_t length) -> string_type {
-        static const auto *s_digits = FLY_STR(CharType, "0123456789abcdef");
+        static auto const *s_digits = FLY_STR(CharType, "0123456789abcdef");
         string_type hex(length, FLY_CHR(CharType, '0'));
 
         for (std::size_t i = 0, j = (length - 1) * 4; i < length; ++i, j -= 4)
@@ -530,8 +530,8 @@ auto BasicUnicode<CharType>::escape_codepoint(codepoint_type codepoint) -> strin
         {
             if constexpr (UnicodePrefix == 'u')
             {
-                const codepoint_type high_surrogate = 0xd7c0 + (codepoint >> 10);
-                const codepoint_type low_surrogate = 0xdc00 + (codepoint & 0x3ff);
+                codepoint_type const high_surrogate = 0xd7c0 + (codepoint >> 10);
+                codepoint_type const low_surrogate = 0xdc00 + (codepoint & 0x3ff);
 
                 result += escape_codepoint<UnicodePrefix>(high_surrogate);
                 result += escape_codepoint<UnicodePrefix>(low_surrogate);
@@ -556,7 +556,7 @@ auto BasicUnicode<CharType>::escape_codepoint(codepoint_type codepoint) -> strin
 template <fly::StandardCharacter CharType>
 template <char UnicodePrefix, typename IteratorType>
 requires fly::UnicodePrefixCharacter<UnicodePrefix>
-auto BasicUnicode<CharType>::unescape_codepoint(IteratorType &it, const IteratorType &end)
+auto BasicUnicode<CharType>::unescape_codepoint(IteratorType &it, IteratorType const &end)
     -> codepoint_type
 {
     if ((it == end) || (*it != '\\') || (++it == end) || (*it != UnicodePrefix))
@@ -567,12 +567,12 @@ auto BasicUnicode<CharType>::unescape_codepoint(IteratorType &it, const Iterator
     codepoint_type codepoint = 0;
     ++it;
 
-    static constexpr const codepoint_type s_expected_digits = (UnicodePrefix == 'u') ? 4 : 8;
+    static constexpr codepoint_type const s_expected_digits = (UnicodePrefix == 'u') ? 4 : 8;
     codepoint_type i = 0;
 
     for (i = 0; (i < s_expected_digits) && (it != end); ++i, ++it)
     {
-        const codepoint_type shift = (4 * (s_expected_digits - i - 1));
+        codepoint_type const shift = (4 * (s_expected_digits - i - 1));
 
         if ((*it >= s_zero) && (*it <= s_nine))
         {
@@ -599,16 +599,16 @@ auto BasicUnicode<CharType>::unescape_codepoint(IteratorType &it, const Iterator
 template <fly::StandardCharacter CharType>
 template <typename IteratorType>
 requires fly::SizeOfTypeIs<CharType, 1>
-auto BasicUnicode<CharType>::codepoint_from_string(IteratorType &it, const IteratorType &end)
+auto BasicUnicode<CharType>::codepoint_from_string(IteratorType &it, IteratorType const &end)
     -> codepoint_type
 {
-    const codepoint_type leading_byte = next_encoded_byte(it, end);
+    codepoint_type const leading_byte = next_encoded_byte(it, end);
 
     // First find the codepoint length by finding which leading byte matches the first encoded byte.
     auto utf8_it = std::find_if(
         s_utf8_leading_bytes.begin(),
         s_utf8_leading_bytes.end(),
-        [&leading_byte](const auto &candidate) {
+        [&leading_byte](auto const &candidate) {
             return (leading_byte & candidate.m_encoding_mask) == candidate.m_leading_byte;
         });
 
@@ -617,7 +617,7 @@ auto BasicUnicode<CharType>::codepoint_from_string(IteratorType &it, const Itera
         return s_invalid_codepoint;
     }
 
-    const std::size_t bytes = utf8_it->m_codepoint_size;
+    std::size_t const bytes = utf8_it->m_codepoint_size;
     std::size_t shift = s_utf8_continuation_byte.m_codepoint_size * (bytes - 1);
 
     // Then decode the encoded bytes using the leading and continuation byte masks.
@@ -625,7 +625,7 @@ auto BasicUnicode<CharType>::codepoint_from_string(IteratorType &it, const Itera
 
     for (std::size_t i = 1; i < bytes; ++i)
     {
-        const codepoint_type continuation_byte = next_encoded_byte(it, end);
+        codepoint_type const continuation_byte = next_encoded_byte(it, end);
 
         if ((continuation_byte & s_utf8_continuation_byte.m_encoding_mask) !=
             s_utf8_continuation_byte.m_leading_byte)
@@ -652,7 +652,7 @@ auto BasicUnicode<CharType>::codepoint_from_string(IteratorType &it, const Itera
 template <fly::StandardCharacter CharType>
 template <typename IteratorType>
 requires fly::SizeOfTypeIs<CharType, 2>
-auto BasicUnicode<CharType>::codepoint_from_string(IteratorType &it, const IteratorType &end)
+auto BasicUnicode<CharType>::codepoint_from_string(IteratorType &it, IteratorType const &end)
     -> codepoint_type
 {
     auto next_codepoint = [&it, &end]() -> codepoint_type {
@@ -666,7 +666,7 @@ auto BasicUnicode<CharType>::codepoint_from_string(IteratorType &it, const Itera
 template <fly::StandardCharacter CharType>
 template <typename IteratorType>
 requires fly::SizeOfTypeIs<CharType, 4>
-auto BasicUnicode<CharType>::codepoint_from_string(IteratorType &it, const IteratorType &end)
+auto BasicUnicode<CharType>::codepoint_from_string(IteratorType &it, IteratorType const &end)
     -> codepoint_type
 {
     return next_encoded_byte(it, end);
@@ -745,7 +745,7 @@ auto BasicUnicode<CharType>::create_codepoint_from_surrogates(
 
     if (is_high_surrogate(codepoint))
     {
-        const codepoint_type low_surrogate = next_codepoint();
+        codepoint_type const low_surrogate = next_codepoint();
 
         if (is_low_surrogate(low_surrogate))
         {
@@ -790,7 +790,7 @@ bool BasicUnicode<CharType>::validate_codepoint(codepoint_type codepoint)
 //==================================================================================================
 template <fly::StandardCharacter CharType>
 template <typename IteratorType>
-inline auto BasicUnicode<CharType>::next_encoded_byte(IteratorType &it, const IteratorType &end)
+inline auto BasicUnicode<CharType>::next_encoded_byte(IteratorType &it, IteratorType const &end)
     -> codepoint_type
 {
     return (it == end) ? s_invalid_codepoint : static_cast<codepoint_type>(*(it++));

--- a/fly/types/string/formatters.hpp
+++ b/fly/types/string/formatters.hpp
@@ -31,7 +31,7 @@ namespace fly {
  * following member template function:
  *
  *     template <typename FormatContext>
- *     void format(const T &value, FormatContext &context);
+ *     void format(T const &value, FormatContext &context);
  *
  * Where the FormatContext is a structure holding the formatting state.
  *
@@ -56,16 +56,16 @@ struct Formatter<T, CharType> : public detail::BasicFormatSpecifier<CharType>
      * @param context The context holding the formatting state.
      */
     template <typename FormatContext>
-    void format(const T &value, FormatContext &context)
+    void format(T const &value, FormatContext &context)
     {
-        const std::size_t min_width = FormatSpecifier::width(context, 0);
-        const std::size_t max_width = FormatSpecifier::precision(context, string_type::npos);
+        std::size_t const min_width = FormatSpecifier::width(context, 0);
+        std::size_t const max_width = FormatSpecifier::precision(context, string_type::npos);
 
-        const std::size_t actual_size = detail::BasicClassifier<CharType>::size(value);
-        const std::size_t value_size = std::min(max_width, actual_size);
+        std::size_t const actual_size = detail::BasicClassifier<CharType>::size(value);
+        std::size_t const value_size = std::min(max_width, actual_size);
 
-        const std::size_t padding_size = std::max(value_size, min_width) - value_size;
-        const auto padding_char = m_fill.value_or(s_space);
+        std::size_t const padding_size = std::max(value_size, min_width) - value_size;
+        auto const padding_char = m_fill.value_or(s_space);
 
         auto append_padding = [&context, padding_char](std::size_t count) {
             for (std::size_t i = 0; i < count; ++i)
@@ -89,8 +89,8 @@ struct Formatter<T, CharType> : public detail::BasicFormatSpecifier<CharType>
 
             case FormatSpecifier::Alignment::Center:
             {
-                const std::size_t left_padding = padding_size / 2;
-                const std::size_t right_padding =
+                std::size_t const left_padding = padding_size / 2;
+                std::size_t const right_padding =
                     (padding_size % 2 == 0) ? left_padding : left_padding + 1;
 
                 append_padding(left_padding);
@@ -115,7 +115,7 @@ struct Formatter<T, CharType> : public detail::BasicFormatSpecifier<CharType>
      * @param context The context holding the formatting state.
      */
     template <typename FormatContext>
-    static void append_string(const T &value, std::size_t value_size, FormatContext &context)
+    static void append_string(T const &value, std::size_t value_size, FormatContext &context)
     {
         using standard_character_type = StandardCharacterType<T>;
         using standard_view_type = std::basic_string_view<standard_character_type>;
@@ -133,7 +133,7 @@ struct Formatter<T, CharType> : public detail::BasicFormatSpecifier<CharType>
 
         if constexpr (fly::SameAs<CharType, standard_character_type>)
         {
-            for (const auto &ch : view)
+            for (auto const &ch : view)
             {
                 *context.out()++ = ch;
             }
@@ -144,7 +144,7 @@ struct Formatter<T, CharType> : public detail::BasicFormatSpecifier<CharType>
 
             if (auto converted = unicode::template convert_encoding<string_type>(view); converted)
             {
-                for (const auto &ch : *converted)
+                for (auto const &ch : *converted)
                 {
                     *context.out()++ = ch;
                 }
@@ -155,7 +155,7 @@ struct Formatter<T, CharType> : public detail::BasicFormatSpecifier<CharType>
 private:
     using string_type = std::basic_string<CharType>;
 
-    static constexpr const auto s_space = FLY_CHR(CharType, ' ');
+    static constexpr auto const s_space = FLY_CHR(CharType, ' ');
 };
 
 //==================================================================================================
@@ -180,7 +180,7 @@ struct Formatter<T, CharType> : public detail::BasicFormatSpecifier<CharType>
 
         Formatter<std::uintptr_t, CharType> formatter(*this);
         formatter.format(
-            reinterpret_cast<std::uintptr_t>(static_cast<const void *>(value)),
+            reinterpret_cast<std::uintptr_t>(static_cast<void const *>(value)),
             context);
     }
 };
@@ -209,8 +209,8 @@ struct Formatter<T, CharType> : public detail::BasicFormatSpecifier<CharType>
             // Compute the absolute value of the integer. Benchmarks showed this is exactly as fast
             // as std::abs, but this also tracks whether the original value was negative without
             // branches.
-            const T sign = value >> std::numeric_limits<T>::digits;
-            const U unsigned_value = static_cast<U>(static_cast<U>(value ^ sign) + (sign & 1));
+            T const sign = value >> std::numeric_limits<T>::digits;
+            U const unsigned_value = static_cast<U>(static_cast<U>(value ^ sign) + (sign & 1));
 
             format(unsigned_value, static_cast<bool>(sign), context);
         }
@@ -259,12 +259,12 @@ private:
             }
         }
 
-        const int base = static_cast<int>(m_type);
-        const std::size_t value_size = count_digits(value, base) + prefix_size;
+        int const base = static_cast<int>(m_type);
+        std::size_t const value_size = count_digits(value, base) + prefix_size;
 
-        const std::size_t width = FormatSpecifier::width(context, 0);
-        const std::size_t padding_size = std::max(value_size, width) - value_size;
-        const auto padding_char = m_fill.value_or(s_space);
+        std::size_t const width = FormatSpecifier::width(context, 0);
+        std::size_t const padding_size = std::max(value_size, width) - value_size;
+        auto const padding_char = m_fill.value_or(s_space);
 
         auto append_prefix = [this, is_negative, &context]() {
             if (is_negative)
@@ -282,7 +282,7 @@ private:
 
             if (m_alternate_form)
             {
-                const bool is_upper_case = m_case == FormatSpecifier::Case::Upper;
+                bool const is_upper_case = m_case == FormatSpecifier::Case::Upper;
                 *context.out()++ = s_zero;
 
                 if (m_type == FormatSpecifier::Type::Binary)
@@ -319,8 +319,8 @@ private:
 
             case FormatSpecifier::Alignment::Center:
             {
-                const std::size_t left_padding = padding_size / 2;
-                const std::size_t right_padding =
+                std::size_t const left_padding = padding_size / 2;
+                std::size_t const right_padding =
                     (padding_size % 2 == 0) ? left_padding : left_padding + 1;
 
                 append_padding(left_padding, padding_char);
@@ -368,9 +368,9 @@ private:
             return;
         }
 
-        const std::size_t width = FormatSpecifier::width(context, 0);
-        const std::size_t padding_size = width > 1 ? width - 1 : 0;
-        const auto padding_char = m_fill.value_or(s_space);
+        std::size_t const width = FormatSpecifier::width(context, 0);
+        std::size_t const padding_size = width > 1 ? width - 1 : 0;
+        auto const padding_char = m_fill.value_or(s_space);
 
         auto append_padding = [&context, padding_char](std::size_t count) {
             for (std::size_t i = 0; i < count; ++i)
@@ -393,8 +393,8 @@ private:
 
             case FormatSpecifier::Alignment::Center:
             {
-                const std::size_t left_padding = padding_size / 2;
-                const std::size_t right_padding =
+                std::size_t const left_padding = padding_size / 2;
+                std::size_t const right_padding =
                     (padding_size % 2 == 0) ? left_padding : left_padding + 1;
 
                 append_padding(left_padding);
@@ -435,7 +435,7 @@ private:
         char *begin = s_buffer.data();
         char *end = begin + s_buffer.size();
 
-        const auto result = std::to_chars(begin, end, value, base);
+        auto const result = std::to_chars(begin, end, value, base);
 
         if ((m_type == FormatSpecifier::Type::Hex) && (m_case == FormatSpecifier::Case::Upper))
         {
@@ -447,7 +447,7 @@ private:
 
         if constexpr (fly::SameAs<string_type, std::string>)
         {
-            for (const char *it = begin; it != result.ptr; ++it)
+            for (char const *it = begin; it != result.ptr; ++it)
             {
                 *context.out()++ = *it;
             }
@@ -487,14 +487,14 @@ private:
         return digits;
     }
 
-    static constexpr const auto s_plus_sign = FLY_CHR(CharType, '+');
-    static constexpr const auto s_minus_sign = FLY_CHR(CharType, '-');
-    static constexpr const auto s_space = FLY_CHR(CharType, ' ');
-    static constexpr const auto s_zero = FLY_CHR(CharType, '0');
-    static constexpr const auto s_lower_b = FLY_CHR(CharType, 'b');
-    static constexpr const auto s_upper_b = FLY_CHR(CharType, 'B');
-    static constexpr const auto s_lower_x = FLY_CHR(CharType, 'x');
-    static constexpr const auto s_upper_x = FLY_CHR(CharType, 'X');
+    static constexpr auto const s_plus_sign = FLY_CHR(CharType, '+');
+    static constexpr auto const s_minus_sign = FLY_CHR(CharType, '-');
+    static constexpr auto const s_space = FLY_CHR(CharType, ' ');
+    static constexpr auto const s_zero = FLY_CHR(CharType, '0');
+    static constexpr auto const s_lower_b = FLY_CHR(CharType, 'b');
+    static constexpr auto const s_upper_b = FLY_CHR(CharType, 'B');
+    static constexpr auto const s_lower_x = FLY_CHR(CharType, 'x');
+    static constexpr auto const s_upper_x = FLY_CHR(CharType, 'X');
 };
 
 //==================================================================================================
@@ -521,7 +521,7 @@ struct Formatter<T, CharType> : public detail::BasicFormatSpecifier<CharType>
     template <typename FormatContext>
     void format(T value, FormatContext &context)
     {
-        const bool is_negative = std::signbit(value);
+        bool const is_negative = std::signbit(value);
         value = std::abs(value);
 
         std::size_t prefix_size = 0;
@@ -532,8 +532,8 @@ struct Formatter<T, CharType> : public detail::BasicFormatSpecifier<CharType>
             ++prefix_size;
         }
 
-        const int precision = static_cast<int>(FormatSpecifier::precision(context, 6));
-        const FloatConversionResult result = convert_value(value, precision);
+        int const precision = static_cast<int>(FormatSpecifier::precision(context, 6));
+        FloatConversionResult const result = convert_value(value, precision);
 
         auto append_prefix = [this, &is_negative, &context]() {
             if (is_negative)
@@ -600,12 +600,12 @@ struct Formatter<T, CharType> : public detail::BasicFormatSpecifier<CharType>
             }
         };
 
-        const std::size_t value_size = prefix_size + result.m_digits.size() +
+        std::size_t const value_size = prefix_size + result.m_digits.size() +
             result.m_exponent.size() + static_cast<std::size_t>(result.m_append_decimal) +
             result.m_zeroes_to_append;
-        const std::size_t width = FormatSpecifier::width(context, 0);
-        const std::size_t padding_size = std::max(value_size, width) - value_size;
-        const auto padding_char = m_fill.value_or(s_space);
+        std::size_t const width = FormatSpecifier::width(context, 0);
+        std::size_t const padding_size = std::max(value_size, width) - value_size;
+        auto const padding_char = m_fill.value_or(s_space);
 
         switch (m_alignment)
         {
@@ -623,8 +623,8 @@ struct Formatter<T, CharType> : public detail::BasicFormatSpecifier<CharType>
 
             case FormatSpecifier::Alignment::Center:
             {
-                const std::size_t left_padding = padding_size / 2;
-                const std::size_t right_padding =
+                std::size_t const left_padding = padding_size / 2;
+                std::size_t const right_padding =
                     (padding_size % 2 == 0) ? left_padding : left_padding + 1;
 
                 append_padding(left_padding, padding_char);
@@ -798,7 +798,7 @@ private:
                 break;
         }
 
-        const auto to_chars_result = std::to_chars(begin, end, value, fmt, precision);
+        auto const to_chars_result = std::to_chars(begin, end, value, fmt, precision);
 
         FloatConversionResult conversion_result;
         conversion_result.m_digits =
@@ -808,7 +808,7 @@ private:
         {
             conversion_result.m_append_decimal = true;
 
-            for (const char *it = begin; it != to_chars_result.ptr; ++it)
+            for (char const *it = begin; it != to_chars_result.ptr; ++it)
             {
                 if (*it == '.')
                 {
@@ -816,7 +816,7 @@ private:
                 }
                 else if (*it == exponent)
                 {
-                    const auto position = static_cast<std::size_t>(it - begin);
+                    auto const position = static_cast<std::size_t>(it - begin);
 
                     conversion_result.m_exponent = conversion_result.m_digits.substr(position);
                     conversion_result.m_digits = conversion_result.m_digits.substr(0, position);
@@ -825,7 +825,7 @@ private:
 
             if (m_type == FormatSpecifier::Type::General)
             {
-                const auto digits = conversion_result.m_digits.size() -
+                auto const digits = conversion_result.m_digits.size() -
                     static_cast<std::size_t>(!conversion_result.m_append_decimal);
 
                 if (static_cast<std::size_t>(precision) > digits)
@@ -849,10 +849,10 @@ private:
 
 #endif // FLY_COMPILER_SUPPORTS_FP_CHARCONV
 
-    static constexpr const auto s_plus_sign = FLY_CHR(CharType, '+');
-    static constexpr const auto s_minus_sign = FLY_CHR(CharType, '-');
-    static constexpr const auto s_space = FLY_CHR(CharType, ' ');
-    static constexpr const auto s_zero = FLY_CHR(CharType, '0');
+    static constexpr auto const s_plus_sign = FLY_CHR(CharType, '+');
+    static constexpr auto const s_minus_sign = FLY_CHR(CharType, '-');
+    static constexpr auto const s_space = FLY_CHR(CharType, ' ');
+    static constexpr auto const s_zero = FLY_CHR(CharType, '0');
 };
 
 //==================================================================================================
@@ -885,8 +885,8 @@ struct Formatter<T, CharType> : public detail::BasicFormatSpecifier<CharType>
     }
 
 private:
-    static constexpr const CharType *s_true = FLY_STR(CharType, "true");
-    static constexpr const CharType *s_false = FLY_STR(CharType, "false");
+    static constexpr CharType const *s_true = FLY_STR(CharType, "true");
+    static constexpr CharType const *s_false = FLY_STR(CharType, "false");
 };
 
 } // namespace fly

--- a/fly/types/string/lexer.hpp
+++ b/fly/types/string/lexer.hpp
@@ -42,7 +42,7 @@ public:
      * @param literals Reference to a C-string literal of size N.
      */
     template <std::size_t N>
-    constexpr explicit BasicLexer(const CharType (&literals)[N]) noexcept;
+    constexpr explicit BasicLexer(CharType const (&literals)[N]) noexcept;
 
     /**
      * Constructor. Stores an existing view into a string.
@@ -135,14 +135,14 @@ private:
     template <typename Condition>
     constexpr std::optional<CharType> consume_if(Condition condition);
 
-    static constexpr const auto s_zero = FLY_CHR(CharType, '0');
-    static constexpr const auto s_upper_a = FLY_CHR(CharType, 'A');
-    static constexpr const auto s_upper_f = FLY_CHR(CharType, 'F');
-    static constexpr const auto s_lower_a = FLY_CHR(CharType, 'a');
-    static constexpr const auto s_lower_f = FLY_CHR(CharType, 'f');
+    static constexpr auto const s_zero = FLY_CHR(CharType, '0');
+    static constexpr auto const s_upper_a = FLY_CHR(CharType, 'A');
+    static constexpr auto const s_upper_f = FLY_CHR(CharType, 'F');
+    static constexpr auto const s_lower_a = FLY_CHR(CharType, 'a');
+    static constexpr auto const s_lower_f = FLY_CHR(CharType, 'f');
 
-    const std::size_t m_size;
-    const view_type m_view;
+    std::size_t const m_size;
+    view_type const m_view;
 
     std::size_t m_index {0};
 };
@@ -150,7 +150,7 @@ private:
 //==================================================================================================
 template <StandardCharacter CharType>
 template <std::size_t N>
-constexpr BasicLexer<CharType>::BasicLexer(const CharType (&literals)[N]) noexcept :
+constexpr BasicLexer<CharType>::BasicLexer(CharType const (&literals)[N]) noexcept :
     m_size(classifier::size(literals)),
     m_view(literals, m_size)
 {

--- a/fly/types/string/literals.hpp
+++ b/fly/types/string/literals.hpp
@@ -39,7 +39,7 @@ template <>
 struct BasicCharacterLiteral<char>
 {
     static constexpr auto
-    value(const char ch, const wchar_t, const char8_t, const char16_t, const char32_t)
+    value(char const ch, wchar_t const, char8_t const, char16_t const, char32_t const)
     {
         return ch;
     }
@@ -50,7 +50,7 @@ template <>
 struct BasicCharacterLiteral<wchar_t>
 {
     static constexpr auto
-    value(const char, const wchar_t ch, const char8_t, const char16_t, const char32_t)
+    value(char const, wchar_t const ch, char8_t const, char16_t const, char32_t const)
     {
         return ch;
     }
@@ -61,7 +61,7 @@ template <>
 struct BasicCharacterLiteral<char8_t>
 {
     static constexpr auto
-    value(const char, const wchar_t, const char8_t ch, const char16_t, const char32_t)
+    value(char const, wchar_t const, char8_t const ch, char16_t const, char32_t const)
     {
         return ch;
     }
@@ -72,7 +72,7 @@ template <>
 struct BasicCharacterLiteral<char16_t>
 {
     static constexpr auto
-    value(const char, const wchar_t, const char8_t, const char16_t ch, const char32_t)
+    value(char const, wchar_t const, char8_t const, char16_t const ch, char32_t const)
     {
         return ch;
     }
@@ -83,7 +83,7 @@ template <>
 struct BasicCharacterLiteral<char32_t>
 {
     static constexpr auto
-    value(const char, const wchar_t, const char8_t, const char16_t, const char32_t ch)
+    value(char const, wchar_t const, char8_t const, char16_t const, char32_t const ch)
     {
         return ch;
     }
@@ -94,7 +94,7 @@ template <>
 struct BasicStringLiteral<char>
 {
     static constexpr auto
-    value(const char *str, const wchar_t *, const char8_t *, const char16_t *, const char32_t *)
+    value(char const *str, wchar_t const *, char8_t const *, char16_t const *, char32_t const *)
     {
         return str;
     }
@@ -105,7 +105,7 @@ template <>
 struct BasicStringLiteral<wchar_t>
 {
     static constexpr auto
-    value(const char *, const wchar_t *str, const char8_t *, const char16_t *, const char32_t *)
+    value(char const *, wchar_t const *str, char8_t const *, char16_t const *, char32_t const *)
     {
         return str;
     }
@@ -116,7 +116,7 @@ template <>
 struct BasicStringLiteral<char8_t>
 {
     static constexpr auto
-    value(const char *, const wchar_t *, const char8_t *str, const char16_t *, const char32_t *)
+    value(char const *, wchar_t const *, char8_t const *str, char16_t const *, char32_t const *)
     {
         return str;
     }
@@ -127,7 +127,7 @@ template <>
 struct BasicStringLiteral<char16_t>
 {
     static constexpr auto
-    value(const char *, const wchar_t *, const char8_t *, const char16_t *str, const char32_t *)
+    value(char const *, wchar_t const *, char8_t const *, char16_t const *str, char32_t const *)
     {
         return str;
     }
@@ -138,7 +138,7 @@ template <>
 struct BasicStringLiteral<char32_t>
 {
     static constexpr auto
-    value(const char *, const wchar_t *, const char8_t *, const char16_t *, const char32_t *str)
+    value(char const *, wchar_t const *, char8_t const *, char16_t const *, char32_t const *str)
     {
         return str;
     }
@@ -150,11 +150,11 @@ struct BasicStringArray<char>
 {
     template <std::size_t N>
     static constexpr auto value(
-        const char (&arr)[N],
-        const wchar_t (&)[N],
-        const char8_t (&)[N],
-        const char16_t (&)[N],
-        const char32_t (&)[N]) -> decltype(arr)
+        char const (&arr)[N],
+        wchar_t const (&)[N],
+        char8_t const (&)[N],
+        char16_t const (&)[N],
+        char32_t const (&)[N]) -> decltype(arr)
     {
         return arr;
     }
@@ -166,11 +166,11 @@ struct BasicStringArray<wchar_t>
 {
     template <std::size_t N>
     static constexpr auto value(
-        const char (&)[N],
-        const wchar_t (&arr)[N],
-        const char8_t (&)[N],
-        const char16_t (&)[N],
-        const char32_t (&)[N]) -> decltype(arr)
+        char const (&)[N],
+        wchar_t const (&arr)[N],
+        char8_t const (&)[N],
+        char16_t const (&)[N],
+        char32_t const (&)[N]) -> decltype(arr)
     {
         return arr;
     }
@@ -182,11 +182,11 @@ struct BasicStringArray<char8_t>
 {
     template <std::size_t N>
     static constexpr auto value(
-        const char (&)[N],
-        const wchar_t (&)[N],
-        const char8_t (&arr)[N],
-        const char16_t (&)[N],
-        const char32_t (&)[N]) -> decltype(arr)
+        char const (&)[N],
+        wchar_t const (&)[N],
+        char8_t const (&arr)[N],
+        char16_t const (&)[N],
+        char32_t const (&)[N]) -> decltype(arr)
     {
         return arr;
     }
@@ -198,11 +198,11 @@ struct BasicStringArray<char16_t>
 {
     template <std::size_t N>
     static constexpr auto value(
-        const char (&)[N],
-        const wchar_t (&)[N],
-        const char8_t (&)[N],
-        const char16_t (&arr)[N],
-        const char32_t (&)[N]) -> decltype(arr)
+        char const (&)[N],
+        wchar_t const (&)[N],
+        char8_t const (&)[N],
+        char16_t const (&arr)[N],
+        char32_t const (&)[N]) -> decltype(arr)
     {
         return arr;
     }
@@ -214,11 +214,11 @@ struct BasicStringArray<char32_t>
 {
     template <std::size_t N>
     static constexpr auto value(
-        const char (&)[N],
-        const wchar_t (&)[N],
-        const char8_t (&)[N],
-        const char16_t (&)[N],
-        const char32_t (&arr)[N]) -> decltype(arr)
+        char const (&)[N],
+        wchar_t const (&)[N],
+        char8_t const (&)[N],
+        char16_t const (&)[N],
+        char32_t const (&arr)[N]) -> decltype(arr)
     {
         return arr;
     }

--- a/fly/types/string/string.hpp
+++ b/fly/types/string/string.hpp
@@ -275,7 +275,7 @@ public:
      */
     template <typename IteratorType>
     static std::optional<codepoint_type>
-    decode_codepoint(IteratorType &it, const IteratorType &end);
+    decode_codepoint(IteratorType &it, IteratorType const &end);
 
     /**
      * Encode a single Unicode codepoint.
@@ -345,7 +345,7 @@ public:
      */
     template <char UnicodePrefix = 'U', typename IteratorType>
     requires fly::UnicodePrefixCharacter<UnicodePrefix>
-    static std::optional<string_type> escape_codepoint(IteratorType &it, const IteratorType &end);
+    static std::optional<string_type> escape_codepoint(IteratorType &it, IteratorType const &end);
 
     /**
      * Unescape all Unicode codepoints in a string.
@@ -383,7 +383,7 @@ public:
      *         uninitialized value.
      */
     template <typename IteratorType>
-    static std::optional<string_type> unescape_codepoint(IteratorType &it, const IteratorType &end);
+    static std::optional<string_type> unescape_codepoint(IteratorType &it, IteratorType const &end);
 
     /**
      * Generate a random string of the given length.
@@ -445,7 +445,7 @@ public:
      *     struct fly::Formatter<MyType, CharType> : public fly::Formatter<int, CharType>
      *     {
      *         template <typename FormatContext>
-     *         void format(const MyType &value, FormatContext &context)
+     *         void format(MyType const &value, FormatContext &context)
      *         {
      *             fly::Formatter<int, CharType>::format(value.as_int(), context);
      *         }
@@ -472,7 +472,7 @@ public:
      *         }
      *
      *         template <typename FormatContext>
-     *         void format(const MyType &value, FormatContext &context)
+     *         void format(MyType const &value, FormatContext &context)
      *         {
      *             fly::BasicString<CharType>::format_to(context.out(), "{}", value.as_int());
      *         }
@@ -550,7 +550,7 @@ public:
      *         value.
      */
     template <typename T>
-    static std::optional<T> convert(const string_type &value);
+    static std::optional<T> convert(string_type const &value);
 
 private:
     /**
@@ -568,14 +568,14 @@ private:
     /**
      * A list of alpha-numeric characters in the range [0-9A-Za-z].
      */
-    static constexpr const char_type *s_alpha_num =
+    static constexpr char_type const *s_alpha_num =
         FLY_STR(char_type, "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz");
 
     static constexpr size_type s_alpha_num_length =
         std::char_traits<char_type>::length(s_alpha_num);
 
-    static constexpr const auto s_left_brace = FLY_CHR(char_type, '{');
-    static constexpr const auto s_right_brace = FLY_CHR(char_type, '}');
+    static constexpr auto const s_left_brace = FLY_CHR(char_type, '{');
+    static constexpr auto const s_right_brace = FLY_CHR(char_type, '}');
 };
 
 //==================================================================================================
@@ -745,7 +745,7 @@ bool BasicString<CharType>::wildcard_match(view_type source, view_type search)
     static constexpr char_type s_wildcard = '*';
     bool result = !search.empty();
 
-    const std::vector<string_type> segments = split(search, s_wildcard);
+    std::vector<string_type> const segments = split(search, s_wildcard);
     size_type index = 0;
 
     if (!segments.empty())
@@ -778,7 +778,7 @@ template <StandardCharacter CharType>
 inline bool BasicString<CharType>::validate(view_type value)
 {
     auto it = value.cbegin();
-    const auto end = value.cend();
+    auto const end = value.cend();
 
     return unicode::validate_encoding(it, end);
 }
@@ -786,7 +786,7 @@ inline bool BasicString<CharType>::validate(view_type value)
 //==================================================================================================
 template <StandardCharacter CharType>
 template <typename IteratorType>
-inline auto BasicString<CharType>::decode_codepoint(IteratorType &it, const IteratorType &end)
+inline auto BasicString<CharType>::decode_codepoint(IteratorType &it, IteratorType const &end)
     -> std::optional<codepoint_type>
 {
     return unicode::decode_codepoint(it, end);
@@ -809,7 +809,7 @@ auto BasicString<CharType>::escape_all_codepoints(view_type value) -> std::optio
     string_type result;
     result.reserve(value.size());
 
-    const auto end = value.cend();
+    auto const end = value.cend();
 
     for (auto it = value.cbegin(); it != end;)
     {
@@ -830,7 +830,7 @@ auto BasicString<CharType>::escape_all_codepoints(view_type value) -> std::optio
 template <StandardCharacter CharType>
 template <char UnicodePrefix, typename IteratorType>
 requires fly::UnicodePrefixCharacter<UnicodePrefix>
-inline auto BasicString<CharType>::escape_codepoint(IteratorType &it, const IteratorType &end)
+inline auto BasicString<CharType>::escape_codepoint(IteratorType &it, IteratorType const &end)
     -> std::optional<string_type>
 {
     return unicode::template escape_codepoint<UnicodePrefix>(it, end);
@@ -843,7 +843,7 @@ auto BasicString<CharType>::unescape_all_codepoints(view_type value) -> std::opt
     string_type result;
     result.reserve(value.size());
 
-    const auto end = value.cend();
+    auto const end = value.cend();
 
     for (auto it = value.cbegin(); it != end;)
     {
@@ -883,7 +883,7 @@ auto BasicString<CharType>::unescape_all_codepoints(view_type value) -> std::opt
 //==================================================================================================
 template <StandardCharacter CharType>
 template <typename IteratorType>
-inline auto BasicString<CharType>::unescape_codepoint(IteratorType &it, const IteratorType &end)
+inline auto BasicString<CharType>::unescape_codepoint(IteratorType &it, IteratorType const &end)
     -> std::optional<string_type>
 {
     return unicode::unescape_codepoint(it, end);
@@ -898,8 +898,8 @@ auto BasicString<CharType>::generate_random_string(size_type length) -> string_t
     constexpr auto limit = static_cast<short_distribution::result_type>(s_alpha_num_length - 1);
     static_assert(limit > 0);
 
-    static thread_local const auto s_now = std::chrono::system_clock::now().time_since_epoch();
-    static thread_local const auto s_seed = static_cast<std::mt19937::result_type>(s_now.count());
+    static thread_local auto const s_now = std::chrono::system_clock::now().time_since_epoch();
+    static thread_local auto const s_seed = static_cast<std::mt19937::result_type>(s_now.count());
 
     static thread_local std::mt19937 s_engine(s_seed);
     short_distribution distribution(0, limit);
@@ -945,7 +945,7 @@ void BasicString<CharType>::format_to(
     using FormatParseContext = detail::BasicFormatParseContext<char_type>;
 
     FormatParseContext &parse_context = fmt.context();
-    const view_type view = parse_context.view();
+    view_type const view = parse_context.view();
 
     if (parse_context.has_error())
     {
@@ -963,7 +963,7 @@ void BasicString<CharType>::format_to(
 
     for (std::size_t pos = 0; pos < view.size();)
     {
-        switch (const auto &ch = view[pos])
+        switch (auto const &ch = view[pos])
         {
             case s_left_brace:
                 if (view[pos + 1] == s_left_brace)
@@ -976,7 +976,7 @@ void BasicString<CharType>::format_to(
                     auto specifier = *std::move(fmt.next_specifier());
                     pos += specifier.m_size;
 
-                    const auto parameter = context.arg(specifier.m_position);
+                    auto const parameter = context.arg(specifier.m_position);
                     parameter.format(parse_context, context, std::move(specifier));
                 }
                 break;
@@ -1029,7 +1029,7 @@ inline void BasicString<CharType>::join_internal(string_type &result, char_type,
 //==================================================================================================
 template <StandardCharacter CharType>
 template <typename T>
-std::optional<T> BasicString<CharType>::convert(const string_type &value)
+std::optional<T> BasicString<CharType>::convert(string_type const &value)
 {
     if constexpr (StandardString<T>)
     {

--- a/test/coders/base64_coder.cpp
+++ b/test/coders/base64_coder.cpp
@@ -10,7 +10,7 @@
 namespace {
 
 // This must match the size of fly::coders::Base64Coder::m_encoded
-constexpr const std::size_t s_large_string_size = 256 << 10;
+constexpr std::size_t s_large_string_size = 256 << 10;
 
 } // namespace
 
@@ -20,7 +20,7 @@ CATCH_TEST_CASE("Base64", "[coders]")
 
     CATCH_SECTION("Encode and decode empty stream")
     {
-        const std::string raw;
+        std::string const raw;
         std::string enc, dec;
 
         CATCH_REQUIRE(coder.encode_string(raw, enc));
@@ -32,7 +32,7 @@ CATCH_TEST_CASE("Base64", "[coders]")
 
     CATCH_SECTION("Encode and decode a stream without padding")
     {
-        const std::string raw = "Man";
+        std::string const raw = "Man";
         std::string enc, dec;
 
         CATCH_REQUIRE(coder.encode_string(raw, enc));
@@ -44,7 +44,7 @@ CATCH_TEST_CASE("Base64", "[coders]")
 
     CATCH_SECTION("Encode and decode a stream with one padding symbol")
     {
-        const std::string raw = "Ma";
+        std::string const raw = "Ma";
         std::string enc, dec;
 
         CATCH_REQUIRE(coder.encode_string(raw, enc));
@@ -56,7 +56,7 @@ CATCH_TEST_CASE("Base64", "[coders]")
 
     CATCH_SECTION("Encode and decode a stream with two padding symbols")
     {
-        const std::string raw = "M";
+        std::string const raw = "M";
         std::string enc, dec;
 
         CATCH_REQUIRE(coder.encode_string(raw, enc));
@@ -77,8 +77,8 @@ CATCH_TEST_CASE("Base64", "[coders]")
                 continue;
             }
 
-            const std::string test(1, ch);
-            const std::string fill("a");
+            std::string const test(1, ch);
+            std::string const fill("a");
 
             CATCH_CHECK_FALSE(coder.decode_string(test + test + test + test, dec));
             CATCH_CHECK_FALSE(coder.decode_string(test + test + test + fill, dec));
@@ -131,7 +131,7 @@ CATCH_TEST_CASE("Base64", "[coders]")
 
     CATCH_SECTION("Example from Wikipedia: https://en.wikipedia.org/wiki/Base64#Examples")
     {
-        const std::string raw =
+        std::string const raw =
             "Man is distinguished, not only by his reason, but by this singular passion from other "
             "animals, which is a lust of the mind, that by a perseverance of delight in the "
             "continued and indefatigable generation of knowledge, exceeds the short vehemence of "
@@ -141,7 +141,7 @@ CATCH_TEST_CASE("Base64", "[coders]")
         CATCH_REQUIRE(coder.encode_string(raw, enc));
         CATCH_REQUIRE(coder.decode_string(enc, dec));
 
-        const std::string expected =
+        std::string const expected =
             "TWFuIGlzIGRpc3Rpbmd1aXNoZWQsIG5vdCBvbmx5IGJ5IGhpcyByZWFzb24sIGJ1dCBieSB0aGlzIHNpbmd1bG"
             "FyIHBhc3Npb24gZnJvbSBvdGhlciBhbmltYWxzLCB3aGljaCBpcyBhIGx1c3Qgb2YgdGhlIG1pbmQsIHRoYXQg"
             "YnkgYSBwZXJzZXZlcmFuY2Ugb2YgZGVsaWdodCBpbiB0aGUgY29udGludWVkIGFuZCBpbmRlZmF0aWdhYmxlIG"
@@ -162,15 +162,15 @@ CATCH_TEST_CASE("Base64", "[coders]")
         {
             // Generated with:
             // tr -dc '[:graph:]' </dev/urandom | head -c 4194304 > test.txt
-            const auto here = std::filesystem::path(__FILE__).parent_path();
-            const auto raw = here / "data" / "test.txt";
+            auto const here = std::filesystem::path(__FILE__).parent_path();
+            auto const raw = here / "data" / "test.txt";
 
             CATCH_REQUIRE(coder.encode_file(raw, encoded_file));
             CATCH_REQUIRE(coder.decode_file(encoded_file, decoded_file));
 
             // Generated with:
             // base64 -w0 test.txt > test.txt.base64
-            const auto expected = here / "data" / "test.txt.base64";
+            auto const expected = here / "data" / "test.txt.base64";
 
             CATCH_CHECK(fly::test::PathUtil::compare_files(encoded_file, expected));
             CATCH_CHECK(fly::test::PathUtil::compare_files(raw, decoded_file));
@@ -178,15 +178,15 @@ CATCH_TEST_CASE("Base64", "[coders]")
 
         CATCH_SECTION("Encode and decode a PNG image file")
         {
-            const auto here = std::filesystem::path(__FILE__).parent_path();
-            const auto raw = here / "data" / "test.png";
+            auto const here = std::filesystem::path(__FILE__).parent_path();
+            auto const raw = here / "data" / "test.png";
 
             CATCH_REQUIRE(coder.encode_file(raw, encoded_file));
             CATCH_REQUIRE(coder.decode_file(encoded_file, decoded_file));
 
             // Generated with:
             // base64 -w0 test.png > test.png.base64
-            const auto expected = here / "data" / "test.png.base64";
+            auto const expected = here / "data" / "test.png.base64";
 
             CATCH_CHECK(fly::test::PathUtil::compare_files(encoded_file, expected));
             CATCH_CHECK(fly::test::PathUtil::compare_files(raw, decoded_file));
@@ -194,15 +194,15 @@ CATCH_TEST_CASE("Base64", "[coders]")
 
         CATCH_SECTION("Encode and decode a GIF image file")
         {
-            const auto here = std::filesystem::path(__FILE__).parent_path();
-            const auto raw = here / "data" / "test.gif";
+            auto const here = std::filesystem::path(__FILE__).parent_path();
+            auto const raw = here / "data" / "test.gif";
 
             CATCH_REQUIRE(coder.encode_file(raw, encoded_file));
             CATCH_REQUIRE(coder.decode_file(encoded_file, decoded_file));
 
             // Generated with:
             // base64 -w0 test.gif > test.gif.base64
-            const auto expected = here / "data" / "test.gif.base64";
+            auto const expected = here / "data" / "test.gif.base64";
 
             CATCH_CHECK(fly::test::PathUtil::compare_files(encoded_file, expected));
             CATCH_CHECK(fly::test::PathUtil::compare_files(raw, decoded_file));

--- a/test/coders/huffman_coder.cpp
+++ b/test/coders/huffman_coder.cpp
@@ -25,7 +25,8 @@ namespace {
 class BadCoderConfig : public fly::coders::CoderConfig
 {
 public:
-    BadCoderConfig() noexcept : fly::coders::CoderConfig()
+    BadCoderConfig() noexcept :
+        fly::coders::CoderConfig()
     {
         m_default_huffman_encoder_max_code_length =
             std::numeric_limits<decltype(m_default_huffman_encoder_max_code_length)>::max();
@@ -38,7 +39,8 @@ public:
 class SmallCodeLengthConfig : public fly::coders::CoderConfig
 {
 public:
-    SmallCodeLengthConfig() noexcept : fly::coders::CoderConfig()
+    SmallCodeLengthConfig() noexcept :
+        fly::coders::CoderConfig()
     {
         m_default_huffman_encoder_max_code_length = 3;
     }
@@ -53,7 +55,7 @@ create_stream_with_remainder(std::vector<fly::byte_type> bytes, fly::byte_type r
     std::ostringstream stream(std::ios::out | std::ios::binary);
     fly::BitStreamWriter output(stream);
 
-    for (const fly::byte_type &byte : bytes)
+    for (fly::byte_type const &byte : bytes)
     {
         output.write_byte(byte);
     }
@@ -85,7 +87,7 @@ CATCH_TEST_CASE("Huffman", "[coders]")
 
     CATCH_SECTION("Cannot encode stream using an invalid configuration")
     {
-        const std::string raw;
+        std::string const raw;
         std::string enc;
 
         config = std::make_shared<BadCoderConfig>();
@@ -96,7 +98,7 @@ CATCH_TEST_CASE("Huffman", "[coders]")
 
     CATCH_SECTION("Cannot decode stream missing the encoder's version")
     {
-        const std::string enc;
+        std::string const enc;
         std::string dec;
 
         CATCH_CHECK_FALSE(decoder.decode_string(enc, dec));
@@ -108,7 +110,7 @@ CATCH_TEST_CASE("Huffman", "[coders]")
             0_u8, // Version
         };
 
-        const std::string enc = create_stream(std::move(bytes));
+        std::string const enc = create_stream(std::move(bytes));
         std::string dec;
 
         CATCH_CHECK_FALSE(enc.empty());
@@ -121,7 +123,7 @@ CATCH_TEST_CASE("Huffman", "[coders]")
             1_u8, // Version
         };
 
-        const std::string enc = create_stream(std::move(bytes));
+        std::string const enc = create_stream(std::move(bytes));
         std::string dec;
 
         CATCH_CHECK_FALSE(enc.empty());
@@ -136,7 +138,7 @@ CATCH_TEST_CASE("Huffman", "[coders]")
             0_u8, // Chunk size KB (low)
         };
 
-        const std::string enc = create_stream(std::move(bytes));
+        std::string const enc = create_stream(std::move(bytes));
         std::string dec;
 
         CATCH_CHECK_FALSE(enc.empty());
@@ -151,7 +153,7 @@ CATCH_TEST_CASE("Huffman", "[coders]")
             1_u8, // Chunk size KB (low)
         };
 
-        const std::string enc = create_stream(std::move(bytes));
+        std::string const enc = create_stream(std::move(bytes));
         std::string dec;
 
         CATCH_CHECK_FALSE(enc.empty());
@@ -167,7 +169,7 @@ CATCH_TEST_CASE("Huffman", "[coders]")
             0_u8, // Maximum Huffman code length
         };
 
-        const std::string enc = create_stream(std::move(bytes));
+        std::string const enc = create_stream(std::move(bytes));
         std::string dec;
 
         CATCH_CHECK_FALSE(enc.empty());
@@ -183,7 +185,7 @@ CATCH_TEST_CASE("Huffman", "[coders]")
             255_u8, // Maximum Huffman code length
         };
 
-        const std::string enc = create_stream(std::move(bytes));
+        std::string const enc = create_stream(std::move(bytes));
         std::string dec;
 
         CATCH_CHECK_FALSE(enc.empty());
@@ -199,7 +201,7 @@ CATCH_TEST_CASE("Huffman", "[coders]")
             4_u8, // Maximum Huffman code length
         };
 
-        const std::string enc = create_stream_with_remainder(std::move(bytes), 1_u8);
+        std::string const enc = create_stream_with_remainder(std::move(bytes), 1_u8);
         std::string dec;
 
         CATCH_CHECK_FALSE(enc.empty());
@@ -216,7 +218,7 @@ CATCH_TEST_CASE("Huffman", "[coders]")
             0_u8, // Number of code length counts
         };
 
-        const std::string enc = create_stream(std::move(bytes));
+        std::string const enc = create_stream(std::move(bytes));
         std::string dec;
 
         CATCH_CHECK_FALSE(enc.empty());
@@ -233,7 +235,7 @@ CATCH_TEST_CASE("Huffman", "[coders]")
             8_u8, // Number of code length counts
         };
 
-        const std::string enc = create_stream(std::move(bytes));
+        std::string const enc = create_stream(std::move(bytes));
         std::string dec;
 
         CATCH_CHECK_FALSE(enc.empty());
@@ -254,7 +256,7 @@ CATCH_TEST_CASE("Huffman", "[coders]")
 
         for (fly::byte_type i = 0; i < number_of_code_length_counts; ++i)
         {
-            const std::string enc = create_stream(bytes);
+            std::string const enc = create_stream(bytes);
             std::string dec;
 
             CATCH_CHECK_FALSE(enc.empty());
@@ -279,7 +281,7 @@ CATCH_TEST_CASE("Huffman", "[coders]")
             1_u8, // Code length count 2 (low)
         };
 
-        const std::string enc = create_stream(std::move(bytes));
+        std::string const enc = create_stream(std::move(bytes));
         std::string dec;
 
         CATCH_CHECK_FALSE(enc.empty());
@@ -305,7 +307,7 @@ CATCH_TEST_CASE("Huffman", "[coders]")
             bytes.push_back(1_u8);
         }
 
-        const std::string enc = create_stream(std::move(bytes));
+        std::string const enc = create_stream(std::move(bytes));
         std::string dec;
 
         CATCH_CHECK_FALSE(enc.empty());
@@ -325,7 +327,7 @@ CATCH_TEST_CASE("Huffman", "[coders]")
             0x41, // Single symbol (A)
         };
 
-        const std::string enc = create_stream_with_remainder(std::move(bytes), 1);
+        std::string const enc = create_stream_with_remainder(std::move(bytes), 1);
         std::string dec;
 
         CATCH_CHECK_FALSE(enc.empty());
@@ -334,7 +336,7 @@ CATCH_TEST_CASE("Huffman", "[coders]")
 
     CATCH_SECTION("Encode and decode empty stream")
     {
-        const std::string raw;
+        std::string const raw;
         std::string enc, dec;
 
         CATCH_REQUIRE(encoder.encode_string(raw, enc));
@@ -345,7 +347,7 @@ CATCH_TEST_CASE("Huffman", "[coders]")
 
     CATCH_SECTION("Encode and decode a stream with a single symbol")
     {
-        const std::string raw = "a";
+        std::string const raw = "a";
         std::string enc, dec;
 
         CATCH_REQUIRE(encoder.encode_string(raw, enc));
@@ -356,7 +358,7 @@ CATCH_TEST_CASE("Huffman", "[coders]")
 
     CATCH_SECTION("Encode and decode a stream with a single symbol repeated")
     {
-        const std::string raw = "aaaaaaaaaa";
+        std::string const raw = "aaaaaaaaaa";
         std::string enc, dec;
 
         CATCH_REQUIRE(encoder.encode_string(raw, enc));
@@ -367,7 +369,7 @@ CATCH_TEST_CASE("Huffman", "[coders]")
 
     CATCH_SECTION("Encode and decode a small stream")
     {
-        const std::string raw = "abcdefabcbbb";
+        std::string const raw = "abcdefabcbbb";
         std::string enc, dec;
 
         CATCH_REQUIRE(encoder.encode_string(raw, enc));
@@ -378,7 +380,7 @@ CATCH_TEST_CASE("Huffman", "[coders]")
 
     CATCH_SECTION("Encode and decode a large stream")
     {
-        const std::string raw = fly::String::generate_random_string(100 << 10);
+        std::string const raw = fly::String::generate_random_string(100 << 10);
         std::string enc, dec;
 
         CATCH_REQUIRE(encoder.encode_string(raw, enc));
@@ -390,7 +392,7 @@ CATCH_TEST_CASE("Huffman", "[coders]")
 
     CATCH_SECTION("Limit code lengths to a small value and validate the Kraft-McMillan inequality")
     {
-        const std::string raw = "abcdefabcbbb";
+        std::string const raw = "abcdefabcbbb";
         std::string enc, dec;
 
         config = std::make_shared<SmallCodeLengthConfig>();
@@ -401,7 +403,7 @@ CATCH_TEST_CASE("Huffman", "[coders]")
 
         CATCH_CHECK(raw == dec);
 
-        const auto max_allowed_kraft = (1_u16 << config->huffman_encoder_max_code_length()) - 1;
+        auto const max_allowed_kraft = (1_u16 << config->huffman_encoder_max_code_length()) - 1;
         CATCH_CHECK(decoder.compute_kraft_mcmillan_constant() <= max_allowed_kraft);
     }
 
@@ -432,8 +434,8 @@ CATCH_TEST_CASE("Huffman", "[coders]")
         {
             // Generated with:
             // tr -dc '[:graph:]' </dev/urandom | head -c 4194304 > test.txt
-            const auto here = std::filesystem::path(__FILE__).parent_path();
-            const auto raw = here / "data" / "test.txt";
+            auto const here = std::filesystem::path(__FILE__).parent_path();
+            auto const raw = here / "data" / "test.txt";
 
             CATCH_REQUIRE(encoder.encode_file(raw, encoded_file));
             CATCH_REQUIRE(decoder.decode_file(encoded_file, decoded_file));
@@ -446,8 +448,8 @@ CATCH_TEST_CASE("Huffman", "[coders]")
         {
             // Generated with:
             // dd if=/dev/urandom of=test.bin count=1 bs=4194304
-            const auto here = std::filesystem::path(__FILE__).parent_path();
-            const auto raw = here / "data" / "test.bin";
+            auto const here = std::filesystem::path(__FILE__).parent_path();
+            auto const raw = here / "data" / "test.bin";
 
             CATCH_REQUIRE(encoder.encode_file(raw, encoded_file));
             CATCH_REQUIRE(decoder.decode_file(encoded_file, decoded_file));

--- a/test/concepts/concepts.cpp
+++ b/test/concepts/concepts.cpp
@@ -25,9 +25,9 @@ CATCH_TEST_CASE("Concepts", "[concepts]")
     CATCH_SECTION("Concept: SameAs")
     {
         CATCH_CHECK(fly::SameAs<int, int>);
-        CATCH_CHECK(fly::SameAs<int, const int>);
-        CATCH_CHECK(fly::SameAs<const int, int>);
-        CATCH_CHECK(fly::SameAs<const int, const int>);
+        CATCH_CHECK(fly::SameAs<int, int const>);
+        CATCH_CHECK(fly::SameAs<int const, int>);
+        CATCH_CHECK(fly::SameAs<int const, int const>);
 
         CATCH_CHECK(fly::SameAs<int, int>);
         CATCH_CHECK(fly::SameAs<int, int &>);
@@ -35,9 +35,9 @@ CATCH_TEST_CASE("Concepts", "[concepts]")
         CATCH_CHECK(fly::SameAs<int &, int &>);
 
         CATCH_CHECK(fly::SameAs<int, int>);
-        CATCH_CHECK(fly::SameAs<int, const int &>);
-        CATCH_CHECK(fly::SameAs<const int &, int>);
-        CATCH_CHECK(fly::SameAs<const int &, const int &>);
+        CATCH_CHECK(fly::SameAs<int, int const &>);
+        CATCH_CHECK(fly::SameAs<int const &, int>);
+        CATCH_CHECK(fly::SameAs<int const &, int const &>);
 
         CATCH_CHECK_FALSE(fly::SameAs<int, char>);
         CATCH_CHECK_FALSE(fly::SameAs<int *, int>);
@@ -48,9 +48,9 @@ CATCH_TEST_CASE("Concepts", "[concepts]")
     CATCH_SECTION("Concept: SameAsAny")
     {
         CATCH_CHECK(fly::SameAsAny<int, int>);
-        CATCH_CHECK(fly::SameAsAny<int, const int>);
-        CATCH_CHECK(fly::SameAsAny<const int, int>);
-        CATCH_CHECK(fly::SameAsAny<const int, const int>);
+        CATCH_CHECK(fly::SameAsAny<int, int const>);
+        CATCH_CHECK(fly::SameAsAny<int const, int>);
+        CATCH_CHECK(fly::SameAsAny<int const, int const>);
 
         CATCH_CHECK(fly::SameAsAny<int, int>);
         CATCH_CHECK(fly::SameAsAny<int, int &>);
@@ -58,19 +58,19 @@ CATCH_TEST_CASE("Concepts", "[concepts]")
         CATCH_CHECK(fly::SameAsAny<int &, int &>);
 
         CATCH_CHECK(fly::SameAsAny<int, int>);
-        CATCH_CHECK(fly::SameAsAny<int, const int &>);
-        CATCH_CHECK(fly::SameAsAny<const int &, int>);
-        CATCH_CHECK(fly::SameAsAny<const int &, const int &>);
+        CATCH_CHECK(fly::SameAsAny<int, int const &>);
+        CATCH_CHECK(fly::SameAsAny<int const &, int>);
+        CATCH_CHECK(fly::SameAsAny<int const &, int const &>);
 
         CATCH_CHECK(fly::SameAsAny<int, int, int>);
-        CATCH_CHECK(fly::SameAsAny<int, int, const int>);
-        CATCH_CHECK(fly::SameAsAny<int, const int, int>);
-        CATCH_CHECK(fly::SameAsAny<int, const int, const int>);
+        CATCH_CHECK(fly::SameAsAny<int, int, int const>);
+        CATCH_CHECK(fly::SameAsAny<int, int const, int>);
+        CATCH_CHECK(fly::SameAsAny<int, int const, int const>);
 
-        CATCH_CHECK(fly::SameAsAny<const int, int, int>);
-        CATCH_CHECK(fly::SameAsAny<const int, int, const int>);
-        CATCH_CHECK(fly::SameAsAny<const int, const int, int>);
-        CATCH_CHECK(fly::SameAsAny<const int, const int, const int>);
+        CATCH_CHECK(fly::SameAsAny<int const, int, int>);
+        CATCH_CHECK(fly::SameAsAny<int const, int, int const>);
+        CATCH_CHECK(fly::SameAsAny<int const, int const, int>);
+        CATCH_CHECK(fly::SameAsAny<int const, int const, int const>);
 
         CATCH_CHECK(fly::SameAsAny<bool, bool, bool>);
         CATCH_CHECK(fly::SameAsAny<float, float, float, float>);
@@ -89,9 +89,9 @@ CATCH_TEST_CASE("Concepts", "[concepts]")
     CATCH_SECTION("Concept: SameAsAll")
     {
         CATCH_CHECK(fly::SameAsAll<int, int>);
-        CATCH_CHECK(fly::SameAsAll<int, const int>);
-        CATCH_CHECK(fly::SameAsAll<const int, int>);
-        CATCH_CHECK(fly::SameAsAll<const int, const int>);
+        CATCH_CHECK(fly::SameAsAll<int, int const>);
+        CATCH_CHECK(fly::SameAsAll<int const, int>);
+        CATCH_CHECK(fly::SameAsAll<int const, int const>);
 
         CATCH_CHECK(fly::SameAsAll<int, int>);
         CATCH_CHECK(fly::SameAsAll<int, int &>);
@@ -99,19 +99,19 @@ CATCH_TEST_CASE("Concepts", "[concepts]")
         CATCH_CHECK(fly::SameAsAll<int &, int &>);
 
         CATCH_CHECK(fly::SameAsAll<int, int>);
-        CATCH_CHECK(fly::SameAsAll<int, const int &>);
-        CATCH_CHECK(fly::SameAsAll<const int &, int>);
-        CATCH_CHECK(fly::SameAsAll<const int &, const int &>);
+        CATCH_CHECK(fly::SameAsAll<int, int const &>);
+        CATCH_CHECK(fly::SameAsAll<int const &, int>);
+        CATCH_CHECK(fly::SameAsAll<int const &, int const &>);
 
         CATCH_CHECK(fly::SameAsAll<int, int, int>);
-        CATCH_CHECK(fly::SameAsAll<int, int, const int>);
-        CATCH_CHECK(fly::SameAsAll<int, const int, int>);
-        CATCH_CHECK(fly::SameAsAll<int, const int, const int>);
+        CATCH_CHECK(fly::SameAsAll<int, int, int const>);
+        CATCH_CHECK(fly::SameAsAll<int, int const, int>);
+        CATCH_CHECK(fly::SameAsAll<int, int const, int const>);
 
-        CATCH_CHECK(fly::SameAsAll<const int, int, int>);
-        CATCH_CHECK(fly::SameAsAll<const int, int, const int>);
-        CATCH_CHECK(fly::SameAsAll<const int, const int, int>);
-        CATCH_CHECK(fly::SameAsAll<const int, const int, const int>);
+        CATCH_CHECK(fly::SameAsAll<int const, int, int>);
+        CATCH_CHECK(fly::SameAsAll<int const, int, int const>);
+        CATCH_CHECK(fly::SameAsAll<int const, int const, int>);
+        CATCH_CHECK(fly::SameAsAll<int const, int const, int const>);
 
         CATCH_CHECK(fly::SameAsAll<bool, bool, bool>);
         CATCH_CHECK(fly::SameAsAll<float, float, float, float>);
@@ -206,18 +206,18 @@ CATCH_TEST_CASE("Concepts", "[concepts]")
         CATCH_CHECK(fly::DerivedFrom<BazClass, BazClass>);
 
         CATCH_CHECK(fly::DerivedFrom<BazClass, FooClass>);
-        CATCH_CHECK(fly::DerivedFrom<BazClass, const FooClass &>);
+        CATCH_CHECK(fly::DerivedFrom<BazClass, FooClass const &>);
         CATCH_CHECK(fly::DerivedFrom<BazClass, FooClass &&>);
 
         CATCH_CHECK(fly::DerivedFrom<BazClass, FooClass>);
-        CATCH_CHECK(fly::DerivedFrom<const BazClass &, FooClass>);
+        CATCH_CHECK(fly::DerivedFrom<BazClass const &, FooClass>);
         CATCH_CHECK(fly::DerivedFrom<BazClass &&, FooClass>);
 
-        CATCH_CHECK(fly::DerivedFrom<const BazClass &, const FooClass &>);
+        CATCH_CHECK(fly::DerivedFrom<BazClass const &, FooClass const &>);
         CATCH_CHECK(fly::DerivedFrom<BazClass &&, FooClass &&>);
 
-        CATCH_CHECK(fly::DerivedFrom<const BazClass &, FooClass &&>);
-        CATCH_CHECK(fly::DerivedFrom<BazClass &&, const FooClass &>);
+        CATCH_CHECK(fly::DerivedFrom<BazClass const &, FooClass &&>);
+        CATCH_CHECK(fly::DerivedFrom<BazClass &&, FooClass const &>);
 
         CATCH_CHECK_FALSE(fly::DerivedFrom<BazClass, BarClass>);
         CATCH_CHECK_FALSE(fly::DerivedFrom<BarClass, FooClass>);

--- a/test/config/config.cpp
+++ b/test/config/config.cpp
@@ -20,7 +20,7 @@ CATCH_TEST_CASE("Config", "[config]")
 
     CATCH_SECTION("Values that can't convert to the desired type fallback to provided default")
     {
-        const fly::Json values = {{"name", "John Doe"}, {"address", "USA"}};
+        fly::Json const values = {{"name", "John Doe"}, {"address", "USA"}};
 
         config.update(values);
 
@@ -30,7 +30,7 @@ CATCH_TEST_CASE("Config", "[config]")
 
     CATCH_SECTION("Mixed conversion of value types")
     {
-        const fly::Json values =
+        fly::Json const values =
             {{"name", "John Doe"}, {"address", "123"}, {"employed", "1"}, {"age", "26.2"}};
 
         config.update(values);

--- a/test/config/config_manager.cpp
+++ b/test/config/config_manager.cpp
@@ -21,7 +21,7 @@ using namespace fly::literals::numeric_literals;
 
 namespace {
 
-constexpr const char *s_config_manager_file = "config_manager.cpp";
+constexpr char const *s_config_manager_file = "config_manager.cpp";
 
 /**
  * Subclass of the path config to decrease the poll interval for faster testing.
@@ -29,7 +29,8 @@ constexpr const char *s_config_manager_file = "config_manager.cpp";
 class TestPathConfig : public fly::path::PathConfig
 {
 public:
-    TestPathConfig() noexcept : fly::path::PathConfig()
+    TestPathConfig() noexcept :
+        fly::path::PathConfig()
     {
         m_default_poll_interval = 10_u64;
     }
@@ -41,7 +42,7 @@ public:
 class BadConfig : public fly::config::Config
 {
 public:
-    [[maybe_unused]] static constexpr const char *identifier = fly::test::TestConfig::identifier;
+    [[maybe_unused]] static constexpr char const *identifier = fly::test::TestConfig::identifier;
 };
 
 } // namespace
@@ -140,7 +141,7 @@ CATCH_TEST_CASE("ConfigManager", "[config]")
     {
         CATCH_CHECK(config_manager->prune() == initial_size);
 
-        const fly::Json json {
+        fly::Json const json {
             {fly::test::TestConfig::identifier, {{"name", "John Doe"}, {"address", "MA"}}}};
 
         CATCH_REQUIRE(fly::test::PathUtil::write_file(config_file, json.serialize()));
@@ -163,7 +164,7 @@ CATCH_TEST_CASE("ConfigManager", "[config]")
 
     CATCH_SECTION("Config manager respects file created before config object")
     {
-        const fly::Json json {
+        fly::Json const json {
             {fly::test::TestConfig::identifier, {{"name", "John Doe"}, {"address", "MA"}}}};
 
         CATCH_REQUIRE(fly::test::PathUtil::write_file(config_file, json.serialize()));
@@ -180,7 +181,7 @@ CATCH_TEST_CASE("ConfigManager", "[config]")
     {
         auto config = config_manager->create_config<fly::test::TestConfig>();
 
-        const fly::Json json {
+        fly::Json const json {
             {fly::test::TestConfig::identifier, {{"name", "John Doe"}, {"address", "MA"}}}};
 
         CATCH_REQUIRE(fly::test::PathUtil::write_file(config_file, json.serialize()));
@@ -195,7 +196,7 @@ CATCH_TEST_CASE("ConfigManager", "[config]")
     {
         auto config = config_manager->create_config<fly::test::TestConfig>();
 
-        const fly::Json json1 {
+        fly::Json const json1 {
             {fly::test::TestConfig::identifier, {{"name", "John Doe"}, {"address", "MA"}}}};
 
         CATCH_REQUIRE(fly::test::PathUtil::write_file(config_file, json1.serialize()));
@@ -206,7 +207,7 @@ CATCH_TEST_CASE("ConfigManager", "[config]")
         CATCH_CHECK(config->get_value<std::string>("address", "") == "MA");
         CATCH_CHECK(config->get_value<int>("age", -1) == -1);
 
-        const fly::Json json2 {
+        fly::Json const json2 {
             {fly::test::TestConfig::identifier, {{"name", "Jane Doe"}, {"age", 27}}}};
 
         CATCH_REQUIRE(fly::test::PathUtil::write_file(config_file, json2.serialize()));
@@ -228,7 +229,7 @@ CATCH_TEST_CASE("ConfigManager", "[config]")
     {
         auto config = config_manager->create_config<fly::test::TestConfig>();
 
-        const fly::Json json {
+        fly::Json const json {
             {fly::test::TestConfig::identifier, {{"name", "John Doe"}, {"address", "MA"}}}};
 
         CATCH_REQUIRE(fly::test::PathUtil::write_file(config_file, json.serialize()));
@@ -249,7 +250,7 @@ CATCH_TEST_CASE("ConfigManager", "[config]")
     {
         auto config = config_manager->create_config<fly::test::TestConfig>();
 
-        const std::string contents(" ");
+        std::string const contents(" ");
 
         CATCH_REQUIRE(fly::test::PathUtil::write_file(config_file, contents));
         task_runner->wait_for_task_to_complete(s_config_manager_file);
@@ -263,7 +264,7 @@ CATCH_TEST_CASE("ConfigManager", "[config]")
     {
         auto config = config_manager->create_config<fly::test::TestConfig>();
 
-        const std::string contents("[1, 2, 3]");
+        std::string const contents("[1, 2, 3]");
 
         CATCH_REQUIRE(fly::test::PathUtil::write_file(config_file, contents));
         task_runner->wait_for_task_to_complete(s_config_manager_file);

--- a/test/config/test_config.hpp
+++ b/test/config/test_config.hpp
@@ -14,15 +14,15 @@ namespace fly::test {
 class TestConfig : public fly::config::Config
 {
 public:
-    static constexpr const char *identifier = "config";
+    static constexpr char const *identifier = "config";
 
     template <typename T>
-    T get_value(const std::string &name, T def) const
+    T get_value(std::string const &name, T def) const
     {
         return fly::config::Config::get_value(name, def);
     }
 
-    void update(const fly::Json &values)
+    void update(fly::Json const &values)
     {
         fly::config::Config::update(values);
     }

--- a/test/fly.cpp
+++ b/test/fly.cpp
@@ -8,14 +8,14 @@ CATCH_TEST_CASE("Fly", "[fly]")
 {
     CATCH_SECTION("Stringize helper")
     {
-        const std::string s = FLY_STRINGIZE(libfly);
+        std::string const s = FLY_STRINGIZE(libfly);
         CATCH_CHECK(s == "libfly");
     }
 
     CATCH_SECTION("Operating system-dependent headers")
     {
         static_assert(fly::is_linux() || fly::is_macos() || fly::is_windows());
-        const std::string header = FLY_OS_IMPL_PATH(libfly, fly);
+        std::string const header = FLY_OS_IMPL_PATH(libfly, fly);
 
         if constexpr (fly::is_linux())
         {

--- a/test/logger/console_logger.cpp
+++ b/test/logger/console_logger.cpp
@@ -19,7 +19,7 @@ CATCH_TEST_CASE("ConsoleLogger", "[logger]")
         fly::test::CaptureStream capture(fly::test::CaptureStream::Stream::Stdout);
         logger->debug("Debug Log");
 
-        const std::string contents = capture();
+        std::string const contents = capture();
         CATCH_REQUIRE_FALSE(contents.empty());
 
         CATCH_CHECK(contents.find("Debug Log") != std::string::npos);
@@ -30,7 +30,7 @@ CATCH_TEST_CASE("ConsoleLogger", "[logger]")
         fly::test::CaptureStream capture(fly::test::CaptureStream::Stream::Stdout);
         logger->info("Info Log");
 
-        const std::string contents = capture();
+        std::string const contents = capture();
         CATCH_REQUIRE_FALSE(contents.empty());
 
         CATCH_CHECK(contents.find("Info Log") != std::string::npos);
@@ -41,7 +41,7 @@ CATCH_TEST_CASE("ConsoleLogger", "[logger]")
         fly::test::CaptureStream capture(fly::test::CaptureStream::Stream::Stderr);
         logger->warn("Warning Log");
 
-        const std::string contents = capture();
+        std::string const contents = capture();
         CATCH_REQUIRE_FALSE(contents.empty());
 
         CATCH_CHECK(contents.find("Warning Log") != std::string::npos);
@@ -52,7 +52,7 @@ CATCH_TEST_CASE("ConsoleLogger", "[logger]")
         fly::test::CaptureStream capture(fly::test::CaptureStream::Stream::Stderr);
         logger->error("Error Log");
 
-        const std::string contents = capture();
+        std::string const contents = capture();
         CATCH_REQUIRE_FALSE(contents.empty());
 
         CATCH_CHECK(contents.find("Error Log") != std::string::npos);
@@ -62,7 +62,7 @@ CATCH_TEST_CASE("ConsoleLogger", "[logger]")
     CATCH_SECTION("Validate style of console logs")
     {
         // Get the substring of a log point that should be styled.
-        auto styled_contents = [](const std::string &contents, std::string &&log) {
+        auto styled_contents = [](std::string const &contents, std::string &&log) {
             auto pos = contents.find(": " + log);
             CATCH_REQUIRE(pos != std::string::npos);
 
@@ -74,10 +74,10 @@ CATCH_TEST_CASE("ConsoleLogger", "[logger]")
             fly::test::CaptureStream capture(fly::test::CaptureStream::Stream::Stdout);
             logger->debug("Debug Log");
 
-            const std::string contents = capture();
+            std::string const contents = capture();
             CATCH_REQUIRE_FALSE(contents.empty());
 
-            const std::string styled = styled_contents(contents, "Debug Log");
+            std::string const styled = styled_contents(contents, "Debug Log");
             CATCH_CHECK(styled.starts_with("\x1b[0m"));
             CATCH_CHECK(styled.ends_with("\x1b[0m"));
         }
@@ -87,10 +87,10 @@ CATCH_TEST_CASE("ConsoleLogger", "[logger]")
             fly::test::CaptureStream capture(fly::test::CaptureStream::Stream::Stdout);
             logger->info("Info Log");
 
-            const std::string contents = capture();
+            std::string const contents = capture();
             CATCH_REQUIRE_FALSE(contents.empty());
 
-            const std::string styled = styled_contents(contents, "Info Log");
+            std::string const styled = styled_contents(contents, "Info Log");
             CATCH_CHECK(styled.starts_with("\x1b[0;32m"));
             CATCH_CHECK(styled.ends_with("\x1b[0m"));
         }
@@ -100,10 +100,10 @@ CATCH_TEST_CASE("ConsoleLogger", "[logger]")
             fly::test::CaptureStream capture(fly::test::CaptureStream::Stream::Stderr);
             logger->warn("Warning Log");
 
-            const std::string contents = capture();
+            std::string const contents = capture();
             CATCH_REQUIRE_FALSE(contents.empty());
 
-            const std::string styled = styled_contents(contents, "Warning Log");
+            std::string const styled = styled_contents(contents, "Warning Log");
             CATCH_CHECK(styled.starts_with("\x1b[0;33m"));
             CATCH_CHECK(styled.ends_with("\x1b[0m"));
         }
@@ -113,10 +113,10 @@ CATCH_TEST_CASE("ConsoleLogger", "[logger]")
             fly::test::CaptureStream capture(fly::test::CaptureStream::Stream::Stderr);
             logger->error("Error Log");
 
-            const std::string contents = capture();
+            std::string const contents = capture();
             CATCH_REQUIRE_FALSE(contents.empty());
 
-            const std::string styled = styled_contents(contents, "Error Log");
+            std::string const styled = styled_contents(contents, "Error Log");
             CATCH_CHECK(styled.starts_with("\x1b[1;31m"));
             CATCH_CHECK(styled.ends_with("\x1b[0m"));
         }

--- a/test/logger/file_logger.cpp
+++ b/test/logger/file_logger.cpp
@@ -30,7 +30,8 @@ namespace {
 class MutableLoggerConfig : public fly::logger::LoggerConfig
 {
 public:
-    MutableLoggerConfig() noexcept : fly::logger::LoggerConfig()
+    MutableLoggerConfig() noexcept :
+        fly::logger::LoggerConfig()
     {
         m_default_max_log_file_size = 1 << 10;
     }
@@ -61,7 +62,7 @@ public:
  *
  * @return The current log file.
  */
-std::filesystem::path find_log_file(const fly::test::PathUtil::ScopedTempDirectory &path)
+std::filesystem::path find_log_file(fly::test::PathUtil::ScopedTempDirectory const &path)
 {
     std::uint32_t most_recent_log_index = 0_u32;
     std::filesystem::path most_recent_log_file;
@@ -88,7 +89,7 @@ std::filesystem::path find_log_file(const fly::test::PathUtil::ScopedTempDirecto
  *
  * @return uintmax_t Size of the log point.
  */
-std::uintmax_t log_size(const std::string &message)
+std::uintmax_t log_size(std::string const &message)
 {
     fly::logger::Log log;
 
@@ -136,7 +137,7 @@ CATCH_TEST_CASE("FileLogger", "[logger]")
         logger->debug("This log will be rejected");
 
         std::filesystem::path log_file = find_log_file(path);
-        const std::string contents = fly::test::PathUtil::read_file(log_file);
+        std::string const contents = fly::test::PathUtil::read_file(log_file);
         CATCH_REQUIRE(contents.empty());
     }
 
@@ -147,7 +148,7 @@ CATCH_TEST_CASE("FileLogger", "[logger]")
         logger->debug("Debug Log");
 
         std::filesystem::path log_file = find_log_file(path);
-        const std::string contents = fly::test::PathUtil::read_file(log_file);
+        std::string const contents = fly::test::PathUtil::read_file(log_file);
         CATCH_REQUIRE_FALSE(contents.empty());
 
         CATCH_CHECK(contents.find("Debug Log") != std::string::npos);
@@ -158,7 +159,7 @@ CATCH_TEST_CASE("FileLogger", "[logger]")
         logger->info("Info Log");
 
         std::filesystem::path log_file = find_log_file(path);
-        const std::string contents = fly::test::PathUtil::read_file(log_file);
+        std::string const contents = fly::test::PathUtil::read_file(log_file);
         CATCH_REQUIRE_FALSE(contents.empty());
 
         CATCH_CHECK(contents.find("Info Log") != std::string::npos);
@@ -169,7 +170,7 @@ CATCH_TEST_CASE("FileLogger", "[logger]")
         logger->warn("Warning Log");
 
         std::filesystem::path log_file = find_log_file(path);
-        const std::string contents = fly::test::PathUtil::read_file(log_file);
+        std::string const contents = fly::test::PathUtil::read_file(log_file);
         CATCH_REQUIRE_FALSE(contents.empty());
 
         CATCH_CHECK(contents.find("Warning Log") != std::string::npos);
@@ -180,7 +181,7 @@ CATCH_TEST_CASE("FileLogger", "[logger]")
         logger->error("Error Log");
 
         std::filesystem::path log_file = find_log_file(path);
-        const std::string contents = fly::test::PathUtil::read_file(log_file);
+        std::string const contents = fly::test::PathUtil::read_file(log_file);
         CATCH_REQUIRE_FALSE(contents.empty());
 
         CATCH_CHECK(contents.find("Error Log") != std::string::npos);

--- a/test/logger/logger.cpp
+++ b/test/logger/logger.cpp
@@ -28,7 +28,8 @@ namespace {
 class QueueSink : public fly::logger::Sink
 {
 public:
-    QueueSink(fly::ConcurrentQueue<fly::logger::Log> &logs) : m_logs(logs)
+    QueueSink(fly::ConcurrentQueue<fly::logger::Log> &logs) :
+        m_logs(logs)
     {
     }
 
@@ -87,7 +88,8 @@ public:
 class FailStreamSink : public QueueSink
 {
 public:
-    FailStreamSink(fly::ConcurrentQueue<fly::logger::Log> &logs) : QueueSink(logs)
+    FailStreamSink(fly::ConcurrentQueue<fly::logger::Log> &logs) :
+        QueueSink(logs)
     {
     }
 
@@ -105,7 +107,7 @@ CATCH_TEST_CASE("Logger", "[logger]")
     fly::ConcurrentQueue<fly::logger::Log> received_logs;
 
     auto validate_log_points = [&](fly::logger::Level expected_level,
-                                   const char *expected_function,
+                                   char const *expected_function,
                                    std::vector<std::string> &&expected_messages) {
         double last_time = 0.0;
 
@@ -191,7 +193,7 @@ CATCH_TEST_CASE("Logger", "[logger]")
     CATCH_SECTION("Log points")
     {
         // Run all of the log point tests with both synchronous and asynchronous loggers.
-        const bool synchronous_logger = GENERATE(true, false);
+        bool const synchronous_logger = GENERATE(true, false);
 
         auto task_runner = fly::task::SequencedTaskRunner::create(fly::test::task_manager());
         auto sink = std::make_unique<QueueSink>(received_logs);

--- a/test/logger/styler.cpp
+++ b/test/logger/styler.cpp
@@ -27,7 +27,7 @@ void test_styler(std::string &&expected_escape, Modifiers &&...modifiers)
         fly::test::CaptureStream capture(fly::test::CaptureStream::Stream::Stdout);
         std::cout << fly::logger::Styler(modifiers...) << "stylized text";
 
-        const std::string contents = capture();
+        std::string const contents = capture();
         CATCH_REQUIRE_FALSE(contents.empty());
 
         CATCH_CHECK(contents.starts_with(expected_escape));
@@ -41,7 +41,7 @@ void test_styler(std::string &&expected_escape, Modifiers &&...modifiers)
         fly::test::CaptureStream capture(fly::test::CaptureStream::Stream::Stderr);
         std::cerr << fly::logger::Styler(modifiers...) << "stylized text";
 
-        const std::string contents = capture();
+        std::string const contents = capture();
         CATCH_REQUIRE_FALSE(contents.empty());
 
         CATCH_CHECK(contents.starts_with(expected_escape));
@@ -60,7 +60,7 @@ CATCH_TEST_CASE("Styler", "[logger]")
         std::stringstream stream;
 
         stream << fly::logger::Styler(fly::logger::Color::Red) << "non-stylized text";
-        const std::string contents = stream.str();
+        std::string const contents = stream.str();
 
         CATCH_CHECK_FALSE(contents.starts_with("\x1b[38;5;1m"));
         CATCH_CHECK_FALSE(contents.ends_with("\x1b[0m"));

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -20,22 +20,22 @@ using namespace fly::literals::numeric_literals;
 class FlyReporter final : public Catch::StreamingReporterBase
 {
 public:
-    explicit FlyReporter(const Catch::ReporterConfig &config);
+    explicit FlyReporter(Catch::ReporterConfig const &config);
     ~FlyReporter() override = default;
 
     static std::string getDescription();
 
-    void testRunStarting(const Catch::TestRunInfo &info) override;
-    void testCaseStarting(const Catch::TestCaseInfo &info) override;
-    void sectionStarting(const Catch::SectionInfo &info) override;
-    void assertionEnded(const Catch::AssertionStats &) override;
-    void sectionEnded(const Catch::SectionStats &stats) override;
-    void testCaseEnded(const Catch::TestCaseStats &stats) override;
-    void testRunEnded(const Catch::TestRunStats &stats) override;
+    void testRunStarting(Catch::TestRunInfo const &info) override;
+    void testCaseStarting(Catch::TestCaseInfo const &info) override;
+    void sectionStarting(Catch::SectionInfo const &info) override;
+    void assertionEnded(Catch::AssertionStats const &) override;
+    void sectionEnded(Catch::SectionStats const &stats) override;
+    void testCaseEnded(Catch::TestCaseStats const &stats) override;
+    void testRunEnded(Catch::TestRunStats const &stats) override;
 
 private:
     void stream_header(fly::logger::Color::StandardColor color, std::string message);
-    void stream_summary(const Catch::Totals &totals);
+    void stream_summary(Catch::Totals const &totals);
 
     std::chrono::steady_clock::time_point m_test_start;
     std::chrono::steady_clock::time_point m_current_test_case_start;
@@ -50,21 +50,22 @@ private:
 class FailedAssertionLogger
 {
 public:
-    explicit FailedAssertionLogger(const Catch::AssertionStats &stats);
-    friend std::ostream &operator<<(std::ostream &stream, const FailedAssertionLogger &logger);
+    explicit FailedAssertionLogger(Catch::AssertionStats const &stats);
+    friend std::ostream &operator<<(std::ostream &stream, FailedAssertionLogger const &logger);
 
 private:
     void stream_source_info(std::ostream &stream) const;
     void stream_expression(std::ostream &stream) const;
     void stream_message(std::ostream &stream) const;
 
-    const Catch::AssertionResult &m_result;
-    const std::vector<Catch::MessageInfo> &m_messages;
+    Catch::AssertionResult const &m_result;
+    std::vector<Catch::MessageInfo> const &m_messages;
     std::string_view m_label;
 };
 
 //==================================================================================================
-FlyReporter::FlyReporter(const Catch::ReporterConfig &config) : Catch::StreamingReporterBase(config)
+FlyReporter::FlyReporter(Catch::ReporterConfig const &config) :
+    Catch::StreamingReporterBase(config)
 {
 }
 
@@ -75,14 +76,14 @@ std::string FlyReporter::getDescription()
 }
 
 //==================================================================================================
-void FlyReporter::testRunStarting(const Catch::TestRunInfo &info)
+void FlyReporter::testRunStarting(Catch::TestRunInfo const &info)
 {
     Catch::StreamingReporterBase::testRunStarting(info);
     m_test_start = std::chrono::steady_clock::now();
 }
 
 //==================================================================================================
-void FlyReporter::testCaseStarting(const Catch::TestCaseInfo &info)
+void FlyReporter::testCaseStarting(Catch::TestCaseInfo const &info)
 {
     Catch::StreamingReporterBase::testCaseStarting(info);
 
@@ -91,7 +92,7 @@ void FlyReporter::testCaseStarting(const Catch::TestCaseInfo &info)
 }
 
 //==================================================================================================
-void FlyReporter::sectionStarting(const Catch::SectionInfo &info)
+void FlyReporter::sectionStarting(Catch::SectionInfo const &info)
 {
     Catch::StreamingReporterBase::sectionStarting(info);
     std::size_t level = m_section_level++;
@@ -110,7 +111,7 @@ void FlyReporter::sectionStarting(const Catch::SectionInfo &info)
         return;
     }
 
-    const fly::logger::Styler style(fly::logger::Color::Cyan, fly::logger::Style::Italic);
+    fly::logger::Styler const style(fly::logger::Color::Cyan, fly::logger::Style::Italic);
     m_stream << style << "[ ";
 
     if (level != 1)
@@ -124,7 +125,7 @@ void FlyReporter::sectionStarting(const Catch::SectionInfo &info)
 }
 
 //==================================================================================================
-void FlyReporter::assertionEnded(const Catch::AssertionStats &stats)
+void FlyReporter::assertionEnded(Catch::AssertionStats const &stats)
 {
     if (!stats.assertionResult.isOk())
     {
@@ -134,21 +135,21 @@ void FlyReporter::assertionEnded(const Catch::AssertionStats &stats)
 }
 
 //==================================================================================================
-void FlyReporter::sectionEnded(const Catch::SectionStats &stats)
+void FlyReporter::sectionEnded(Catch::SectionStats const &stats)
 {
     Catch::StreamingReporterBase::sectionEnded(stats);
     --m_section_level;
 }
 
 //==================================================================================================
-void FlyReporter::testCaseEnded(const Catch::TestCaseStats &stats)
+void FlyReporter::testCaseEnded(Catch::TestCaseStats const &stats)
 {
     Catch::StreamingReporterBase::testCaseEnded(stats);
 
-    const auto end = std::chrono::steady_clock::now();
-    const auto duration = std::chrono::duration<double>(end - m_current_test_case_start);
+    auto const end = std::chrono::steady_clock::now();
+    auto const duration = std::chrono::duration<double>(end - m_current_test_case_start);
 
-    const std::string &name = stats.testInfo->name;
+    std::string const &name = stats.testInfo->name;
 
     if (stats.totals.assertions.allOk())
     {
@@ -168,12 +169,12 @@ void FlyReporter::testCaseEnded(const Catch::TestCaseStats &stats)
 }
 
 //==================================================================================================
-void FlyReporter::testRunEnded(const Catch::TestRunStats &stats)
+void FlyReporter::testRunEnded(Catch::TestRunStats const &stats)
 {
     Catch::StreamingReporterBase::testRunEnded(stats);
 
-    const auto end = std::chrono::steady_clock::now();
-    const auto duration = std::chrono::duration<double>(end - m_test_start);
+    auto const end = std::chrono::steady_clock::now();
+    auto const duration = std::chrono::duration<double>(end - m_test_start);
 
     stream_summary(stats.totals);
 
@@ -190,7 +191,7 @@ void FlyReporter::stream_header(fly::logger::Color::StandardColor color, std::st
 }
 
 //==================================================================================================
-void FlyReporter::stream_summary(const Catch::Totals &totals)
+void FlyReporter::stream_summary(Catch::Totals const &totals)
 {
     static constexpr std::size_t s_divider_width = 80;
 
@@ -255,7 +256,7 @@ void FlyReporter::stream_summary(const Catch::Totals &totals)
 }
 
 //==================================================================================================
-FailedAssertionLogger::FailedAssertionLogger(const Catch::AssertionStats &stats) :
+FailedAssertionLogger::FailedAssertionLogger(Catch::AssertionStats const &stats) :
     m_result(stats.assertionResult),
     m_messages(stats.infoMessages)
 {
@@ -288,7 +289,7 @@ FailedAssertionLogger::FailedAssertionLogger(const Catch::AssertionStats &stats)
 }
 
 //==================================================================================================
-std::ostream &operator<<(std::ostream &stream, const FailedAssertionLogger &logger)
+std::ostream &operator<<(std::ostream &stream, FailedAssertionLogger const &logger)
 {
     logger.stream_source_info(stream);
     logger.stream_expression(stream);
@@ -321,7 +322,7 @@ void FailedAssertionLogger::stream_message(std::ostream &stream) const
         stream << m_label << ':' << '\n';
     }
 
-    for (const auto &message : m_messages)
+    for (auto const &message : m_messages)
     {
         stream << "    " << message.message << '\n';
     }

--- a/test/mock/mock_system.cpp
+++ b/test/mock/mock_system.cpp
@@ -8,7 +8,8 @@ bool MockSystem::s_mock_system_enabled = false;
 MockCalls MockSystem::s_mocked_calls;
 
 //==================================================================================================
-MockSystem::MockSystem(MockCall mock) noexcept : m_mock(mock)
+MockSystem::MockSystem(MockCall mock) noexcept :
+    m_mock(mock)
 {
     std::lock_guard<std::mutex> lock(s_mock_system_mutex);
 
@@ -16,7 +17,8 @@ MockSystem::MockSystem(MockCall mock) noexcept : m_mock(mock)
     s_mock_system_enabled = true;
 }
 //==================================================================================================
-MockSystem::MockSystem(MockCall mock, bool fail) noexcept : m_mock(mock)
+MockSystem::MockSystem(MockCall mock, bool fail) noexcept :
+    m_mock(mock)
 {
     std::lock_guard<std::mutex> lock(s_mock_system_mutex);
 

--- a/test/mock/mock_system.hpp
+++ b/test/mock/mock_system.hpp
@@ -74,7 +74,7 @@ private:
     static bool s_mock_system_enabled;
     static MockCalls s_mocked_calls;
 
-    const MockCall m_mock;
+    MockCall const m_mock;
 };
 
 } // namespace fly::test

--- a/test/mock/nix/mock_calls.cpp
+++ b/test/mock/nix/mock_calls.cpp
@@ -191,15 +191,15 @@ int __wrap_fcntl(int fd, int cmd, int args)
 //==============================================================================================
 // NOLINTNEXTLINE(readability-identifier-naming)
 int __real_getaddrinfo(
-    const char *node,
-    const char *service,
+    char const *node,
+    char const *service,
     const struct addrinfo *hints,
     struct addrinfo **res);
 
 // NOLINTNEXTLINE(readability-identifier-naming)
 int __wrap_getaddrinfo(
-    const char *node,
-    const char *service,
+    char const *node,
+    char const *service,
     const struct addrinfo *hints,
     struct addrinfo **res)
 {
@@ -262,10 +262,10 @@ int __wrap_getsockopt(int sockfd, int level, int optname, void *optval, socklen_
 
 //==============================================================================================
 // NOLINTNEXTLINE(readability-identifier-naming)
-int __real_inotify_add_watch(int fd, const char *pathname, uint32_t mask);
+int __real_inotify_add_watch(int fd, char const *pathname, uint32_t mask);
 
 // NOLINTNEXTLINE(readability-identifier-naming)
-int __wrap_inotify_add_watch(int fd, const char *pathname, uint32_t mask)
+int __wrap_inotify_add_watch(int fd, char const *pathname, uint32_t mask)
 {
     if (fly::test::MockSystem::mock_enabled(fly::test::MockCall::InotifyAddWatch))
     {
@@ -328,10 +328,10 @@ int __wrap_listen(int sockfd, int backlog)
 
 //==============================================================================================
 // NOLINTNEXTLINE(readability-identifier-naming)
-struct tm *__real_localtime_r(const time_t *timep, struct tm *result);
+struct tm *__real_localtime_r(time_t const *timep, struct tm *result);
 
 // NOLINTNEXTLINE(readability-identifier-naming)
-struct tm *__wrap_localtime_r(const time_t *timep, struct tm *result)
+struct tm *__wrap_localtime_r(time_t const *timep, struct tm *result)
 {
     if (fly::test::MockSystem::mock_enabled(fly::test::MockCall::LocalTime))
     {
@@ -475,10 +475,10 @@ int __wrap_select(
 
 //==============================================================================================
 // NOLINTNEXTLINE(readability-identifier-naming)
-ssize_t __real_send(int sockfd, const void *buf, size_t len, int flags);
+ssize_t __real_send(int sockfd, void const *buf, size_t len, int flags);
 
 // NOLINTNEXTLINE(readability-identifier-naming)
-ssize_t __wrap_send(int sockfd, const void *buf, size_t len, int flags)
+ssize_t __wrap_send(int sockfd, void const *buf, size_t len, int flags)
 {
     if (fly::test::MockSystem::mock_enabled(fly::test::MockCall::Send))
     {
@@ -510,7 +510,7 @@ ssize_t __wrap_send(int sockfd, const void *buf, size_t len, int flags)
 // NOLINTNEXTLINE(readability-identifier-naming)
 ssize_t __real_sendto(
     int sockfd,
-    const void *buf,
+    void const *buf,
     size_t len,
     int flags,
     const struct sockaddr *dest_addr,
@@ -519,7 +519,7 @@ ssize_t __real_sendto(
 // NOLINTNEXTLINE(readability-identifier-naming)
 ssize_t __wrap_sendto(
     int sockfd,
-    const void *buf,
+    void const *buf,
     size_t len,
     int flags,
     const struct sockaddr *dest_addr,
@@ -553,10 +553,10 @@ ssize_t __wrap_sendto(
 
 //==============================================================================================
 // NOLINTNEXTLINE(readability-identifier-naming)
-int __real_setsockopt(int sockfd, int level, int optname, const void *optval, socklen_t optlen);
+int __real_setsockopt(int sockfd, int level, int optname, void const *optval, socklen_t optlen);
 
 // NOLINTNEXTLINE(readability-identifier-naming)
-int __wrap_setsockopt(int sockfd, int level, int optname, const void *optval, socklen_t optlen)
+int __wrap_setsockopt(int sockfd, int level, int optname, void const *optval, socklen_t optlen)
 {
     if (fly::test::MockSystem::mock_enabled(fly::test::MockCall::Setsockopt))
     {
@@ -617,10 +617,10 @@ clock_t __wrap_times(struct tms *buf)
 
 //==============================================================================================
 // NOLINTNEXTLINE(readability-identifier-naming)
-ssize_t __real_write(int fd, const void *buf, size_t count);
+ssize_t __real_write(int fd, void const *buf, size_t count);
 
 // NOLINTNEXTLINE(readability-identifier-naming)
-ssize_t __wrap_write(int fd, const void *buf, size_t count)
+ssize_t __wrap_write(int fd, void const *buf, size_t count)
 {
     if (fly::test::MockSystem::mock_enabled(fly::test::MockCall::Write))
     {

--- a/test/net/endpoint.cpp
+++ b/test/net/endpoint.cpp
@@ -15,7 +15,7 @@ CATCH_TEMPLATE_TEST_CASE("Endpoint", "[net]", fly::net::IPv4Address, fly::net::I
 
     CATCH_SECTION("Endpoints may be default constructed")
     {
-        const EndpointType endpoint;
+        EndpointType const endpoint;
 
         CATCH_CHECK(endpoint.address() == IPAddressType());
         CATCH_CHECK(endpoint.port() == 0);
@@ -26,14 +26,14 @@ CATCH_TEMPLATE_TEST_CASE("Endpoint", "[net]", fly::net::IPv4Address, fly::net::I
 
     CATCH_SECTION("Endpoints may be constructed from existing IP addresses")
     {
-        const auto address1 = IPAddressType::in_addr_loopback();
-        const EndpointType endpoint1(address1, 1);
+        auto const address1 = IPAddressType::in_addr_loopback();
+        EndpointType const endpoint1(address1, 1);
 
         CATCH_CHECK(endpoint1.address() == address1);
         CATCH_CHECK(endpoint1.port() == 1);
 
         auto address2 = IPAddressType::in_addr_loopback();
-        const EndpointType endpoint2(std::move(address2), 2);
+        EndpointType const endpoint2(std::move(address2), 2);
 
         CATCH_CHECK(endpoint2.address() == address1);
         CATCH_CHECK(endpoint2.port() == 2);
@@ -41,8 +41,8 @@ CATCH_TEMPLATE_TEST_CASE("Endpoint", "[net]", fly::net::IPv4Address, fly::net::I
 
     CATCH_SECTION("Endpoints may be copied")
     {
-        const auto endpoint1 = EndpointType(IPAddressType::in_addr_loopback(), 1);
-        const auto endpoint2 = endpoint1;
+        auto const endpoint1 = EndpointType(IPAddressType::in_addr_loopback(), 1);
+        auto const endpoint2 = endpoint1;
 
         CATCH_CHECK(endpoint1 == endpoint2);
     }
@@ -50,7 +50,7 @@ CATCH_TEMPLATE_TEST_CASE("Endpoint", "[net]", fly::net::IPv4Address, fly::net::I
     CATCH_SECTION("Endpoints may be moved")
     {
         auto endpoint1 = EndpointType(IPAddressType::in_addr_loopback(), 1);
-        const auto endpoint2 = std::move(endpoint1);
+        auto const endpoint2 = std::move(endpoint1);
 
         CATCH_CHECK(endpoint2.address() == IPAddressType::in_addr_loopback());
         CATCH_CHECK(endpoint2.port() == 1);
@@ -58,9 +58,9 @@ CATCH_TEMPLATE_TEST_CASE("Endpoint", "[net]", fly::net::IPv4Address, fly::net::I
 
     CATCH_SECTION("Endpoints may be compared")
     {
-        const auto endpoint1 = EndpointType(IPAddressType::in_addr_loopback(), 1);
-        const auto endpoint2 = EndpointType(IPAddressType::in_addr_loopback(), 2);
-        const auto endpoint3 = EndpointType(IPAddressType::in_addr_loopback(), 3);
+        auto const endpoint1 = EndpointType(IPAddressType::in_addr_loopback(), 1);
+        auto const endpoint2 = EndpointType(IPAddressType::in_addr_loopback(), 2);
+        auto const endpoint3 = EndpointType(IPAddressType::in_addr_loopback(), 3);
 
         CATCH_CHECK(endpoint2 == endpoint2);
         CATCH_CHECK(endpoint1 != endpoint2);
@@ -92,13 +92,13 @@ CATCH_TEMPLATE_TEST_CASE("Endpoint", "[net]", fly::net::IPv4Address, fly::net::I
     {
         CATCH_SECTION("Endpoints may be converted to a string")
         {
-            const auto endpoint = EndpointType(IPAddressType::in_addr_loopback(), 1);
+            auto const endpoint = EndpointType(IPAddressType::in_addr_loopback(), 1);
             CATCH_CHECK(fly::String::format("{}", endpoint) == "127.0.0.1:1");
         }
 
         CATCH_SECTION("Endpoints may be created from a string")
         {
-            const auto endpoint = EndpointType::from_string("127.0.0.1:123");
+            auto const endpoint = EndpointType::from_string("127.0.0.1:123");
             CATCH_REQUIRE(endpoint);
 
             CATCH_CHECK(endpoint->address() == IPAddressType::in_addr_loopback());
@@ -142,13 +142,13 @@ CATCH_TEMPLATE_TEST_CASE("Endpoint", "[net]", fly::net::IPv4Address, fly::net::I
     {
         CATCH_SECTION("Endpoints may be converted to a string")
         {
-            const auto endpoint = EndpointType(IPAddressType::in_addr_loopback(), 1);
+            auto const endpoint = EndpointType(IPAddressType::in_addr_loopback(), 1);
             CATCH_CHECK(fly::String::format("{}", endpoint) == "[::1]:1");
         }
 
         CATCH_SECTION("Endpoints may be created from a string")
         {
-            const auto endpoint = EndpointType::from_string("[::1]:123");
+            auto const endpoint = EndpointType::from_string("[::1]:123");
             CATCH_REQUIRE(endpoint);
 
             CATCH_CHECK(endpoint->address() == IPAddressType::in_addr_loopback());

--- a/test/net/ipv4_address.cpp
+++ b/test/net/ipv4_address.cpp
@@ -15,32 +15,32 @@ CATCH_TEST_CASE("IPv4Address", "[net]")
 {
     CATCH_SECTION("INADDR_ANY should be equivalent to system value")
     {
-        const auto address = fly::net::IPv4Address::in_addr_any();
+        auto const address = fly::net::IPv4Address::in_addr_any();
         CATCH_CHECK(address.host_order() == INADDR_ANY);
     }
 
     CATCH_SECTION("INADDR_BROADCAST should be equivalent to system value")
     {
-        const auto address = fly::net::IPv4Address::in_addr_broadcast();
+        auto const address = fly::net::IPv4Address::in_addr_broadcast();
         CATCH_CHECK(address.host_order() == INADDR_BROADCAST);
     }
 
     CATCH_SECTION("INADDR_LOOPBACK should be equivalent to system value")
     {
-        const auto address = fly::net::IPv4Address::in_addr_loopback();
+        auto const address = fly::net::IPv4Address::in_addr_loopback();
         CATCH_CHECK(address.host_order() == INADDR_LOOPBACK);
     }
 
     CATCH_SECTION("Default constructed IPv4 addresses are initialized to 0.0.0.0")
     {
-        const fly::net::IPv4Address address;
+        fly::net::IPv4Address const address;
         CATCH_CHECK(address == fly::net::IPv4Address::in_addr_any());
     }
 
     CATCH_SECTION("Construction from an array is interpreted as host order")
     {
-        const fly::net::IPv4Address address({0x11, 0x22, 0x33, 0x44});
-        const fly::net::IPv4Address::int_type ip = 0x11'22'33'44;
+        fly::net::IPv4Address const address({0x11, 0x22, 0x33, 0x44});
+        fly::net::IPv4Address::int_type const ip = 0x11'22'33'44;
 
         CATCH_CHECK(
             address.network_order() == fly::endian_swap_if_non_native<std::endian::big>(ip));
@@ -49,8 +49,8 @@ CATCH_TEST_CASE("IPv4Address", "[net]")
 
     CATCH_SECTION("Construction from an integer is interpreted as network order")
     {
-        const fly::net::IPv4Address address(0x11'22'33'44);
-        const fly::net::IPv4Address::int_type ip = 0x11'22'33'44;
+        fly::net::IPv4Address const address(0x11'22'33'44);
+        fly::net::IPv4Address::int_type const ip = 0x11'22'33'44;
 
         CATCH_CHECK(address.network_order() == ip);
         CATCH_CHECK(address.host_order() == fly::endian_swap_if_non_native<std::endian::big>(ip));
@@ -58,24 +58,24 @@ CATCH_TEST_CASE("IPv4Address", "[net]")
 
     CATCH_SECTION("Network ordered address is big-endian")
     {
-        const fly::net::IPv4Address::int_type ip = 0x11'22'33'44;
-        const fly::net::IPv4Address address(ip);
+        fly::net::IPv4Address::int_type const ip = 0x11'22'33'44;
+        fly::net::IPv4Address const address(ip);
 
         CATCH_CHECK(address.network_order() == 0x11'22'33'44);
     }
 
     CATCH_SECTION("Host ordered address is little-endian")
     {
-        const fly::net::IPv4Address::int_type ip = 0x11'22'33'44;
-        const fly::net::IPv4Address address(ip);
+        fly::net::IPv4Address::int_type const ip = 0x11'22'33'44;
+        fly::net::IPv4Address const address(ip);
 
         CATCH_CHECK(address.host_order() == fly::endian_swap_if_non_native<std::endian::big>(ip));
     }
 
     CATCH_SECTION("IPv4 addresses may be copied")
     {
-        const auto address1 = fly::net::IPv4Address::in_addr_loopback();
-        const auto address2 = address1;
+        auto const address1 = fly::net::IPv4Address::in_addr_loopback();
+        auto const address2 = address1;
 
         CATCH_CHECK(address1 == address2);
     }
@@ -83,16 +83,16 @@ CATCH_TEST_CASE("IPv4Address", "[net]")
     CATCH_SECTION("IPv4 addresses may be moved")
     {
         auto address1 = fly::net::IPv4Address::in_addr_loopback();
-        const auto address2 = std::move(address1);
+        auto const address2 = std::move(address1);
 
         CATCH_CHECK(address2 == fly::net::IPv4Address::in_addr_loopback());
     }
 
     CATCH_SECTION("IPv4 addresses may be compared")
     {
-        const auto address1 = fly::net::IPv4Address::in_addr_any();
-        const auto address2 = fly::net::IPv4Address::in_addr_loopback();
-        const auto address3 = fly::net::IPv4Address::in_addr_broadcast();
+        auto const address1 = fly::net::IPv4Address::in_addr_any();
+        auto const address2 = fly::net::IPv4Address::in_addr_loopback();
+        auto const address3 = fly::net::IPv4Address::in_addr_broadcast();
 
         CATCH_CHECK(address2 == address2);
         CATCH_CHECK(address1 != address2);
@@ -139,60 +139,60 @@ CATCH_TEST_CASE("IPv4Address", "[net]")
 
     CATCH_SECTION("Single-part strings are parsed as 32-bit values")
     {
-        const auto address1 = fly::net::IPv4Address::from_string("0");
+        auto const address1 = fly::net::IPv4Address::from_string("0");
         CATCH_REQUIRE(address1.has_value());
         CATCH_CHECK(address1->host_order() == INADDR_ANY);
 
-        const auto address2 = fly::net::IPv4Address::from_string("2130706433");
+        auto const address2 = fly::net::IPv4Address::from_string("2130706433");
         CATCH_REQUIRE(address2.has_value());
         CATCH_CHECK(address2->host_order() == INADDR_LOOPBACK);
 
-        const auto address3 = fly::net::IPv4Address::from_string("4294967295");
+        auto const address3 = fly::net::IPv4Address::from_string("4294967295");
         CATCH_REQUIRE(address3.has_value());
         CATCH_CHECK(address3->host_order() == INADDR_BROADCAST);
     }
 
     CATCH_SECTION("Two-part strings are parsed as an octet and a 24-bit value")
     {
-        const auto address1 = fly::net::IPv4Address::from_string("0.0");
+        auto const address1 = fly::net::IPv4Address::from_string("0.0");
         CATCH_REQUIRE(address1.has_value());
         CATCH_CHECK(address1->host_order() == 0U);
 
-        const auto address2 = fly::net::IPv4Address::from_string("127.1");
+        auto const address2 = fly::net::IPv4Address::from_string("127.1");
         CATCH_REQUIRE(address2.has_value());
         CATCH_CHECK(address2->host_order() == INADDR_LOOPBACK);
 
-        const auto address3 = fly::net::IPv4Address::from_string("255.16777215");
+        auto const address3 = fly::net::IPv4Address::from_string("255.16777215");
         CATCH_REQUIRE(address3.has_value());
         CATCH_CHECK(address3->host_order() == INADDR_BROADCAST);
     }
 
     CATCH_SECTION("Three-part strings are parsed as two octet and a 16-bit value")
     {
-        const auto address1 = fly::net::IPv4Address::from_string("0.0.0");
+        auto const address1 = fly::net::IPv4Address::from_string("0.0.0");
         CATCH_REQUIRE(address1.has_value());
         CATCH_CHECK(address1->host_order() == 0U);
 
-        const auto address2 = fly::net::IPv4Address::from_string("127.0.1");
+        auto const address2 = fly::net::IPv4Address::from_string("127.0.1");
         CATCH_REQUIRE(address2.has_value());
         CATCH_CHECK(address2->host_order() == INADDR_LOOPBACK);
 
-        const auto address3 = fly::net::IPv4Address::from_string("255.255.65535");
+        auto const address3 = fly::net::IPv4Address::from_string("255.255.65535");
         CATCH_REQUIRE(address3.has_value());
         CATCH_CHECK(address3->host_order() == INADDR_BROADCAST);
     }
 
     CATCH_SECTION("Four-part strings are parsed as four octets")
     {
-        const auto address1 = fly::net::IPv4Address::from_string("0.0.0.0");
+        auto const address1 = fly::net::IPv4Address::from_string("0.0.0.0");
         CATCH_REQUIRE(address1.has_value());
         CATCH_CHECK(address1->host_order() == 0U);
 
-        const auto address2 = fly::net::IPv4Address::from_string("127.0.0.1");
+        auto const address2 = fly::net::IPv4Address::from_string("127.0.0.1");
         CATCH_REQUIRE(address2.has_value());
         CATCH_CHECK(address2->host_order() == INADDR_LOOPBACK);
 
-        const auto address3 = fly::net::IPv4Address::from_string("255.255.255.255");
+        auto const address3 = fly::net::IPv4Address::from_string("255.255.255.255");
         CATCH_REQUIRE(address3.has_value());
         CATCH_CHECK(address3->host_order() == INADDR_BROADCAST);
     }

--- a/test/net/ipv6_address.cpp
+++ b/test/net/ipv6_address.cpp
@@ -15,7 +15,7 @@ CATCH_TEST_CASE("IPv6Address", "[net]")
 {
     CATCH_SECTION("IN6ADDR_ANY should be equivalent to system value")
     {
-        const auto address = fly::net::IPv6Address::in_addr_any();
+        auto const address = fly::net::IPv6Address::in_addr_any();
         in6_addr system = in6addr_any;
 
         CATCH_CHECK(address == fly::net::IPv6Address(system.s6_addr));
@@ -23,7 +23,7 @@ CATCH_TEST_CASE("IPv6Address", "[net]")
 
     CATCH_SECTION("IN6ADDR_LOOPBACK should be equivalent to system value")
     {
-        const auto address = fly::net::IPv6Address::in_addr_loopback();
+        auto const address = fly::net::IPv6Address::in_addr_loopback();
         in6_addr system = in6addr_loopback;
 
         CATCH_CHECK(address == fly::net::IPv6Address(system.s6_addr));
@@ -31,17 +31,17 @@ CATCH_TEST_CASE("IPv6Address", "[net]")
 
     CATCH_SECTION("Default constructed IPv6 addresses are initialized to ::")
     {
-        const fly::net::IPv6Address address;
+        fly::net::IPv6Address const address;
         CATCH_CHECK(address == fly::net::IPv6Address::in_addr_any());
     }
 
     CATCH_SECTION("IPv6 addresses may be constructed from compatible array types")
     {
-        const fly::net::IPv6Address::address_type address1 {};
+        fly::net::IPv6Address::address_type const address1 {};
         fly::net::IPv6Address::address_type address2 {};
-        const fly::net::IPv6Address::address_type::value_type address3[16] {};
+        fly::net::IPv6Address::address_type::value_type const address3[16] {};
 
-        const auto any = fly::net::IPv6Address::in_addr_any();
+        auto const any = fly::net::IPv6Address::in_addr_any();
 
         CATCH_CHECK(fly::net::IPv6Address(address1) == any);
         CATCH_CHECK(fly::net::IPv6Address(std::move(address2)) == any);
@@ -50,8 +50,8 @@ CATCH_TEST_CASE("IPv6Address", "[net]")
 
     CATCH_SECTION("IPv6 addresses may be copied")
     {
-        const auto address1 = fly::net::IPv6Address::in_addr_loopback();
-        const auto address2 = address1;
+        auto const address1 = fly::net::IPv6Address::in_addr_loopback();
+        auto const address2 = address1;
 
         CATCH_CHECK(address1 == address2);
     }
@@ -59,19 +59,19 @@ CATCH_TEST_CASE("IPv6Address", "[net]")
     CATCH_SECTION("IPv6 addresses may be moved")
     {
         auto address1 = fly::net::IPv6Address::in_addr_loopback();
-        const auto address2 = std::move(address1);
+        auto const address2 = std::move(address1);
 
         CATCH_CHECK(address2 == fly::net::IPv6Address::in_addr_loopback());
     }
 
     CATCH_SECTION("IPv6 addresses may be compared")
     {
-        const auto address1 = fly::net::IPv6Address::in_addr_any();
-        const auto address2 = fly::net::IPv6Address::in_addr_loopback();
+        auto const address1 = fly::net::IPv6Address::in_addr_any();
+        auto const address2 = fly::net::IPv6Address::in_addr_loopback();
 
         fly::net::IPv6Address::address_type data {};
         data.fill(0xff);
-        const fly::net::IPv6Address address3(std::move(data));
+        fly::net::IPv6Address const address3(std::move(data));
 
         CATCH_CHECK(address2 == address2);
         CATCH_CHECK(address1 != address2);
@@ -94,7 +94,7 @@ CATCH_TEST_CASE("IPv6Address", "[net]")
 
     CATCH_SECTION("IPv6 addresses may be converted to a string")
     {
-        const fly::net::IPv6Address address1({
+        fly::net::IPv6Address const address1({
             0xa1,
             0xa2,
             0xa3,
@@ -119,7 +119,7 @@ CATCH_TEST_CASE("IPv6Address", "[net]")
 
     CATCH_SECTION("IPv6 addresses may be copied to an array")
     {
-        const fly::net::IPv6Address address1({1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6});
+        fly::net::IPv6Address const address1({1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6});
 
         fly::net::IPv6Address::address_type::value_type data[16] {};
         address1.copy(data);
@@ -129,44 +129,44 @@ CATCH_TEST_CASE("IPv6Address", "[net]")
 
     CATCH_SECTION("IPv6 addresses may be converted to a string with leading zeros removed")
     {
-        const fly::net::IPv6Address address1({1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6});
+        fly::net::IPv6Address const address1({1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6});
         CATCH_CHECK(fly::String::format("{}", address1) == "102:304:506:708:900:102:304:506");
     }
 
     CATCH_SECTION("IPv6 addresses may be converted to a string with consecutive zeros removed once")
     {
-        const fly::net::IPv6Address address1({1, 2, 0, 0, 0, 0, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6});
+        fly::net::IPv6Address const address1({1, 2, 0, 0, 0, 0, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6});
         CATCH_CHECK(fly::String::format("{}", address1) == "102::708:900:102:304:506");
 
-        const fly::net::IPv6Address address2({1, 2, 0, 0, 0, 0, 7, 8, 0, 0, 0, 0, 3, 4, 5, 6});
+        fly::net::IPv6Address const address2({1, 2, 0, 0, 0, 0, 7, 8, 0, 0, 0, 0, 3, 4, 5, 6});
         CATCH_CHECK(fly::String::format("{}", address2) == "102::708:0:0:304:506");
 
-        const fly::net::IPv6Address address3({1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 0, 0});
+        fly::net::IPv6Address const address3({1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 0, 0});
         CATCH_CHECK(fly::String::format("{}", address3) == "102:304:506:708:900:102:304::");
 
-        const fly::net::IPv6Address address4({0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
+        fly::net::IPv6Address const address4({0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
         CATCH_CHECK(fly::String::format("{}", address4) == "1::");
 
-        const fly::net::IPv6Address address5({0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1});
+        fly::net::IPv6Address const address5({0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1});
         CATCH_CHECK(fly::String::format("{}", address5) == "::1");
 
-        const fly::net::IPv6Address address6({0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1});
+        fly::net::IPv6Address const address6({0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1});
         CATCH_CHECK(fly::String::format("{}", address6) == "1::1");
     }
 
     CATCH_SECTION("IPv6 addresses may be created from full form strings")
     {
-        const auto address1 = fly::net::IPv6Address::from_string("0:0:0:0:0:0:0:0");
+        auto const address1 = fly::net::IPv6Address::from_string("0:0:0:0:0:0:0:0");
         CATCH_REQUIRE(address1);
         CATCH_CHECK(
             *address1 == fly::net::IPv6Address({0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}));
 
-        const auto address2 = fly::net::IPv6Address::from_string("1:2:3:4:5:6:7:8");
+        auto const address2 = fly::net::IPv6Address::from_string("1:2:3:4:5:6:7:8");
         CATCH_REQUIRE(address2);
         CATCH_CHECK(
             *address2 == fly::net::IPv6Address({0, 1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0, 7, 0, 8}));
 
-        const auto address3 =
+        auto const address3 =
             fly::net::IPv6Address::from_string("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff");
         CATCH_REQUIRE(address3);
         CATCH_CHECK(
@@ -193,37 +193,37 @@ CATCH_TEST_CASE("IPv6Address", "[net]")
 
     CATCH_SECTION("IPv6 addresses may be created from prefixed short form strings")
     {
-        const auto address1 = fly::net::IPv6Address::from_string("::1");
+        auto const address1 = fly::net::IPv6Address::from_string("::1");
         CATCH_REQUIRE(address1);
         CATCH_CHECK(
             *address1 == fly::net::IPv6Address({0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}));
 
-        const auto address2 = fly::net::IPv6Address::from_string("::1:2");
+        auto const address2 = fly::net::IPv6Address::from_string("::1:2");
         CATCH_REQUIRE(address2);
         CATCH_CHECK(
             *address2 == fly::net::IPv6Address({0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 2}));
 
-        const auto address3 = fly::net::IPv6Address::from_string("::1:2:3");
+        auto const address3 = fly::net::IPv6Address::from_string("::1:2:3");
         CATCH_REQUIRE(address3);
         CATCH_CHECK(
             *address3 == fly::net::IPv6Address({0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 2, 0, 3}));
 
-        const auto address4 = fly::net::IPv6Address::from_string("::1:2:3:4");
+        auto const address4 = fly::net::IPv6Address::from_string("::1:2:3:4");
         CATCH_REQUIRE(address4);
         CATCH_CHECK(
             *address4 == fly::net::IPv6Address({0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 2, 0, 3, 0, 4}));
 
-        const auto address5 = fly::net::IPv6Address::from_string("::1:2:3:4:5");
+        auto const address5 = fly::net::IPv6Address::from_string("::1:2:3:4:5");
         CATCH_REQUIRE(address5);
         CATCH_CHECK(
             *address5 == fly::net::IPv6Address({0, 0, 0, 0, 0, 0, 0, 1, 0, 2, 0, 3, 0, 4, 0, 5}));
 
-        const auto address6 = fly::net::IPv6Address::from_string("::1:2:3:4:5:6");
+        auto const address6 = fly::net::IPv6Address::from_string("::1:2:3:4:5:6");
         CATCH_REQUIRE(address6);
         CATCH_CHECK(
             *address6 == fly::net::IPv6Address({0, 0, 0, 0, 0, 1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6}));
 
-        const auto address7 = fly::net::IPv6Address::from_string("::1:2:3:4:5:6:7");
+        auto const address7 = fly::net::IPv6Address::from_string("::1:2:3:4:5:6:7");
         CATCH_REQUIRE(address7);
         CATCH_CHECK(
             *address7 == fly::net::IPv6Address({0, 0, 0, 1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0, 7}));
@@ -231,37 +231,37 @@ CATCH_TEST_CASE("IPv6Address", "[net]")
 
     CATCH_SECTION("IPv6 addresses may be created from suffixed short form strings")
     {
-        const auto address1 = fly::net::IPv6Address::from_string("1::");
+        auto const address1 = fly::net::IPv6Address::from_string("1::");
         CATCH_REQUIRE(address1);
         CATCH_CHECK(
             *address1 == fly::net::IPv6Address({0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}));
 
-        const auto address2 = fly::net::IPv6Address::from_string("1:2::");
+        auto const address2 = fly::net::IPv6Address::from_string("1:2::");
         CATCH_REQUIRE(address2);
         CATCH_CHECK(
             *address2 == fly::net::IPv6Address({0, 1, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}));
 
-        const auto address3 = fly::net::IPv6Address::from_string("1:2:3::");
+        auto const address3 = fly::net::IPv6Address::from_string("1:2:3::");
         CATCH_REQUIRE(address3);
         CATCH_CHECK(
             *address3 == fly::net::IPv6Address({0, 1, 0, 2, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}));
 
-        const auto address4 = fly::net::IPv6Address::from_string("1:2:3:4::");
+        auto const address4 = fly::net::IPv6Address::from_string("1:2:3:4::");
         CATCH_REQUIRE(address4);
         CATCH_CHECK(
             *address4 == fly::net::IPv6Address({0, 1, 0, 2, 0, 3, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0}));
 
-        const auto address5 = fly::net::IPv6Address::from_string("1:2:3:4:5::");
+        auto const address5 = fly::net::IPv6Address::from_string("1:2:3:4:5::");
         CATCH_REQUIRE(address5);
         CATCH_CHECK(
             *address5 == fly::net::IPv6Address({0, 1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 0, 0, 0, 0, 0}));
 
-        const auto address6 = fly::net::IPv6Address::from_string("1:2:3:4:5:6::");
+        auto const address6 = fly::net::IPv6Address::from_string("1:2:3:4:5:6::");
         CATCH_REQUIRE(address6);
         CATCH_CHECK(
             *address6 == fly::net::IPv6Address({0, 1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0, 0, 0, 0}));
 
-        const auto address7 = fly::net::IPv6Address::from_string("1:2:3:4:5:6:7::");
+        auto const address7 = fly::net::IPv6Address::from_string("1:2:3:4:5:6:7::");
         CATCH_REQUIRE(address7);
         CATCH_CHECK(
             *address7 == fly::net::IPv6Address({0, 1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0, 7, 0, 0}));
@@ -269,37 +269,37 @@ CATCH_TEST_CASE("IPv6Address", "[net]")
 
     CATCH_SECTION("IPv6 addresses may be created from mid-string short form strings")
     {
-        const auto address1 = fly::net::IPv6Address::from_string("::");
+        auto const address1 = fly::net::IPv6Address::from_string("::");
         CATCH_REQUIRE(address1);
         CATCH_CHECK(
             *address1 == fly::net::IPv6Address({0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}));
 
-        const auto address2 = fly::net::IPv6Address::from_string("1::1");
+        auto const address2 = fly::net::IPv6Address::from_string("1::1");
         CATCH_REQUIRE(address2);
         CATCH_CHECK(
             *address2 == fly::net::IPv6Address({0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}));
 
-        const auto address3 = fly::net::IPv6Address::from_string("1:2::3");
+        auto const address3 = fly::net::IPv6Address::from_string("1:2::3");
         CATCH_REQUIRE(address3);
         CATCH_CHECK(
             *address3 == fly::net::IPv6Address({0, 1, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3}));
 
-        const auto address4 = fly::net::IPv6Address::from_string("1::2:3");
+        auto const address4 = fly::net::IPv6Address::from_string("1::2:3");
         CATCH_REQUIRE(address4);
         CATCH_CHECK(
             *address4 == fly::net::IPv6Address({0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 3}));
 
-        const auto address5 = fly::net::IPv6Address::from_string("1:2:3::4");
+        auto const address5 = fly::net::IPv6Address::from_string("1:2:3::4");
         CATCH_REQUIRE(address5);
         CATCH_CHECK(
             *address5 == fly::net::IPv6Address({0, 1, 0, 2, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4}));
 
-        const auto address6 = fly::net::IPv6Address::from_string("1:2::3:4");
+        auto const address6 = fly::net::IPv6Address::from_string("1:2::3:4");
         CATCH_REQUIRE(address6);
         CATCH_CHECK(
             *address6 == fly::net::IPv6Address({0, 1, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 4}));
 
-        const auto address7 = fly::net::IPv6Address::from_string("1::2:3:4");
+        auto const address7 = fly::net::IPv6Address::from_string("1::2:3:4");
         CATCH_REQUIRE(address7);
         CATCH_CHECK(
             *address7 == fly::net::IPv6Address({0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 3, 0, 4}));

--- a/test/net/listen_socket.cpp
+++ b/test/net/listen_socket.cpp
@@ -25,8 +25,8 @@
 
 namespace {
 
-constexpr const char *s_localhost = "localhost";
-constexpr const fly::net::port_type s_port = 12389;
+constexpr char const *s_localhost = "localhost";
+constexpr fly::net::port_type s_port = 12389;
 
 } // namespace
 
@@ -38,8 +38,8 @@ CATCH_TEMPLATE_TEST_CASE("ListenSocket", "[net]", fly::net::IPv4Address, fly::ne
 
     fly::test::ScopedSocketServiceSetup::create();
 
-    constexpr const auto in_addr_any = IPAddressType::in_addr_any();
-    constexpr const auto in_addr_loopback = IPAddressType::in_addr_loopback();
+    constexpr auto in_addr_any = IPAddressType::in_addr_any();
+    constexpr auto in_addr_loopback = IPAddressType::in_addr_loopback();
 
     CATCH_SECTION("Moving a socket marks the moved-from socket as invalid")
     {

--- a/test/net/socket_service.cpp
+++ b/test/net/socket_service.cpp
@@ -26,8 +26,8 @@
 
 namespace {
 
-constexpr const char *s_localhost = "localhost";
-constexpr const fly::net::port_type s_port = 12389;
+constexpr char const *s_localhost = "localhost";
+constexpr fly::net::port_type s_port = 12389;
 
 } // namespace
 
@@ -84,7 +84,7 @@ CATCH_TEMPLATE_TEST_CASE("SocketService", "[net]", fly::net::IPv4Address, fly::n
             CATCH_REQUIRE(client_socket);
             client_signal.wait();
 
-            const std::string message(fly::String::generate_random_string(128));
+            std::string const message(fly::String::generate_random_string(128));
             CATCH_CHECK(client_socket->send(s_localhost, s_port, message) == message.size());
         };
 
@@ -103,7 +103,7 @@ CATCH_TEMPLATE_TEST_CASE("SocketService", "[net]", fly::net::IPv4Address, fly::n
 
     CATCH_SECTION("Many socket service requests are all satisfied")
     {
-        static constexpr const std::size_t s_requests = 100;
+        static constexpr std::size_t s_requests = 100;
 
         auto socket = socket_service->create_socket<UdpSocket>();
         CATCH_REQUIRE(socket);

--- a/test/net/tcp_socket.cpp
+++ b/test/net/tcp_socket.cpp
@@ -27,8 +27,8 @@
 
 namespace {
 
-constexpr const char *s_localhost = "localhost";
-constexpr const fly::net::port_type s_port = 12389;
+constexpr char const *s_localhost = "localhost";
+constexpr fly::net::port_type s_port = 12389;
 
 } // namespace
 
@@ -41,8 +41,8 @@ CATCH_TEMPLATE_TEST_CASE("TcpSocket", "[net]", fly::net::IPv4Address, fly::net::
 
     fly::test::ScopedSocketServiceSetup::create();
 
-    const std::string message(fly::String::generate_random_string(1 << 10));
-    constexpr const auto in_addr_loopback = IPAddressType::in_addr_loopback();
+    std::string const message(fly::String::generate_random_string(1 << 10));
+    constexpr auto in_addr_loopback = IPAddressType::in_addr_loopback();
 
     CATCH_SECTION("Moving a socket marks the moved-from socket as invalid")
     {
@@ -329,7 +329,7 @@ CATCH_TEMPLATE_TEST_CASE("AsyncTcpSocket", "[net]", fly::net::IPv4Address, fly::
         fly::task::SequencedTaskRunner::create(fly::test::task_manager()),
         std::make_shared<fly::net::NetworkConfig>());
 
-    const std::string message(fly::String::generate_random_string(1 << 10));
+    std::string const message(fly::String::generate_random_string(1 << 10));
     fly::test::Signal signal;
 
     CATCH_SECTION("Sockets created without socket service may not connect asynchronously")

--- a/test/net/udp_socket.cpp
+++ b/test/net/udp_socket.cpp
@@ -26,8 +26,8 @@
 
 namespace {
 
-constexpr const char *s_localhost = "localhost";
-constexpr const fly::net::port_type s_port = 12389;
+constexpr char const *s_localhost = "localhost";
+constexpr fly::net::port_type s_port = 12389;
 
 } // namespace
 
@@ -39,8 +39,8 @@ CATCH_TEMPLATE_TEST_CASE("UdpSocket", "[net]", fly::net::IPv4Address, fly::net::
 
     fly::test::ScopedSocketServiceSetup::create();
 
-    const std::string message(fly::String::generate_random_string(1 << 10));
-    constexpr const auto in_addr_any = IPAddressType::in_addr_any();
+    std::string const message(fly::String::generate_random_string(1 << 10));
+    constexpr auto in_addr_any = IPAddressType::in_addr_any();
 
     CATCH_SECTION("Moving a socket marks the moved-from socket as invalid")
     {
@@ -265,7 +265,7 @@ CATCH_TEMPLATE_TEST_CASE("AsyncUdpSocket", "[net]", fly::net::IPv4Address, fly::
         fly::task::SequencedTaskRunner::create(fly::test::task_manager()),
         std::make_shared<fly::net::NetworkConfig>());
 
-    const std::string message(fly::String::generate_random_string(1 << 10));
+    std::string const message(fly::String::generate_random_string(1 << 10));
     fly::test::Signal signal;
 
     CATCH_SECTION("Sockets created without socket service may not send asynchronously")

--- a/test/parser/ini_parser.cpp
+++ b/test/parser/ini_parser.cpp
@@ -22,7 +22,7 @@ CATCH_TEST_CASE("IniParser", "[parser]")
 
     CATCH_SECTION("Empty file cannot be parsed")
     {
-        const std::string contents;
+        std::string const contents;
 
         auto parsed = parser.parse_string(contents);
         CATCH_CHECK_FALSE(parsed.has_value());
@@ -30,19 +30,19 @@ CATCH_TEST_CASE("IniParser", "[parser]")
 
     CATCH_SECTION("Empty section can be parsed")
     {
-        const std::string contents("[section]");
+        std::string const contents("[section]");
 
         auto parsed = parser.parse_string(contents);
         CATCH_REQUIRE(parsed.has_value());
 
-        const fly::Json values = *std::move(parsed);
+        fly::Json const values = *std::move(parsed);
         CATCH_CHECK(values.size() == 1);
         CATCH_CHECK(values["section"].size() == 0);
     }
 
     CATCH_SECTION("Single section with name-value pairs")
     {
-        const std::string contents(
+        std::string const contents(
             "[section]\n"
             "name=John Doe\n"
             "address=USA");
@@ -50,7 +50,7 @@ CATCH_TEST_CASE("IniParser", "[parser]")
         auto parsed = parser.parse_string(contents);
         CATCH_REQUIRE(parsed.has_value());
 
-        const fly::Json values = *std::move(parsed);
+        fly::Json const values = *std::move(parsed);
         CATCH_CHECK(values.size() == 1);
         CATCH_CHECK(values["section"].size() == 2);
         CATCH_CHECK(values["section"]["name"] == "John Doe");
@@ -59,7 +59,7 @@ CATCH_TEST_CASE("IniParser", "[parser]")
 
     CATCH_SECTION("Multiple section with name-value pairs")
     {
-        const std::string contents(
+        std::string const contents(
             "[section1]\n"
             "name=John Doe\n"
             "age=26\n"
@@ -73,7 +73,7 @@ CATCH_TEST_CASE("IniParser", "[parser]")
         auto parsed = parser.parse_string(contents);
         CATCH_REQUIRE(parsed.has_value());
 
-        const fly::Json values = *std::move(parsed);
+        fly::Json const values = *std::move(parsed);
         CATCH_CHECK(values.size() == 3);
 
         CATCH_CHECK(values["section1"].size() == 2);
@@ -91,7 +91,7 @@ CATCH_TEST_CASE("IniParser", "[parser]")
 
     CATCH_SECTION("Only existing section names are parsed")
     {
-        const std::string contents(
+        std::string const contents(
             "[section]\n"
             "name=John Doe\n"
             "address=USA");
@@ -99,7 +99,7 @@ CATCH_TEST_CASE("IniParser", "[parser]")
         auto parsed = parser.parse_string(contents);
         CATCH_REQUIRE(parsed.has_value());
 
-        const fly::Json values = *std::move(parsed);
+        fly::Json const values = *std::move(parsed);
         CATCH_CHECK(values["section"].size() == 2);
         CATCH_CHECK_THROWS_AS(values["bad-section"], fly::JsonException);
         CATCH_CHECK_THROWS_AS(values["section-bad"], fly::JsonException);
@@ -107,7 +107,7 @@ CATCH_TEST_CASE("IniParser", "[parser]")
 
     CATCH_SECTION("Commented out sections are not parsed")
     {
-        const std::string contents(
+        std::string const contents(
             "[section]\n"
             "name=John Doe\n"
             "; [other-section]\n"
@@ -116,7 +116,7 @@ CATCH_TEST_CASE("IniParser", "[parser]")
         auto parsed = parser.parse_string(contents);
         CATCH_REQUIRE(parsed.has_value());
 
-        const fly::Json values = *std::move(parsed);
+        fly::Json const values = *std::move(parsed);
         CATCH_CHECK(values.size() == 1);
         CATCH_CHECK(values["section"].size() == 1);
         CATCH_CHECK_THROWS_AS(values["other-section"], fly::JsonException);
@@ -124,7 +124,7 @@ CATCH_TEST_CASE("IniParser", "[parser]")
 
     CATCH_SECTION("Extra whitespace is ignored")
     {
-        const std::string contents(
+        std::string const contents(
             "   [section   ]  \n"
             "\t\t\n   name=John Doe\t  \n"
             "\taddress  = USA\t \r \n");
@@ -132,7 +132,7 @@ CATCH_TEST_CASE("IniParser", "[parser]")
         auto parsed = parser.parse_string(contents);
         CATCH_REQUIRE(parsed.has_value());
 
-        const fly::Json values = *std::move(parsed);
+        fly::Json const values = *std::move(parsed);
         CATCH_CHECK(values.size() == 1);
         CATCH_CHECK(values["section"].size() == 2);
         CATCH_CHECK(values["section"]["name"] == "John Doe");
@@ -141,7 +141,7 @@ CATCH_TEST_CASE("IniParser", "[parser]")
 
     CATCH_SECTION("Extra whitespace between quotes is not ignored")
     {
-        const std::string contents(
+        std::string const contents(
             "[section]\n"
             "name=\"  John Doe  \"\n"
             "address= \t '\\tUSA'");
@@ -149,7 +149,7 @@ CATCH_TEST_CASE("IniParser", "[parser]")
         auto parsed = parser.parse_string(contents);
         CATCH_REQUIRE(parsed.has_value());
 
-        const fly::Json values = *std::move(parsed);
+        fly::Json const values = *std::move(parsed);
         CATCH_CHECK(values.size() == 1);
         CATCH_CHECK(values["section"].size() == 2);
         CATCH_CHECK(values["section"]["name"] == "  John Doe  ");
@@ -158,7 +158,7 @@ CATCH_TEST_CASE("IniParser", "[parser]")
 
     CATCH_SECTION("Duplicate sections override existing sections")
     {
-        const std::string contents1(
+        std::string const contents1(
             "[section]\n"
             "name=John Doe\n"
             "[section]\n"
@@ -167,12 +167,12 @@ CATCH_TEST_CASE("IniParser", "[parser]")
         auto parsed1 = parser.parse_string(contents1);
         CATCH_REQUIRE(parsed1.has_value());
 
-        const fly::Json values1 = *std::move(parsed1);
+        fly::Json const values1 = *std::move(parsed1);
         CATCH_CHECK(values1.size() == 1);
         CATCH_CHECK(values1["section"].size() == 1);
         CATCH_CHECK(values1["section"]["name"] == "Jane Doe");
 
-        const std::string contents2(
+        std::string const contents2(
             "[  \tsection]\n"
             "name=John Doe\n"
             "[section  ]\n"
@@ -181,7 +181,7 @@ CATCH_TEST_CASE("IniParser", "[parser]")
         auto parsed2 = parser.parse_string(contents1);
         CATCH_REQUIRE(parsed2.has_value());
 
-        const fly::Json values2 = *std::move(parsed2);
+        fly::Json const values2 = *std::move(parsed2);
         CATCH_CHECK(values2.size() == 1);
         CATCH_CHECK(values2["section"].size() == 1);
         CATCH_CHECK(values2["section"]["name"] == "Jane Doe");
@@ -189,7 +189,7 @@ CATCH_TEST_CASE("IniParser", "[parser]")
 
     CATCH_SECTION("Duplicate values override existing values")
     {
-        const std::string contents(
+        std::string const contents(
             "[section]\n"
             "name=John Doe\n"
             "name=Jane Doe\n");
@@ -197,7 +197,7 @@ CATCH_TEST_CASE("IniParser", "[parser]")
         auto parsed = parser.parse_string(contents);
         CATCH_REQUIRE(parsed.has_value());
 
-        const fly::Json values = *std::move(parsed);
+        fly::Json const values = *std::move(parsed);
         CATCH_CHECK(values.size() == 1);
         CATCH_CHECK(values["section"].size() == 1);
         CATCH_CHECK(values["section"]["name"] == "Jane Doe");
@@ -205,11 +205,11 @@ CATCH_TEST_CASE("IniParser", "[parser]")
 
     CATCH_SECTION("Imbalanced braces on section names cannot be parsed")
     {
-        const std::string contents1(
+        std::string const contents1(
             "[section\n"
             "name=John Doe\n");
 
-        const std::string contents2(
+        std::string const contents2(
             "section]\n"
             "name=John Doe\n");
 
@@ -219,26 +219,26 @@ CATCH_TEST_CASE("IniParser", "[parser]")
 
     CATCH_SECTION("Imbalanced quotes on values cannot be parsed")
     {
-        const std::string contents1(
+        std::string const contents1(
             "[section]\n"
             "name=\"John Doe\n");
 
-        const std::string contents2(
+        std::string const contents2(
             "[section]\n"
             "name=John Doe\"\n");
-        const std::string contents3(
+        std::string const contents3(
             "[section]\n"
             "name='John Doe\n");
 
-        const std::string contents4(
+        std::string const contents4(
             "[section]\n"
             "name=John Doe'\n");
 
-        const std::string contents5(
+        std::string const contents5(
             "[section]\n"
             "name=\"John Doe'\n");
 
-        const std::string contents6(
+        std::string const contents6(
             "[section]\n"
             "name='John Doe\"\n");
 
@@ -252,27 +252,27 @@ CATCH_TEST_CASE("IniParser", "[parser]")
 
     CATCH_SECTION("Section names and values names cannot be quoted")
     {
-        const std::string contents1(
+        std::string const contents1(
             "[section]\n"
             "\"name\"=John Doe\n");
 
-        const std::string contents2(
+        std::string const contents2(
             "[section]\n"
             "\'name\'=John Doe\n");
 
-        const std::string contents3(
+        std::string const contents3(
             "[\"section\"]\n"
             "name=John Doe\n");
 
-        const std::string contents4(
+        std::string const contents4(
             "[\'section\']\n"
             "name=John Doe\n");
 
-        const std::string contents5(
+        std::string const contents5(
             "\"[section]\"\n"
             "name=John Doe\n");
 
-        const std::string contents6(
+        std::string const contents6(
             "\'[section]\'\n"
             "name=John Doe\n");
 
@@ -286,17 +286,17 @@ CATCH_TEST_CASE("IniParser", "[parser]")
 
     CATCH_SECTION("Secondary assignment operators are captured as part of the value")
     {
-        const std::string contents1(
+        std::string const contents1(
             "[section]\n"
             "name=John=Doe\n");
-        const std::string contents2(
+        std::string const contents2(
             "[section]\n"
             "name=\"John=Doe\"\n");
 
         auto parsed1 = parser.parse_string(contents1);
         CATCH_REQUIRE(parsed1.has_value());
 
-        const fly::Json values1 = *std::move(parsed1);
+        fly::Json const values1 = *std::move(parsed1);
         CATCH_CHECK(values1.size() == 1);
         CATCH_CHECK(values1["section"].size() == 1);
         CATCH_CHECK(values1["section"]["name"] == "John=Doe");
@@ -304,7 +304,7 @@ CATCH_TEST_CASE("IniParser", "[parser]")
         auto parsed2 = parser.parse_string(contents2);
         CATCH_REQUIRE(parsed2.has_value());
 
-        const fly::Json values2 = *std::move(parsed2);
+        fly::Json const values2 = *std::move(parsed2);
         CATCH_CHECK(values2.size() == 1);
         CATCH_CHECK(values2["section"].size() == 1);
         CATCH_CHECK(values2["section"]["name"] == "John=Doe");
@@ -312,7 +312,7 @@ CATCH_TEST_CASE("IniParser", "[parser]")
 
     CATCH_SECTION("Missing an assignment operator cannot be parsed")
     {
-        const std::string contents(
+        std::string const contents(
             "[section]\n"
             "name\n");
 
@@ -321,7 +321,7 @@ CATCH_TEST_CASE("IniParser", "[parser]")
 
     CATCH_SECTION("Empty values cannot be parsed")
     {
-        const std::string contents(
+        std::string const contents(
             "[section]\n"
             "name=\n");
 
@@ -330,15 +330,15 @@ CATCH_TEST_CASE("IniParser", "[parser]")
 
     CATCH_SECTION("Assignments before a section name cannot be parsed")
     {
-        const std::string contents1(
+        std::string const contents1(
             "name=John Doe\n"
             "[section]\n");
 
-        const std::string contents2(
+        std::string const contents2(
             "name=\n"
             "[section]\n");
 
-        const std::string contents3(
+        std::string const contents3(
             "name\n"
             "[section]\n");
 
@@ -349,7 +349,7 @@ CATCH_TEST_CASE("IniParser", "[parser]")
 
     CATCH_SECTION("Section names with invalid JSON string contents cannot be parsed")
     {
-        const std::string contents(
+        std::string const contents(
             "[\xff]\n"
             "name=John Doe\n"
             "address=USA");
@@ -359,7 +359,7 @@ CATCH_TEST_CASE("IniParser", "[parser]")
 
     CATCH_SECTION("Value names with invalid JSON string contents cannot be parsed")
     {
-        const std::string contents(
+        std::string const contents(
             "[section]\n"
             "\xff=John Doe\n"
             "address=USA");
@@ -369,7 +369,7 @@ CATCH_TEST_CASE("IniParser", "[parser]")
 
     CATCH_SECTION("Values with invalid JSON string contents cannot be parsed")
     {
-        const std::string contents(
+        std::string const contents(
             "[section]\n"
             "name=John Doe\n"
             "address=\xff");
@@ -379,7 +379,7 @@ CATCH_TEST_CASE("IniParser", "[parser]")
 
     CATCH_SECTION("The parser is re-entrant")
     {
-        const std::string contents(
+        std::string const contents(
             "[section]\n"
             "name=John Doe\n"
             "address=USA");
@@ -389,7 +389,7 @@ CATCH_TEST_CASE("IniParser", "[parser]")
             auto parsed = parser.parse_string(contents);
             CATCH_REQUIRE(parsed.has_value());
 
-            const fly::Json values = *std::move(parsed);
+            fly::Json const values = *std::move(parsed);
             CATCH_CHECK(values.size() == 1);
             CATCH_CHECK(values["section"].size() == 2);
             CATCH_CHECK(values["section"]["name"] == "John Doe");

--- a/test/parser/json_parser.cpp
+++ b/test/parser/json_parser.cpp
@@ -15,17 +15,17 @@ CATCH_TEST_CASE("JsonParser", "[parser]")
 {
     fly::parser::JsonParser parser;
 
-    auto validate_fail_raw = [&](const std::string &test) {
+    auto validate_fail_raw = [&](std::string const &test) {
         CATCH_CAPTURE(test);
         CATCH_CHECK_FALSE(parser.parse_string(test).has_value());
     };
 
-    auto validate_fail = [&](const std::string &test) {
+    auto validate_fail = [&](std::string const &test) {
         validate_fail_raw(fly::String::format("{{ \"a\" : {} }}", test));
     };
 
     auto validate_pass_raw =
-        [&](const std::string &test, const std::string &key, const fly::Json &expected) {
+        [&](std::string const &test, std::string const &key, fly::Json const &expected) {
             CATCH_CAPTURE(test);
 
             std::optional<fly::Json> actual = parser.parse_string(test);
@@ -46,7 +46,7 @@ CATCH_TEST_CASE("JsonParser", "[parser]")
             CATCH_CHECK(*actual == *repeat);
         };
 
-    auto validate_pass = [&](const std::string &test, const fly::Json &expected) {
+    auto validate_pass = [&](std::string const &test, fly::Json const &expected) {
         validate_pass_raw(fly::String::format("{{ \"a\" : {} }}", test), "a", expected);
     };
 
@@ -57,13 +57,13 @@ CATCH_TEST_CASE("JsonParser", "[parser]")
         // - fail18.json: The parser has no max-depth
 
         // Get the path to the JSON checker directory.
-        const auto here = std::filesystem::path(__FILE__);
-        const auto path = here.parent_path() / "json" / "json_checker";
+        auto const here = std::filesystem::path(__FILE__);
+        auto const path = here.parent_path() / "json" / "json_checker";
 
         // Validate each JSON file in the JSON checker directory.
-        for (const auto &it : std::filesystem::directory_iterator(path))
+        for (auto const &it : std::filesystem::directory_iterator(path))
         {
-            const auto file = it.path().filename();
+            auto const file = it.path().filename();
             CATCH_CAPTURE(file);
 
             if (file.string().starts_with("pass"))
@@ -84,8 +84,8 @@ CATCH_TEST_CASE("JsonParser", "[parser]")
     // https://code.google.com/archive/p/json-test-suite/
     CATCH_SECTION("Google's json-test-suite")
     {
-        const auto here = std::filesystem::path(__FILE__);
-        const auto path = here.parent_path() / "json" / "google_json_test_suite";
+        auto const here = std::filesystem::path(__FILE__);
+        auto const path = here.parent_path() / "json" / "google_json_test_suite";
 
         CATCH_CHECK(parser.parse_file(path / "sample.json").has_value());
     }
@@ -109,13 +109,13 @@ CATCH_TEST_CASE("JsonParser", "[parser]")
         fly::parser::JsonParser type_parser(fly::parser::JsonParser::Features::AllowAnyType);
 
         // Get the path to the JSONTestSuite directory.
-        const auto here = std::filesystem::path(__FILE__);
-        const auto path = here.parent_path() / "json" / "nst_json_test_suite";
+        auto const here = std::filesystem::path(__FILE__);
+        auto const path = here.parent_path() / "json" / "nst_json_test_suite";
 
         // Validate each JSON file in the JSONTestSuite directory.
-        for (const auto &it : std::filesystem::directory_iterator(path))
+        for (auto const &it : std::filesystem::directory_iterator(path))
         {
-            const auto file = it.path().filename();
+            auto const file = it.path().filename();
             CATCH_CAPTURE(file);
 
             if (file.string().starts_with('y'))
@@ -147,8 +147,8 @@ CATCH_TEST_CASE("JsonParser", "[parser]")
     // https://github.com/minimaxir/big-list-of-naughty-strings
     CATCH_SECTION("Big List of Naughty Strings")
     {
-        const auto here = std::filesystem::path(__FILE__);
-        const auto path = here.parent_path() / "json" / "big_list_of_naughty_strings";
+        auto const here = std::filesystem::path(__FILE__);
+        auto const path = here.parent_path() / "json" / "big_list_of_naughty_strings";
 
         auto parsed = parser.parse_file(path / "blns.json");
         CATCH_REQUIRE(parsed.has_value());
@@ -164,8 +164,8 @@ CATCH_TEST_CASE("JsonParser", "[parser]")
 
     CATCH_SECTION("All Unicode characters")
     {
-        const auto here = std::filesystem::path(__FILE__);
-        const auto path = here.parent_path() / "json" / "unicode";
+        auto const here = std::filesystem::path(__FILE__);
+        auto const path = here.parent_path() / "json" / "unicode";
 
         auto parsed = parser.parse_file(path / "all_unicode.json");
         CATCH_REQUIRE(parsed.has_value());
@@ -176,7 +176,7 @@ CATCH_TEST_CASE("JsonParser", "[parser]")
 
     CATCH_SECTION("String with UTF-8 encoding (std::string)")
     {
-        const std::string contents("{\"encoding\": \"UTF-8\"}");
+        std::string const contents("{\"encoding\": \"UTF-8\"}");
 
         auto parsed = parser.parse_string(contents);
         CATCH_REQUIRE(parsed.has_value());
@@ -190,7 +190,7 @@ CATCH_TEST_CASE("JsonParser", "[parser]")
 
     CATCH_SECTION("String with UTF-8 encoding (std::u8string)")
     {
-        const std::u8string contents(u8"{\"encoding\": \"UTF-8\"}");
+        std::u8string const contents(u8"{\"encoding\": \"UTF-8\"}");
 
         auto parsed = parser.parse_string(contents);
         CATCH_REQUIRE(parsed.has_value());
@@ -204,8 +204,8 @@ CATCH_TEST_CASE("JsonParser", "[parser]")
 
     CATCH_SECTION("File with UTF-8 byte order mark")
     {
-        const auto here = std::filesystem::path(__FILE__);
-        const auto path = here.parent_path() / "json" / "unicode";
+        auto const here = std::filesystem::path(__FILE__);
+        auto const path = here.parent_path() / "json" / "unicode";
 
         auto parsed = parser.parse_file(path / "utf_8.json");
         CATCH_REQUIRE(parsed.has_value());
@@ -219,7 +219,7 @@ CATCH_TEST_CASE("JsonParser", "[parser]")
 
     CATCH_SECTION("String with UTF-16 encoding")
     {
-        const std::u16string contents(u"{\"encoding\": \"UTF-16\"}");
+        std::u16string const contents(u"{\"encoding\": \"UTF-16\"}");
 
         auto parsed = parser.parse_string(contents);
         CATCH_REQUIRE(parsed.has_value());
@@ -236,8 +236,8 @@ CATCH_TEST_CASE("JsonParser", "[parser]")
 
     CATCH_SECTION("File with UTF-16 big endian byte order mark")
     {
-        const auto here = std::filesystem::path(__FILE__);
-        const auto path = here.parent_path() / "json" / "unicode";
+        auto const here = std::filesystem::path(__FILE__);
+        auto const path = here.parent_path() / "json" / "unicode";
 
         auto parsed = parser.parse_file(path / "utf_16_big_endian.json");
         CATCH_REQUIRE(parsed.has_value());
@@ -254,8 +254,8 @@ CATCH_TEST_CASE("JsonParser", "[parser]")
 
     CATCH_SECTION("File with UTF-16 little endian byte order mark")
     {
-        const auto here = std::filesystem::path(__FILE__);
-        const auto path = here.parent_path() / "json" / "unicode";
+        auto const here = std::filesystem::path(__FILE__);
+        auto const path = here.parent_path() / "json" / "unicode";
 
         auto parsed = parser.parse_file(path / "utf_16_little_endian.json");
         CATCH_REQUIRE(parsed.has_value());
@@ -272,7 +272,7 @@ CATCH_TEST_CASE("JsonParser", "[parser]")
 
     CATCH_SECTION("String with UTF-32 encoding")
     {
-        const std::u32string contents(U"{\"encoding\": \"UTF-32\"}");
+        std::u32string const contents(U"{\"encoding\": \"UTF-32\"}");
 
         auto parsed = parser.parse_string(contents);
         CATCH_REQUIRE(parsed.has_value());
@@ -289,8 +289,8 @@ CATCH_TEST_CASE("JsonParser", "[parser]")
 
     CATCH_SECTION("File with UTF-32 big endian byte order mark")
     {
-        const auto here = std::filesystem::path(__FILE__);
-        const auto path = here.parent_path() / "json" / "unicode";
+        auto const here = std::filesystem::path(__FILE__);
+        auto const path = here.parent_path() / "json" / "unicode";
 
         auto parsed = parser.parse_file(path / "utf_32_big_endian.json");
         CATCH_REQUIRE(parsed.has_value());
@@ -307,8 +307,8 @@ CATCH_TEST_CASE("JsonParser", "[parser]")
 
     CATCH_SECTION("File with UTF-32 little endian byte order mark")
     {
-        const auto here = std::filesystem::path(__FILE__);
-        const auto path = here.parent_path() / "json" / "unicode";
+        auto const here = std::filesystem::path(__FILE__);
+        auto const path = here.parent_path() / "json" / "unicode";
 
         auto parsed = parser.parse_file(path / "utf_32_little_endian.json");
         CATCH_REQUIRE(parsed.has_value());
@@ -337,7 +337,7 @@ CATCH_TEST_CASE("JsonParser", "[parser]")
 
     CATCH_SECTION("Empty file cannot be parsed")
     {
-        const std::string contents;
+        std::string const contents;
 
         auto parsed = parser.parse_string(contents);
         CATCH_CHECK_FALSE(parsed.has_value());
@@ -345,7 +345,7 @@ CATCH_TEST_CASE("JsonParser", "[parser]")
 
     CATCH_SECTION("Empty JSON object can be parsed")
     {
-        const std::string contents("{}");
+        std::string const contents("{}");
 
         auto parsed = parser.parse_string(contents);
         CATCH_REQUIRE(parsed.has_value());
@@ -357,7 +357,7 @@ CATCH_TEST_CASE("JsonParser", "[parser]")
 
     CATCH_SECTION("Empty JSON array can be parsed")
     {
-        const std::string contents("[]");
+        std::string const contents("[]");
 
         auto parsed = parser.parse_string(contents);
         CATCH_REQUIRE(parsed.has_value());
@@ -369,7 +369,7 @@ CATCH_TEST_CASE("JsonParser", "[parser]")
 
     CATCH_SECTION("Nested empty JSON object can be parsed")
     {
-        const std::string contents("[{}]");
+        std::string const contents("[{}]");
 
         auto parsed = parser.parse_string(contents);
         CATCH_REQUIRE(parsed.has_value());
@@ -385,7 +385,7 @@ CATCH_TEST_CASE("JsonParser", "[parser]")
 
     CATCH_SECTION("Nested empty JSON array can be parsed")
     {
-        const std::string contents("[[]]");
+        std::string const contents("[[]]");
 
         auto parsed = parser.parse_string(contents);
         CATCH_REQUIRE(parsed.has_value());
@@ -402,7 +402,7 @@ CATCH_TEST_CASE("JsonParser", "[parser]")
     CATCH_SECTION("Empty key/value strings can be parsed")
     {
         {
-            const std::string contents("{\"a\" : \"\" }");
+            std::string const contents("{\"a\" : \"\" }");
 
             auto parsed = parser.parse_string(contents);
             CATCH_REQUIRE(parsed.has_value());
@@ -413,7 +413,7 @@ CATCH_TEST_CASE("JsonParser", "[parser]")
             CATCH_CHECK(values["a"] == "");
         }
         {
-            const std::string contents("{\"\" : \"a\" }");
+            std::string const contents("{\"\" : \"a\" }");
 
             auto parsed = parser.parse_string(contents);
             CATCH_REQUIRE(parsed.has_value());
@@ -424,7 +424,7 @@ CATCH_TEST_CASE("JsonParser", "[parser]")
             CATCH_CHECK(values[""] == "a");
         }
         {
-            const std::string contents("{\"\" : \"\" }");
+            std::string const contents("{\"\" : \"\" }");
 
             auto parsed = parser.parse_string(contents);
             CATCH_REQUIRE(parsed.has_value());

--- a/test/path/path_monitor.cpp
+++ b/test/path/path_monitor.cpp
@@ -26,8 +26,8 @@ using namespace fly::literals::numeric_literals;
 
 namespace {
 
-constexpr const char *s_path_monitor_file = "path_monitor.cpp";
-const std::chrono::seconds s_wait_time(5);
+constexpr char const *s_path_monitor_file = "path_monitor.cpp";
+constexpr std::chrono::seconds s_wait_time(5);
 
 /**
  * Subclass of the path config to decrease the poll interval for faster testing.
@@ -35,7 +35,8 @@ const std::chrono::seconds s_wait_time(5);
 class TestPathConfig : public fly::path::PathConfig
 {
 public:
-    TestPathConfig() noexcept : fly::path::PathConfig()
+    TestPathConfig() noexcept :
+        fly::path::PathConfig()
     {
         m_default_poll_interval = 10_i64;
     }

--- a/test/system/system_monitor.cpp
+++ b/test/system/system_monitor.cpp
@@ -25,7 +25,7 @@ using namespace fly::literals::numeric_literals;
 
 namespace {
 
-constexpr const char *s_system_monitor_file = "system_monitor.cpp";
+constexpr char const *s_system_monitor_file = "system_monitor.cpp";
 
 /**
  * Subclass of the system config to decrease the poll interval for faster testing.
@@ -33,7 +33,8 @@ constexpr const char *s_system_monitor_file = "system_monitor.cpp";
 class TestSystemConfig : public fly::system::SystemConfig
 {
 public:
-    TestSystemConfig() noexcept : fly::system::SystemConfig()
+    TestSystemConfig() noexcept :
+        fly::system::SystemConfig()
     {
         m_default_poll_interval = 100_i64;
     }

--- a/test/task/task.cpp
+++ b/test/task/task.cpp
@@ -29,7 +29,8 @@ void standalone_task(bool &task_was_called)
 class TaskClass
 {
 public:
-    explicit TaskClass(bool &task_was_called) : m_task_was_called(task_was_called)
+    explicit TaskClass(bool &task_was_called) :
+        m_task_was_called(task_was_called)
     {
     }
 
@@ -53,7 +54,8 @@ private:
 class CountTask
 {
 public:
-    CountTask() noexcept : m_count(0)
+    CountTask() noexcept :
+        m_count(0)
     {
     }
 
@@ -77,7 +79,8 @@ private:
 class MarkerTask
 {
 public:
-    MarkerTask(fly::ConcurrentQueue<int> *ordering) noexcept : m_ordering(ordering)
+    MarkerTask(fly::ConcurrentQueue<int> *ordering) noexcept :
+        m_ordering(ordering)
     {
     }
 
@@ -96,7 +99,8 @@ private:
 class TimerTask
 {
 public:
-    TimerTask() noexcept : m_start_time(std::chrono::steady_clock::now())
+    TimerTask() noexcept :
+        m_start_time(std::chrono::steady_clock::now())
     {
     }
 
@@ -248,7 +252,7 @@ CATCH_TEST_CASE("Task", "[task]")
             fly::test::WaitableSequencedTaskRunner::create(fly::test::task_manager());
 
         TimerTask task;
-        const std::chrono::milliseconds delay(10);
+        std::chrono::milliseconds const delay(10);
 
         CATCH_REQUIRE(
             task_runner->post_task_with_delay(FROM_HERE, delay, std::bind(&TimerTask::run, &task)));

--- a/test/types/bit_stream/bit_stream.cpp
+++ b/test/types/bit_stream/bit_stream.cpp
@@ -21,10 +21,10 @@ CATCH_TEST_CASE("BitStream", "[bit_stream]")
     };
 
     auto verify_header = [&output_stream](fly::byte_type expected_remainder) {
-        const std::string buffer = output_stream.str();
+        std::string const buffer = output_stream.str();
         CATCH_REQUIRE_FALSE(buffer.empty());
 
-        const fly::byte_type header = static_cast<fly::byte_type>(buffer[0]);
+        fly::byte_type const header = static_cast<fly::byte_type>(buffer[0]);
 
         fly::byte_type magic = (header >> fly::detail::s_magic_shift) & fly::detail::s_magic_mask;
         fly::byte_type remainder =

--- a/test/types/json/json.cpp
+++ b/test/types/json/json.cpp
@@ -57,7 +57,7 @@ CATCH_TEST_CASE("Json", "[json]")
     CATCH_SECTION("Check the iterator at the beginning of a JSON instance")
     {
         fly::Json json1 {1, 2, 3};
-        const fly::Json json2 {4, 5, 6};
+        fly::Json const json2 {4, 5, 6};
 
         auto begin1 = json1.begin();
         CATCH_CHECK(*begin1 == 1);
@@ -80,7 +80,7 @@ CATCH_TEST_CASE("Json", "[json]")
     CATCH_SECTION("Check the iterator at the end of a JSON instance")
     {
         fly::Json json1 {1, 2, 3};
-        const fly::Json json2 {4, 5, 6};
+        fly::Json const json2 {4, 5, 6};
 
         auto end1 = json1.end();
         CATCH_CHECK(*(end1 - 1) == 3);
@@ -103,7 +103,7 @@ CATCH_TEST_CASE("Json", "[json]")
     CATCH_SECTION("Check the reverse iterator at the beginning of a JSON instance")
     {
         fly::Json json1 {1, 2, 3};
-        const fly::Json json2 {4, 5, 6};
+        fly::Json const json2 {4, 5, 6};
 
         auto begin1 = json1.rbegin();
         CATCH_CHECK(*begin1 == 3);
@@ -126,7 +126,7 @@ CATCH_TEST_CASE("Json", "[json]")
     CATCH_SECTION("Check the reverse iterator at the end of a JSON instance")
     {
         fly::Json json1 {1, 2, 3};
-        const fly::Json json2 {4, 5, 6};
+        fly::Json const json2 {4, 5, 6};
 
         auto end1 = json1.rend();
         CATCH_CHECK(*(end1 - 1) == 1);
@@ -191,7 +191,7 @@ CATCH_TEST_CASE("Json", "[json]")
         {
             fly::Json::size_type size = 0;
 
-            for (const fly::Json &value : json)
+            for (fly::Json const &value : json)
             {
                 CATCH_CHECK(value == (size++ == 0 ? 1 : 2));
             }
@@ -243,7 +243,7 @@ CATCH_TEST_CASE("Json", "[json]")
         {
             fly::Json::size_type size = 0;
 
-            for (const fly::Json &value : json)
+            for (fly::Json const &value : json)
             {
                 CATCH_CHECK(value == json[size++]);
             }

--- a/test/types/json/json_accessors.cpp
+++ b/test/types/json/json_accessors.cpp
@@ -10,7 +10,7 @@ CATCH_JSON_TEST_CASE("JsonAccessors")
     using json_type = TestType;
 
     fly::Json json1 = fly::test::create_json<json_type>();
-    const fly::Json json2 = fly::test::create_json<json_type>();
+    fly::Json const json2 = fly::test::create_json<json_type>();
 
     CATCH_SECTION("Access a JSON array's values via the accessor 'at'")
     {
@@ -86,7 +86,7 @@ CATCH_JSON_TEST_CASE("JsonAccessors")
             auto &front1 = json1.front();
             CATCH_CHECK(front1 == *(json1.begin()));
 
-            const auto &front2 = json2.front();
+            auto const &front2 = json2.front();
             CATCH_CHECK(front2 == *(json2.begin()));
 
             fly::Json empty = json_type();
@@ -112,7 +112,7 @@ CATCH_JSON_TEST_CASE("JsonAccessors")
             auto &back1 = json1.back();
             CATCH_CHECK(back1 == *(--(json1.end())));
 
-            const auto &back2 = json2.back();
+            auto const &back2 = json2.back();
             CATCH_CHECK(back2 == *(--(json2.end())));
 
             fly::Json empty = json_type();
@@ -186,7 +186,7 @@ CATCH_JSON_TEST_CASE("JsonAccessors")
 
         if constexpr (is_string_or_array)
         {
-            const auto size_before = json1.size();
+            auto const size_before = json1.size();
 
             json1.resize(size_before * 2);
             CATCH_CHECK(json1.size() == (size_before * 2));
@@ -215,8 +215,8 @@ CATCH_JSON_TEST_CASE("JsonAccessors")
         }
         else if constexpr (is_string_or_array)
         {
-            const auto capacity1 = json1.capacity();
-            const auto capacity2 = json2.capacity();
+            auto const capacity1 = json1.capacity();
+            auto const capacity2 = json2.capacity();
             CATCH_CHECK(capacity1 == capacity2);
             CATCH_CHECK(capacity1 > 0);
         }
@@ -239,9 +239,9 @@ CATCH_JSON_TEST_CASE("JsonAccessors")
 
         if constexpr (is_string_or_array)
         {
-            const auto capacity_before = json1.capacity();
+            auto const capacity_before = json1.capacity();
             json1.reserve(capacity_before * 2);
-            const auto capacity_after = json1.capacity();
+            auto const capacity_after = json1.capacity();
             CATCH_CHECK(capacity_after > capacity_before);
 
             json1.reserve(capacity_before);
@@ -264,7 +264,7 @@ CATCH_JSON_STRING_TEST_CASE("JsonAccessorsByString")
     using char_type = typename string_type::value_type;
 
     fly::Json json1 = fly::test::create_json<json_type, string_type>();
-    const fly::Json json2 = fly::test::create_json<json_type, string_type>();
+    fly::Json const json2 = fly::test::create_json<json_type, string_type>();
 
     CATCH_SECTION("Access a JSON object's values via the accessor 'at'")
     {
@@ -335,7 +335,7 @@ CATCH_JSON_STRING_TEST_CASE("JsonAccessorsByString")
     {
         if constexpr (std::is_same_v<json_type, fly::json_object_type>)
         {
-            const fly::Json empty = fly::json_object_type();
+            fly::Json const empty = fly::json_object_type();
             CATCH_CHECK(empty.count(J_STR("a")) == 0);
             CATCH_CHECK(empty.count(J_STR("b")) == 0);
             CATCH_CHECK(empty.count(J_STR("c")) == 0);
@@ -400,7 +400,7 @@ CATCH_JSON_STRING_TEST_CASE("JsonAccessorsByString")
     {
         if constexpr (std::is_same_v<json_type, fly::json_object_type>)
         {
-            const fly::Json empty = fly::json_object_type();
+            fly::Json const empty = fly::json_object_type();
             CATCH_CHECK_FALSE(empty.contains(J_STR("a")));
             CATCH_CHECK_FALSE(empty.contains(J_STR("b")));
             CATCH_CHECK_FALSE(empty.contains(J_STR("c")));

--- a/test/types/json/json_concepts.cpp
+++ b/test/types/json/json_concepts.cpp
@@ -76,22 +76,22 @@ CATCH_TEMPLATE_TEST_CASE(
 
     CATCH_SECTION("Concepts for string-like JSON types")
     {
-        CATCH_CHECK(fly::JsonString<const string_type>);
+        CATCH_CHECK(fly::JsonString<string_type const>);
         CATCH_CHECK(fly::JsonString<string_type>);
-        CATCH_CHECK_FALSE(fly::JsonString<const char_type *>);
+        CATCH_CHECK_FALSE(fly::JsonString<char_type const *>);
         CATCH_CHECK_FALSE(fly::JsonString<char_type *>);
-        CATCH_CHECK_FALSE(fly::JsonString<const char_type[]>);
+        CATCH_CHECK_FALSE(fly::JsonString<char_type const[]>);
         CATCH_CHECK_FALSE(fly::JsonString<char_type[]>);
-        CATCH_CHECK_FALSE(fly::JsonString<const view_type>);
+        CATCH_CHECK_FALSE(fly::JsonString<view_type const>);
         CATCH_CHECK_FALSE(fly::JsonString<view_type>);
 
-        CATCH_CHECK(fly::JsonStringLike<const string_type>);
+        CATCH_CHECK(fly::JsonStringLike<string_type const>);
         CATCH_CHECK(fly::JsonStringLike<string_type>);
-        CATCH_CHECK(fly::JsonStringLike<const char_type *>);
+        CATCH_CHECK(fly::JsonStringLike<char_type const *>);
         CATCH_CHECK(fly::JsonStringLike<char_type *>);
-        CATCH_CHECK(fly::JsonStringLike<const char_type[]>);
+        CATCH_CHECK(fly::JsonStringLike<char_type const[]>);
         CATCH_CHECK(fly::JsonStringLike<char_type[]>);
-        CATCH_CHECK(fly::JsonStringLike<const view_type>);
+        CATCH_CHECK(fly::JsonStringLike<view_type const>);
         CATCH_CHECK(fly::JsonStringLike<view_type>);
 
         CATCH_CHECK_FALSE(fly::JsonString<array_type>);
@@ -127,7 +127,7 @@ CATCH_TEMPLATE_TEST_CASE(
         CATCH_CHECK_FALSE(fly::JsonString<boolean_type>);
         CATCH_CHECK_FALSE(fly::JsonString<float_type>);
         CATCH_CHECK_FALSE(fly::JsonString<double_type>);
-        CATCH_CHECK_FALSE(fly::JsonString<const char_type>);
+        CATCH_CHECK_FALSE(fly::JsonString<char_type const>);
         CATCH_CHECK_FALSE(fly::JsonString<char_type>);
 
         CATCH_CHECK_FALSE(fly::JsonStringLike<null_type>);
@@ -135,7 +135,7 @@ CATCH_TEMPLATE_TEST_CASE(
         CATCH_CHECK_FALSE(fly::JsonStringLike<boolean_type>);
         CATCH_CHECK_FALSE(fly::JsonStringLike<float_type>);
         CATCH_CHECK_FALSE(fly::JsonStringLike<double_type>);
-        CATCH_CHECK_FALSE(fly::JsonStringLike<const char_type>);
+        CATCH_CHECK_FALSE(fly::JsonStringLike<char_type const>);
         CATCH_CHECK_FALSE(fly::JsonStringLike<char_type>);
     }
 

--- a/test/types/json/json_construction.cpp
+++ b/test/types/json/json_construction.cpp
@@ -28,7 +28,7 @@ CATCH_TEMPLATE_TEST_CASE(
     using char_type = typename string_type::value_type;
 
     auto reserved_codepoint = []() -> string_type {
-        static constexpr const std::uint32_t s_reserved = 0xd800;
+        static constexpr std::uint32_t s_reserved = 0xd800;
         string_type result;
 
         if constexpr (sizeof(char_type) == 1)
@@ -47,19 +47,19 @@ CATCH_TEMPLATE_TEST_CASE(
 
     CATCH_SECTION("Construct a JSON instance from string-like types")
     {
-        const string_type str1 = J_STR("a");
+        string_type const str1 = J_STR("a");
         CATCH_CHECK(fly::Json(str1).is_string());
 
         string_type str2 = J_STR("b");
         CATCH_CHECK(fly::Json(str2).is_string());
 
-        const char_type *cstr1 = J_STR("c");
+        char_type const *cstr1 = J_STR("c");
         CATCH_CHECK(fly::Json(cstr1).is_string());
 
         char_type *cstr2 = const_cast<char_type *>(J_STR("d"));
         CATCH_CHECK(fly::Json(cstr2).is_string());
 
-        const char_type arr1[] = {J_CHR('g'), '\0'};
+        char_type const arr1[] = {J_CHR('g'), '\0'};
         CATCH_CHECK(fly::Json(arr1).is_string());
 
         char_type arr2[] = {J_CHR('h'), '\0'};
@@ -218,16 +218,16 @@ CATCH_TEMPLATE_TEST_CASE(
 
     CATCH_SECTION("Construct a JSON instance from initializer lists")
     {
-        const fly::Json empty {};
+        fly::Json const empty {};
         CATCH_CHECK(fly::Json(empty).is_null());
 
-        const fly::Json array {J_CHR('7'), 8, J_STR("nine"), 10};
+        fly::Json const array {J_CHR('7'), 8, J_STR("nine"), 10};
         CATCH_CHECK(fly::Json(array).is_array());
 
-        const fly::Json object {{J_STR("a"), 1}, {J_STR("b"), 2}};
+        fly::Json const object {{J_STR("a"), 1}, {J_STR("b"), 2}};
         CATCH_CHECK(fly::Json(object).is_object());
 
-        const fly::Json almost {{J_STR("a"), 1}, {J_STR("b"), 2}, 4};
+        fly::Json const almost {{J_STR("a"), 1}, {J_STR("b"), 2}, 4};
         CATCH_CHECK(fly::Json(almost).is_array());
     }
 

--- a/test/types/json/json_conversion.cpp
+++ b/test/types/json/json_conversion.cpp
@@ -37,7 +37,7 @@ CATCH_JSON_STRING_TEST_CASE("JsonConversion")
 
     CATCH_SECTION("Convert a JSON instance to object-like types")
     {
-        auto validate = [&json]<typename T1, typename T2, typename T3>(const char *name) {
+        auto validate = [&json]<typename T1, typename T2, typename T3>(char const *name) {
             CATCH_CAPTURE(name);
 
             auto test1 = T1 {{J_STR("a"), 2}, {J_STR("b"), 4}};
@@ -64,7 +64,7 @@ CATCH_JSON_STRING_TEST_CASE("JsonConversion")
             CATCH_CHECK_THROWS_JSON(T1(json), "JSON type is not numeric: ({})", json["a"]);
         };
 
-        auto invalidate = [&json]<typename T>(const char *name) {
+        auto invalidate = [&json]<typename T>(char const *name) {
             CATCH_CAPTURE(name);
 
             CATCH_CHECK_THROWS_JSON(
@@ -80,7 +80,7 @@ CATCH_JSON_STRING_TEST_CASE("JsonConversion")
 
     CATCH_SECTION("Convert a JSON instance to array-like types")
     {
-        auto validate = [&json]<typename T1, typename T2, typename T3>(const char *name) {
+        auto validate = [&json]<typename T1, typename T2, typename T3>(char const *name) {
             CATCH_CAPTURE(name);
 
             auto test1 = T1 {50, 60, 70, 80};
@@ -113,7 +113,7 @@ CATCH_JSON_STRING_TEST_CASE("JsonConversion")
                 json[0]);
         };
 
-        auto invalidate = [&json]<typename T>(const char *name) {
+        auto invalidate = [&json]<typename T>(char const *name) {
             CATCH_CAPTURE(name);
 
             CATCH_CHECK_THROWS_JSON(FLY_UNUSED((T(json))), "JSON type is not an array: ({})", json);

--- a/test/types/json/json_exception.cpp
+++ b/test/types/json/json_exception.cpp
@@ -63,7 +63,7 @@ CATCH_TEST_CASE("JsonException", "[json]")
         {
             throw fly::OutOfRangeJsonException(string, 12389);
         }
-        catch (const fly::OutOfRangeJsonException &ex)
+        catch (fly::OutOfRangeJsonException const &ex)
         {
             offset = ex.offset();
         }

--- a/test/types/json/json_modifiers.cpp
+++ b/test/types/json/json_modifiers.cpp
@@ -26,8 +26,8 @@ CATCH_JSON_TEST_CASE("JsonModifiers")
 
     CATCH_SECTION("Insert a value into a JSON array")
     {
-        const fly::Json array = {1, 2, 3, 4};
-        const fly::Json value = 1;
+        fly::Json const array = {1, 2, 3, 4};
+        fly::Json const value = 1;
 
         if constexpr (std::is_same_v<json_type, fly::json_array_type>)
         {
@@ -64,7 +64,7 @@ CATCH_JSON_TEST_CASE("JsonModifiers")
 
     CATCH_SECTION("Insert a moved value into a JSON array")
     {
-        const fly::Json array = {1, 2, 3};
+        fly::Json const array = {1, 2, 3};
 
         auto value = []() -> fly::Json {
             return fly::Json(1);
@@ -105,8 +105,8 @@ CATCH_JSON_TEST_CASE("JsonModifiers")
 
     CATCH_SECTION("Insert copies of a value into a JSON array")
     {
-        const fly::Json array = {1, 2, 3};
-        const fly::Json value = 1;
+        fly::Json const array = {1, 2, 3};
+        fly::Json const value = 1;
 
         if constexpr (std::is_same_v<json_type, fly::json_array_type>)
         {
@@ -154,8 +154,8 @@ CATCH_JSON_TEST_CASE("JsonModifiers")
 
     CATCH_SECTION("Insert copies of a value into a JSON array")
     {
-        const fly::Json object = {{"c", 3}, {"d", 4}};
-        const fly::Json array = {1, 2, 3};
+        fly::Json const object = {{"c", 3}, {"d", 4}};
+        fly::Json const array = {1, 2, 3};
 
         if constexpr (std::is_same_v<json_type, fly::json_array_type>)
         {
@@ -209,7 +209,7 @@ CATCH_JSON_TEST_CASE("JsonModifiers")
 
     CATCH_SECTION("Insert a list of values into a JSON array")
     {
-        const fly::Json array = {1, 2, 3};
+        fly::Json const array = {1, 2, 3};
 
         if constexpr (std::is_same_v<json_type, fly::json_array_type>)
         {
@@ -254,9 +254,9 @@ CATCH_JSON_TEST_CASE("JsonModifiers")
 
         if constexpr (fly::test::is_null_or_other_type_v<json_type, fly::json_array_type>)
         {
-            const auto size_before = json.size();
+            auto const size_before = json.size();
             auto &result = json.emplace_back(std::move(value));
-            const auto size_after = json.size();
+            auto const size_after = json.size();
 
             CATCH_CHECK((size_after - size_before) == 1);
             CATCH_CHECK(result == 3);
@@ -272,12 +272,12 @@ CATCH_JSON_TEST_CASE("JsonModifiers")
 
     CATCH_SECTION("Push a value into a JSON array")
     {
-        const fly::Json value1 = 3;
-        const fly::Json value2 = 4;
+        fly::Json const value1 = 3;
+        fly::Json const value2 = 4;
 
         if constexpr (fly::test::is_null_or_other_type_v<json_type, fly::json_array_type>)
         {
-            const auto starting_size = json.size();
+            auto const starting_size = json.size();
 
             json.push_back(value1);
             CATCH_CHECK(json.size() == (starting_size + 1));
@@ -303,7 +303,7 @@ CATCH_JSON_TEST_CASE("JsonModifiers")
 
         if constexpr (fly::test::is_null_or_other_type_v<json_type, fly::json_array_type>)
         {
-            const auto starting_size = json.size();
+            auto const starting_size = json.size();
 
             json.push_back(std::move(value1));
             CATCH_CHECK(json.size() == (starting_size + 1));
@@ -501,7 +501,7 @@ CATCH_JSON_TEST_CASE("JsonModifiers")
 
     CATCH_SECTION("Swap a JSON instance with an array-like type")
     {
-        auto validate = [&json]<typename T1, typename T2, typename T3>(const char *name) {
+        auto validate = [&json]<typename T1, typename T2, typename T3>(char const *name) {
             CATCH_CAPTURE(name);
             json = {1, 2};
 
@@ -538,7 +538,7 @@ CATCH_JSON_TEST_CASE("JsonModifiers")
             CATCH_CHECK(test3 == T3 {nullptr, true});
         };
 
-        auto invalidate = [&json]<typename T>(const char *name) {
+        auto invalidate = [&json]<typename T>(char const *name) {
             CATCH_CAPTURE(name);
             T test {};
 
@@ -620,12 +620,12 @@ CATCH_JSON_STRING_TEST_CASE("JsonModifiersByString")
     using char_type = typename string_type::value_type;
 
     fly::Json json = fly::test::create_json<json_type, string_type>();
-    const string_type key = J_STR("k\\u0065y"); // "key"
+    string_type const key = J_STR("k\\u0065y"); // "key"
 
     CATCH_SECTION("Insert a value into a JSON object")
     {
-        const fly::Json value1 = 3;
-        const fly::Json value2 = 4;
+        fly::Json const value1 = 3;
+        fly::Json const value2 = 4;
 
         if constexpr (std::is_same_v<json_type, fly::json_object_type>)
         {
@@ -702,11 +702,11 @@ CATCH_JSON_STRING_TEST_CASE("JsonModifiersByString")
 
     CATCH_SECTION("Insert a range of values into a JSON object")
     {
-        const fly::Json object = {{J_STR("c"), fly::Json(3)}, {J_STR("d"), fly::Json(4)}};
+        fly::Json const object = {{J_STR("c"), fly::Json(3)}, {J_STR("d"), fly::Json(4)}};
 
         if constexpr (std::is_same_v<json_type, fly::json_object_type>)
         {
-            const fly::Json array = {J_STR("c"), J_STR("d")};
+            fly::Json const array = {J_STR("c"), J_STR("d")};
 
             CATCH_CHECK_THROWS_JSON(
                 json.insert(object.begin(), fly::Json::const_iterator()),
@@ -809,7 +809,7 @@ CATCH_JSON_STRING_TEST_CASE("JsonModifiersByString")
 
     CATCH_SECTION("Swap a JSON instance with an object-like type")
     {
-        auto validate = [&json]<typename T1, typename T2, typename T3>(const char *name) {
+        auto validate = [&json]<typename T1, typename T2, typename T3>(char const *name) {
             CATCH_CAPTURE(name);
             json = {{J_STR("c"), 100}, {J_STR("d"), 200}};
 
@@ -834,7 +834,7 @@ CATCH_JSON_STRING_TEST_CASE("JsonModifiersByString")
             CATCH_CHECK(test1 == T1 {{J_STR("a"), 5}, {J_STR("b"), 6}});
         };
 
-        auto invalidate = [&json]<typename T>(const char *name) {
+        auto invalidate = [&json]<typename T>(char const *name) {
             CATCH_CAPTURE(name);
             T test {};
 
@@ -851,7 +851,7 @@ CATCH_JSON_STRING_TEST_CASE("JsonModifiersByString")
 
     CATCH_SECTION("Merge an object-like type into a JSON instance")
     {
-        auto validate = [&json]<typename T1, typename T2, typename T3>(const char *name) {
+        auto validate = [&json]<typename T1, typename T2, typename T3>(char const *name) {
             json = fly::test::create_json<json_type, string_type>();
             CATCH_CAPTURE(name);
 
@@ -886,7 +886,7 @@ CATCH_JSON_STRING_TEST_CASE("JsonModifiersByString")
             CATCH_CHECK(json[J_STR("g")] == "8");
         };
 
-        auto invalidate = [&json]<typename T>(const char *name) {
+        auto invalidate = [&json]<typename T>(char const *name) {
             CATCH_CAPTURE(name);
             T test {};
 

--- a/test/types/numeric/endian.cpp
+++ b/test/types/numeric/endian.cpp
@@ -62,7 +62,7 @@ template <typename DataType, std::endian Desired>
 void run_test()
 {
     constexpr DataType iterations = 100;
-    const DataType step = std::numeric_limits<DataType>::max() / iterations;
+    DataType const step = std::numeric_limits<DataType>::max() / iterations;
 
     for (DataType data = 0, i = 0; i++ < iterations; data += step)
     {

--- a/test/types/string/classifier.cpp
+++ b/test/types/string/classifier.cpp
@@ -16,10 +16,10 @@ CATCH_TEMPLATE_TEST_CASE("BasicClassifier", "[string]", char, wchar_t, char8_t, 
 
     CATCH_SECTION("Get the size of a string-like type")
     {
-        const char_type *cstr = FLY_STR(char_type, "ten chars!");
+        char_type const *cstr = FLY_STR(char_type, "ten chars!");
         string_type str = cstr;
         view_type view = str;
-        const char_type arr[] = {'t', 'e', 'n', ' ', 'c', 'h', 'a', 'r', 's', '!'};
+        char_type const arr[] = {'t', 'e', 'n', ' ', 'c', 'h', 'a', 'r', 's', '!'};
 
         CATCH_CHECK(BasicString::size(cstr) == 10);
         CATCH_CHECK(BasicString::size(str) == 10);

--- a/test/types/string/converter.cpp
+++ b/test/types/string/converter.cpp
@@ -54,7 +54,7 @@ CATCH_TEMPLATE_TEST_CASE("Converter", "[string]", char, wchar_t, char8_t, char16
     using codepoint_type = typename BasicString::codepoint_type;
 
     auto out_of_range_codepoint = []() -> string_type {
-        static constexpr const codepoint_type s_out_of_range = 0x110000;
+        static constexpr codepoint_type s_out_of_range = 0x110000;
         string_type result;
 
         if constexpr (sizeof(char_type) == 1)
@@ -82,7 +82,7 @@ CATCH_TEMPLATE_TEST_CASE("Converter", "[string]", char, wchar_t, char8_t, char16
         string_type s = FLY_STR(char_type, "abc");
         CATCH_CHECK(BasicString::template convert<string_type>(s) == s);
 
-        const char_type *c = FLY_STR(char_type, "def");
+        char_type const *c = FLY_STR(char_type, "def");
         CATCH_CHECK(BasicString::template convert<string_type>(c) == c);
 
         char_type *d = const_cast<char_type *>(FLY_STR(char_type, "ghi"));
@@ -97,7 +97,7 @@ CATCH_TEMPLATE_TEST_CASE("Converter", "[string]", char, wchar_t, char8_t, char16
             CATCH_CHECK(BasicString::template convert<std::string>(test) == utf8);
         }
         {
-            const auto utf8 = FLY_STR(std::string::value_type, "\U0001f355 in the morning");
+            auto const utf8 = FLY_STR(std::string::value_type, "\U0001f355 in the morning");
             CATCH_CHECK(BasicString::template convert<std::string>(test) == utf8);
         }
         {
@@ -105,7 +105,7 @@ CATCH_TEMPLATE_TEST_CASE("Converter", "[string]", char, wchar_t, char8_t, char16
             CATCH_CHECK(BasicString::template convert<std::u8string>(test) == utf8);
         }
         {
-            const auto utf8 = FLY_STR(std::u8string::value_type, "\U0001f355 in the morning");
+            auto const utf8 = FLY_STR(std::u8string::value_type, "\U0001f355 in the morning");
             CATCH_CHECK(BasicString::template convert<std::u8string>(test) == utf8);
         }
 
@@ -122,7 +122,7 @@ CATCH_TEMPLATE_TEST_CASE("Converter", "[string]", char, wchar_t, char8_t, char16
             CATCH_CHECK(BasicString::template convert<std::u16string>(test) == utf16);
         }
         {
-            const auto utf16 = FLY_STR(std::u16string::value_type, "\U0001f355 in the morning");
+            auto const utf16 = FLY_STR(std::u16string::value_type, "\U0001f355 in the morning");
             CATCH_CHECK(BasicString::template convert<std::u16string>(test) == utf16);
         }
 
@@ -136,7 +136,7 @@ CATCH_TEMPLATE_TEST_CASE("Converter", "[string]", char, wchar_t, char8_t, char16
                 CATCH_CHECK(BasicString::template convert<std::wstring>(test) == utf16);
             }
             {
-                const auto utf16 = FLY_STR(std::wstring::value_type, "\U0001f355 in the morning");
+                auto const utf16 = FLY_STR(std::wstring::value_type, "\U0001f355 in the morning");
                 CATCH_CHECK(BasicString::template convert<std::wstring>(test) == utf16);
             }
 
@@ -153,7 +153,7 @@ CATCH_TEMPLATE_TEST_CASE("Converter", "[string]", char, wchar_t, char8_t, char16
             CATCH_CHECK(BasicString::template convert<std::u32string>(test) == utf32);
         }
         {
-            const auto utf32 = FLY_STR(std::u32string::value_type, "\U0001f355 in the morning");
+            auto const utf32 = FLY_STR(std::u32string::value_type, "\U0001f355 in the morning");
             CATCH_CHECK(BasicString::template convert<std::u32string>(test) == utf32);
         }
 
@@ -167,7 +167,7 @@ CATCH_TEMPLATE_TEST_CASE("Converter", "[string]", char, wchar_t, char8_t, char16
                 CATCH_CHECK(BasicString::template convert<std::wstring>(test) == utf32);
             }
             {
-                const auto utf32 = FLY_STR(std::wstring::value_type, "\U0001f355 in the morning");
+                auto const utf32 = FLY_STR(std::wstring::value_type, "\U0001f355 in the morning");
                 CATCH_CHECK(BasicString::template convert<std::wstring>(test) == utf32);
             }
 

--- a/test/types/string/format.cpp
+++ b/test/types/string/format.cpp
@@ -57,7 +57,7 @@ StringType reserved_codepoint()
 {
     using char_type = typename StringType::value_type;
 
-    static constexpr const std::uint32_t s_reserved = 0xd800;
+    static constexpr std::uint32_t s_reserved = 0xd800;
     StringType result;
 
     if constexpr (sizeof(char_type) == 1)
@@ -442,15 +442,15 @@ CATCH_TEMPLATE_TEST_CASE("Format", "[string]", char, wchar_t, char8_t, char16_t,
         test_format(FMT("{:.3s}"), FMT("abc"), FLY_STR(char16_t, "abcdef"));
         test_format(FMT("{:.3s}"), FMT("abc"), FLY_STR(char32_t, "abcdef"));
 
-        const char arr[] = {'a', 'b', 'c', 'd'};
+        char const arr[] = {'a', 'b', 'c', 'd'};
         test_format(FMT("{:.3s}"), FMT("abc"), arr);
-        const wchar_t warr[] = {L'a', L'b', L'c', L'd'};
+        wchar_t const warr[] = {L'a', L'b', L'c', L'd'};
         test_format(FMT("{:.3s}"), FMT("abc"), warr);
-        const char8_t arr8[] = {u8'a', u8'b', u8'c', u8'd'};
+        char8_t const arr8[] = {u8'a', u8'b', u8'c', u8'd'};
         test_format(FMT("{:.3s}"), FMT("abc"), arr8);
-        const char16_t arr16[] = {u'a', u'b', u'c', u'd'};
+        char16_t const arr16[] = {u'a', u'b', u'c', u'd'};
         test_format(FMT("{:.3s}"), FMT("abc"), arr16);
-        const char32_t arr32[] = {U'a', U'b', U'c', U'd'};
+        char32_t const arr32[] = {U'a', U'b', U'c', U'd'};
         test_format(FMT("{:.3s}"), FMT("abc"), arr32);
 
         test_format(FMT("{:.0s}"), FMT(""), FLY_STR(char_type, "a"));
@@ -499,7 +499,7 @@ CATCH_TEMPLATE_TEST_CASE("FormatTypes", "[string]", char, wchar_t, char8_t, char
             value = value.substr(2);
         }
 
-        for (const auto &ch : value)
+        for (auto const &ch : value)
         {
             if (!BasicString::is_x_digit(ch))
             {
@@ -548,15 +548,15 @@ CATCH_TEMPLATE_TEST_CASE("FormatTypes", "[string]", char, wchar_t, char8_t, char
         test_format(FMT("{:s}"), FMT("ab"), FLY_STR(char16_t, "ab"));
         test_format(FMT("{:s}"), FMT("ab"), FLY_STR(char32_t, "ab"));
 
-        const char arr[] = {'a', 'b'};
+        char const arr[] = {'a', 'b'};
         test_format(FMT("{:s}"), FMT("ab"), arr);
-        const wchar_t warr[] = {L'a', L'b'};
+        wchar_t const warr[] = {L'a', L'b'};
         test_format(FMT("{:s}"), FMT("ab"), warr);
-        const char8_t arr8[] = {u8'a', u8'b'};
+        char8_t const arr8[] = {u8'a', u8'b'};
         test_format(FMT("{:s}"), FMT("ab"), arr8);
-        const char16_t arr16[] = {u'a', u'b'};
+        char16_t const arr16[] = {u'a', u'b'};
         test_format(FMT("{:s}"), FMT("ab"), arr16);
-        const char32_t arr32[] = {U'a', U'b'};
+        char32_t const arr32[] = {U'a', U'b'};
         test_format(FMT("{:s}"), FMT("ab"), arr32);
 
         test_format(FMT("{:s}"), FMT("true"), true);
@@ -569,7 +569,7 @@ CATCH_TEMPLATE_TEST_CASE("FormatTypes", "[string]", char, wchar_t, char8_t, char
 
         int i = 0;
         void *p1 = &i;
-        const void *p2 = &i;
+        void const *p2 = &i;
 
         auto result = BasicString::format(FMT("{:p}"), p1);
         CATCH_CHECK(is_all_hex(result));
@@ -854,35 +854,35 @@ CATCH_TEMPLATE_TEST_CASE("FormatErrors", "[string]", char, wchar_t, char8_t, cha
     {
         if constexpr (!std::is_same_v<char_type, char>)
         {
-            const auto reserved = reserved_codepoint<std::string>();
+            auto const reserved = reserved_codepoint<std::string>();
             test_format(FMT("{}"), FMT(""), reserved);
             test_format(FMT("ab {} ab"), FMT("ab  ab"), reserved);
             test_format(FMT("ab {} ab"), FMT("ab  ab"), "ab" + reserved);
         }
         if constexpr (!std::is_same_v<char_type, wchar_t>)
         {
-            const auto reserved = reserved_codepoint<std::wstring>();
+            auto const reserved = reserved_codepoint<std::wstring>();
             test_format(FMT("{}"), FMT(""), reserved);
             test_format(FMT("ab {} ab"), FMT("ab  ab"), reserved);
             test_format(FMT("ab {} ab"), FMT("ab  ab"), L"ab" + reserved);
         }
         if constexpr (!std::is_same_v<char_type, char8_t>)
         {
-            const auto reserved = reserved_codepoint<std::u8string>();
+            auto const reserved = reserved_codepoint<std::u8string>();
             test_format(FMT("{}"), FMT(""), reserved);
             test_format(FMT("ab {} ab"), FMT("ab  ab"), reserved);
             test_format(FMT("ab {} ab"), FMT("ab  ab"), u8"ab" + reserved);
         }
         if constexpr (!std::is_same_v<char_type, char16_t>)
         {
-            const auto reserved = reserved_codepoint<std::u16string>();
+            auto const reserved = reserved_codepoint<std::u16string>();
             test_format(FMT("{}"), FMT(""), reserved);
             test_format(FMT("ab {} ab"), FMT("ab  ab"), reserved);
             test_format(FMT("ab {} ab"), FMT("ab  ab"), u"ab" + reserved);
         }
         if constexpr (!std::is_same_v<char_type, char32_t>)
         {
-            const auto reserved = reserved_codepoint<std::u32string>();
+            auto const reserved = reserved_codepoint<std::u32string>();
             test_format(FMT("{}"), FMT(""), reserved);
             test_format(FMT("ab {} ab"), FMT("ab  ab"), reserved);
             test_format(FMT("ab {} ab"), FMT("ab  ab"), U"ab" + reserved);

--- a/test/types/string/format_parameters.cpp
+++ b/test/types/string/format_parameters.cpp
@@ -24,7 +24,7 @@ template <typename CharType>
 struct fly::Formatter<UserDefinedType, CharType>
 {
     template <typename FormatContext>
-    void format(const UserDefinedType &, FormatContext &)
+    void format(UserDefinedType const &, FormatContext &)
     {
     }
 };
@@ -114,7 +114,7 @@ CATCH_TEMPLATE_TEST_CASE(
 
     CATCH_SECTION("String values are type-erased")
     {
-        const auto &arr = FLY_ARR(char_type, "str");
+        auto const &arr = FLY_ARR(char_type, "str");
         string_type str(FLY_STR(char_type, "str"));
 
         auto verify = [&str](auto value) {
@@ -122,7 +122,7 @@ CATCH_TEMPLATE_TEST_CASE(
 
             if constexpr (std::is_same_v<decltype(value), StringValue>)
             {
-                view_type view(static_cast<const char_type *>(value.m_value), value.m_size);
+                view_type view(static_cast<char_type const *>(value.m_value), value.m_size);
                 CATCH_CHECK(view == str);
                 CATCH_CHECK(value.m_format != nullptr);
             }
@@ -144,7 +144,7 @@ CATCH_TEMPLATE_TEST_CASE(
 
         std::nullptr_t p1 = nullptr;
         void *p2 = &i;
-        const void *p3 = &i;
+        void const *p3 = &i;
 
         auto params = fly::detail::make_format_parameters<FormatContext>(p1, p2, p3);
         FormatContext context(out, params);

--- a/test/types/string/format_string.cpp
+++ b/test/types/string/format_string.cpp
@@ -45,7 +45,7 @@ public:
         ++s_default_constructor_count;
     }
 
-    ConstructorCounter(const ConstructorCounter &)
+    ConstructorCounter(ConstructorCounter const &)
     {
         ++s_copy_constructor_count;
     }
@@ -84,16 +84,16 @@ private:
 };
 
 template <typename CharType, std::size_t N, typename... Types>
-FLY_CONSTEVAL auto make_format(const CharType (&format)[N], Types &&...)
+FLY_CONSTEVAL auto make_format(CharType const (&format)[N], Types &&...)
 {
     using FormatString = fly::detail::BasicFormatString<CharType, std::type_identity_t<Types>...>;
     return FormatString(format);
 }
 
 template <typename FormatStringType, typename... SpecifierType>
-void test_format(FormatStringType &&format, const SpecifierType &...specifiers)
+void test_format(FormatStringType &&format, SpecifierType const &...specifiers)
 {
-    [[maybe_unused]] auto equals = [&format](const auto &specifier) {
+    [[maybe_unused]] auto equals = [&format](auto const &specifier) {
         auto actual_specifier = format.next_specifier();
         CATCH_REQUIRE(actual_specifier);
         CATCH_CHECK(actual_specifier == specifier);
@@ -118,39 +118,39 @@ void test_error(FormatStringType &&format, std::string &&error)
 // Copies of all of the error messages that BasicFormatString might raise. Ideally, these could be
 // defined in a common header, but when FLY_CONSTEVAL evaluates to 'consteval', the error message
 // raised would not display in the compile error (the variable name or macro name would display).
-constexpr const char *s_unclosed_string = "Detected unclosed replacement field - must end with }";
-constexpr const char *s_unescaped_close = "Closing brace } must be escaped";
-constexpr const char *s_too_many_specifiers = "Exceeded maximum allowed number of specifiers";
-constexpr const char *s_bad_position = "Argument position exceeds number of provided arguments";
-constexpr const char *s_position_mismatch =
+constexpr char const *s_unclosed_string = "Detected unclosed replacement field - must end with }";
+constexpr char const *s_unescaped_close = "Closing brace } must be escaped";
+constexpr char const *s_too_many_specifiers = "Exceeded maximum allowed number of specifiers";
+constexpr char const *s_bad_position = "Argument position exceeds number of provided arguments";
+constexpr char const *s_position_mismatch =
     "Argument position must be provided on all or not on any specifier";
-constexpr const char *s_bad_fill = "Characters { and } are not allowed as fill characters";
-constexpr const char *s_non_ascii_fill = "Non-ascii characters are not allowed as fill characters";
-constexpr const char *s_bad_sign = "Sign may only be used with numeric presentation types";
-constexpr const char *s_bad_alternate_form =
+constexpr char const *s_bad_fill = "Characters { and } are not allowed as fill characters";
+constexpr char const *s_non_ascii_fill = "Non-ascii characters are not allowed as fill characters";
+constexpr char const *s_bad_sign = "Sign may only be used with numeric presentation types";
+constexpr char const *s_bad_alternate_form =
     "Alternate form may only be used with non-decimal numeric presentation types";
-constexpr const char *s_bad_zero_padding =
+constexpr char const *s_bad_zero_padding =
     "Zero-padding may only be used with numeric presentation types";
-constexpr const char *s_bad_width = "Width must be a positive (non-zero) value";
-constexpr const char *s_bad_width_position = "Position of width parameter must be an integral type";
-constexpr const char *s_missing_precision =
+constexpr char const *s_bad_width = "Width must be a positive (non-zero) value";
+constexpr char const *s_bad_width_position = "Position of width parameter must be an integral type";
+constexpr char const *s_missing_precision =
     "Expected a non-negative precision or nested replacement field after decimal";
-constexpr const char *s_bad_precision =
+constexpr char const *s_bad_precision =
     "Precision may only be used for string and floating-point types";
-constexpr const char *s_bad_precision_position =
+constexpr char const *s_bad_precision_position =
     "Position of precision parameter must be an integral type";
-constexpr const char *s_bad_locale =
+constexpr char const *s_bad_locale =
     "Locale-specific form may only be used for numeric and boolean types";
-constexpr const char *s_bad_user_defined =
+constexpr char const *s_bad_user_defined =
     "User-defined formatter without a parser may not have formatting options";
-constexpr const char *s_bad_character = "Character types must be formatted with {} or {:cbBodxX}";
-constexpr const char *s_bad_string = "String types must be formatted with {} or {:s}";
-constexpr const char *s_bad_pointer = "Pointer types must be formatted with {} or {:p}";
-constexpr const char *s_bad_integer =
+constexpr char const *s_bad_character = "Character types must be formatted with {} or {:cbBodxX}";
+constexpr char const *s_bad_string = "String types must be formatted with {} or {:s}";
+constexpr char const *s_bad_pointer = "Pointer types must be formatted with {} or {:p}";
+constexpr char const *s_bad_integer =
     "Integral types must be formatted with {} or one of {:cbBodxX}";
-constexpr const char *s_bad_float =
+constexpr char const *s_bad_float =
     "Floating-point types must be formatted with {} or one of {:aAeEfFgG}";
-constexpr const char *s_bad_bool = "Boolean types must be formatted with {} or one of {:csbBodxX}";
+constexpr char const *s_bad_bool = "Boolean types must be formatted with {} or one of {:csbBodxX}";
 
 #endif
 
@@ -230,14 +230,14 @@ CATCH_TEMPLATE_TEST_CASE(
     using char_type = TestType;
     using Specifier = fly::detail::BasicFormatSpecifier<char_type>;
 
-    constexpr const UserDefinedType u {};
-    constexpr const UserDefinedTypeWithParser up {};
-    constexpr const auto c = FLY_CHR(char_type, 'a');
-    constexpr const auto s = FLY_STR(char_type, "a");
-    constexpr const auto &a = FLY_ARR(char_type, "a");
-    constexpr const int i = 1;
-    constexpr const float f = 3.14f;
-    constexpr const bool b = true;
+    constexpr UserDefinedType u {};
+    constexpr UserDefinedTypeWithParser up {};
+    constexpr auto c = FLY_CHR(char_type, 'a');
+    constexpr auto s = FLY_STR(char_type, "a");
+    constexpr auto &a = FLY_ARR(char_type, "a");
+    constexpr int i = 1;
+    constexpr float f = 3.14f;
+    constexpr bool b = true;
 
     CATCH_SECTION("No specifiers are parsed from empty string")
     {
@@ -273,7 +273,7 @@ CATCH_TEMPLATE_TEST_CASE(
             1);
         CATCH_CHECK_FALSE(format.context().has_error());
 
-        const std::size_t specifiers_created = format.context().view().size() / 3;
+        std::size_t const specifiers_created = format.context().view().size() / 3;
         std::size_t specifiers_parsed = 0;
 
         while (format.next_specifier())
@@ -774,13 +774,13 @@ CATCH_TEMPLATE_TEST_CASE(
 {
     using char_type = TestType;
 
-    constexpr const UserDefinedType u {};
-    constexpr const UserDefinedTypeWithParserWhichFails upf {};
-    constexpr const auto c = FLY_CHR(char_type, 'a');
-    constexpr const auto s = FLY_STR(char_type, "a");
-    constexpr const int i = 1;
-    constexpr const float f = 3.14f;
-    constexpr const bool b = true;
+    constexpr UserDefinedType u {};
+    constexpr UserDefinedTypeWithParserWhichFails upf {};
+    constexpr auto c = FLY_CHR(char_type, 'a');
+    constexpr auto s = FLY_STR(char_type, "a");
+    constexpr int i = 1;
+    constexpr float f = 3.14f;
+    constexpr bool b = true;
 
     CATCH_SECTION("Cannot parse single opening brace")
     {
@@ -837,7 +837,7 @@ CATCH_TEMPLATE_TEST_CASE(
     CATCH_SECTION("Fill character must be ASCII")
     {
         {
-            constexpr const char_type fmt[] {
+            constexpr char_type const fmt[] {
                 static_cast<char_type>(0x7b), // {
                 static_cast<char_type>(0x3a), // :
                 static_cast<char_type>(0x80), // Non-ASCII
@@ -848,7 +848,7 @@ CATCH_TEMPLATE_TEST_CASE(
             test_error(make_format(fmt, 1), s_non_ascii_fill);
         }
         {
-            constexpr const char_type fmt[] {
+            constexpr char_type const fmt[] {
                 static_cast<char_type>(0x7b), // {
                 static_cast<char_type>(0x3a), // :
                 static_cast<char_type>(0xff), // Non-ASCII

--- a/test/types/string/lexer.cpp
+++ b/test/types/string/lexer.cpp
@@ -36,7 +36,7 @@ CATCH_TEMPLATE_TEST_CASE("BasicLexer", "[string]", char, wchar_t, char8_t, char1
 
     CATCH_SECTION("Lexer accepts non-null-terminated string")
     {
-        constexpr const char_type str[] {
+        constexpr char_type const str[] {
             static_cast<char_type>(0x61), // a
             static_cast<char_type>(0x62), // b
         };
@@ -51,7 +51,7 @@ CATCH_TEMPLATE_TEST_CASE("BasicLexer", "[string]", char, wchar_t, char8_t, char1
 
     CATCH_SECTION("Lexer accepts an already-existing string view")
     {
-        const char_type *str = FLY_STR(char_type, "ab");
+        char_type const *str = FLY_STR(char_type, "ab");
         auto view = std::basic_string_view<char_type>(str);
 
         Lexer lexer(view);

--- a/test/types/string/string.cpp
+++ b/test/types/string/string.cpp
@@ -14,7 +14,9 @@ template <typename CharType>
 class UserDefinedType
 {
 public:
-    UserDefinedType(std::basic_string_view<CharType> str, int num) noexcept : m_str(str), m_num(num)
+    UserDefinedType(std::basic_string_view<CharType> str, int num) noexcept :
+        m_str(str),
+        m_num(num)
     {
     }
 
@@ -39,7 +41,7 @@ template <typename CharType>
 struct fly::Formatter<UserDefinedType<CharType>, CharType>
 {
     template <typename FormatContext>
-    void format(const UserDefinedType<CharType> &value, FormatContext &context)
+    void format(UserDefinedType<CharType> const &value, FormatContext &context)
     {
         fly::BasicString<CharType>::format_to(
             context.out(),
@@ -67,13 +69,13 @@ CATCH_TEMPLATE_TEST_CASE("BasicString", "[string]", char, wchar_t, char8_t, char
 
         for (size_type i = 0; i < s_size; ++i)
         {
-            const string_type curr = BasicString::generate_random_string(10);
+            string_type const curr = BasicString::generate_random_string(10);
 
             input += curr + delim;
             input_split[i] = curr;
         }
 
-        const auto output_split = BasicString::split(input, delim);
+        auto const output_split = BasicString::split(input, delim);
         CATCH_CHECK(input_split.size() == output_split.size());
 
         for (size_type i = 0; i < s_size; ++i)
@@ -93,7 +95,7 @@ CATCH_TEMPLATE_TEST_CASE("BasicString", "[string]", char, wchar_t, char8_t, char
 
         for (size_type i = 0; i < s_size; ++i)
         {
-            const string_type curr = BasicString::generate_random_string(10);
+            string_type const curr = BasicString::generate_random_string(10);
             input += curr + delim;
 
             if (i < s_count)
@@ -107,7 +109,7 @@ CATCH_TEMPLATE_TEST_CASE("BasicString", "[string]", char, wchar_t, char8_t, char
             }
         }
 
-        const auto output_split = BasicString::split(input, delim, s_count);
+        auto const output_split = BasicString::split(input, delim, s_count);
         CATCH_CHECK(input_split.size() == output_split.size());
 
         for (size_type i = 0; i < s_count; ++i)
@@ -126,10 +128,10 @@ CATCH_TEMPLATE_TEST_CASE("BasicString", "[string]", char, wchar_t, char8_t, char
         string_type test6 = FLY_STR(char_type, " \n\t\r  a   c  \n\t\r ");
         string_type test7 = FLY_STR(char_type, " \n\t\r  a\n \tc  \n\t\r ");
 
-        const string_type expected1;
-        const string_type expected2 = FLY_STR(char_type, "abc");
-        const string_type expected3 = FLY_STR(char_type, "a   c");
-        const string_type expected4 = FLY_STR(char_type, "a\n \tc");
+        string_type const expected1;
+        string_type const expected2 = FLY_STR(char_type, "abc");
+        string_type const expected3 = FLY_STR(char_type, "a   c");
+        string_type const expected4 = FLY_STR(char_type, "a\n \tc");
 
         BasicString::trim(test1);
         BasicString::trim(test2);
@@ -151,8 +153,8 @@ CATCH_TEMPLATE_TEST_CASE("BasicString", "[string]", char, wchar_t, char8_t, char
     CATCH_SECTION("Replace all instances of a substring in a string with a character")
     {
         string_type source = FLY_STR(char_type, "To Be Replaced! To Be Replaced!");
-        const string_type search = FLY_STR(char_type, "Be Replaced");
-        const char_type replace('x');
+        string_type const search = FLY_STR(char_type, "Be Replaced");
+        char_type const replace('x');
 
         BasicString::replace_all(source, search, replace);
         CATCH_CHECK(source == FLY_STR(char_type, "To x! To x!"));
@@ -161,8 +163,8 @@ CATCH_TEMPLATE_TEST_CASE("BasicString", "[string]", char, wchar_t, char8_t, char
     CATCH_SECTION("Replace all instances of a substring in a string with another string")
     {
         string_type source = FLY_STR(char_type, "To Be Replaced! To Be Replaced!");
-        const string_type search = FLY_STR(char_type, "Be Replaced");
-        const string_type replace = FLY_STR(char_type, "new value");
+        string_type const search = FLY_STR(char_type, "Be Replaced");
+        string_type const replace = FLY_STR(char_type, "new value");
 
         BasicString::replace_all(source, search, replace);
         CATCH_CHECK(source == FLY_STR(char_type, "To new value! To new value!"));
@@ -171,7 +173,7 @@ CATCH_TEMPLATE_TEST_CASE("BasicString", "[string]", char, wchar_t, char8_t, char
     CATCH_SECTION("Replace all instances of a substring in a string with an empty string")
     {
         string_type source = FLY_STR(char_type, "To Be Replaced! To Be Replaced!");
-        const string_type replace = FLY_STR(char_type, "new value");
+        string_type const replace = FLY_STR(char_type, "new value");
 
         BasicString::replace_all(source, string_type(), replace);
         CATCH_CHECK(source == FLY_STR(char_type, "To Be Replaced! To Be Replaced!"));
@@ -180,7 +182,7 @@ CATCH_TEMPLATE_TEST_CASE("BasicString", "[string]", char, wchar_t, char8_t, char
     CATCH_SECTION("Remove all instances of a substring in a string")
     {
         string_type source = FLY_STR(char_type, "To Be Replaced! To Be Replaced!");
-        const string_type search = FLY_STR(char_type, "Be Rep");
+        string_type const search = FLY_STR(char_type, "Be Rep");
 
         BasicString::remove_all(source, search);
         CATCH_CHECK(source == FLY_STR(char_type, "To laced! To laced!"));
@@ -283,18 +285,18 @@ CATCH_TEMPLATE_TEST_CASE("BasicString", "[string]", char, wchar_t, char8_t, char
     {
         static constexpr size_type s_size = (1 << 10);
 
-        const auto random = BasicString::generate_random_string(s_size);
+        auto const random = BasicString::generate_random_string(s_size);
         CATCH_CHECK(s_size == random.size());
     }
 
     CATCH_SECTION("Join generic types by a delimeter")
     {
         string_type str = FLY_STR(char_type, "a");
-        const char_type *ctr = FLY_STR(char_type, "b");
-        const char_type arr[] = {'c', '\0'};
-        const char_type chr = 'd';
+        char_type const *ctr = FLY_STR(char_type, "b");
+        char_type const arr[] = {'c', '\0'};
+        char_type const chr = 'd';
 
-        const UserDefinedType<char_type> obj(FLY_STR(char_type, "hi"), 0xbeef);
+        UserDefinedType<char_type> const obj(FLY_STR(char_type, "hi"), 0xbeef);
 
         CATCH_CHECK(FLY_STR(char_type, "a") == BasicString::join('.', str));
         CATCH_CHECK(FLY_STR(char_type, "b") == BasicString::join('.', ctr));

--- a/test/types/string/string_concepts.cpp
+++ b/test/types/string/string_concepts.cpp
@@ -8,37 +8,37 @@
 namespace {
 
 template <fly::StandardString T>
-constexpr bool is_supported_string(const T &)
+constexpr bool is_supported_string(T const &)
 {
     return true;
 }
 
 template <typename T>
-constexpr bool is_supported_string(const T &) requires(!fly::StandardString<T>)
+constexpr bool is_supported_string(T const &) requires(!fly::StandardString<T>)
 {
     return false;
 }
 
 template <fly::StandardCharacter T>
-constexpr bool is_supported_character(const T &)
+constexpr bool is_supported_character(T const &)
 {
     return true;
 }
 
 template <typename T>
-constexpr bool is_supported_character(const T &) requires(!fly::StandardCharacter<T>)
+constexpr bool is_supported_character(T const &) requires(!fly::StandardCharacter<T>)
 {
     return false;
 }
 
 template <fly::StandardStringLike T>
-constexpr bool is_like_supported_string(const T &)
+constexpr bool is_like_supported_string(T const &)
 {
     return true;
 }
 
 template <typename T>
-constexpr bool is_like_supported_string(const T &) requires(!fly::StandardStringLike<T>)
+constexpr bool is_like_supported_string(T const &) requires(!fly::StandardStringLike<T>)
 {
     return false;
 }
@@ -66,55 +66,45 @@ CATCH_TEMPLATE_TEST_CASE(
         CATCH_SECTION("Plain data types")
         {
             CATCH_CHECK_FALSE(fly::StandardString<int>);
-            CATCH_CHECK_FALSE(fly::StandardString<const int>);
             CATCH_CHECK_FALSE(fly::StandardString<int const>);
 
             CATCH_CHECK_FALSE(fly::StandardString<char_type>);
-            CATCH_CHECK_FALSE(fly::StandardString<const char_type>);
             CATCH_CHECK_FALSE(fly::StandardString<char_type const>);
 
             CATCH_CHECK_FALSE(fly::StandardString<char_type &>);
-            CATCH_CHECK_FALSE(fly::StandardString<const char_type &>);
             CATCH_CHECK_FALSE(fly::StandardString<char_type const &>);
         }
 
         CATCH_SECTION("C-string types")
         {
             CATCH_CHECK_FALSE(fly::StandardString<char_type *>);
-            CATCH_CHECK_FALSE(fly::StandardString<const char_type *>);
             CATCH_CHECK_FALSE(fly::StandardString<char_type const *>);
         }
 
         CATCH_SECTION("C++-string types")
         {
             CATCH_CHECK(fly::StandardString<string_type>);
-            CATCH_CHECK(fly::StandardString<const string_type>);
             CATCH_CHECK(fly::StandardString<string_type const>);
 
             CATCH_CHECK_FALSE(fly::StandardString<view_type>);
-            CATCH_CHECK_FALSE(fly::StandardString<const view_type>);
             CATCH_CHECK_FALSE(fly::StandardString<view_type const>);
         }
 
         CATCH_SECTION("C++-string type references")
         {
             CATCH_CHECK(fly::StandardString<string_type &>);
-            CATCH_CHECK(fly::StandardString<const string_type &>);
             CATCH_CHECK(fly::StandardString<string_type const &>);
 
             CATCH_CHECK_FALSE(fly::StandardString<view_type &>);
-            CATCH_CHECK_FALSE(fly::StandardString<const view_type &>);
             CATCH_CHECK_FALSE(fly::StandardString<view_type const &>);
         }
 
         CATCH_SECTION("C++-string type pointers")
         {
             CATCH_CHECK_FALSE(fly::StandardString<string_type *>);
-            CATCH_CHECK_FALSE(fly::StandardString<const string_type *>);
             CATCH_CHECK_FALSE(fly::StandardString<string_type const *>);
 
             CATCH_CHECK_FALSE(fly::StandardString<view_type *>);
-            CATCH_CHECK_FALSE(fly::StandardString<const view_type *>);
             CATCH_CHECK_FALSE(fly::StandardString<view_type const *>);
         }
     }
@@ -124,55 +114,45 @@ CATCH_TEMPLATE_TEST_CASE(
         CATCH_SECTION("Plain data types")
         {
             CATCH_CHECK_FALSE(fly::StandardCharacter<int>);
-            CATCH_CHECK_FALSE(fly::StandardCharacter<const int>);
             CATCH_CHECK_FALSE(fly::StandardCharacter<int const>);
 
             CATCH_CHECK(fly::StandardCharacter<char_type>);
-            CATCH_CHECK(fly::StandardCharacter<const char_type>);
             CATCH_CHECK(fly::StandardCharacter<char_type const>);
 
             CATCH_CHECK(fly::StandardCharacter<char_type &>);
-            CATCH_CHECK(fly::StandardCharacter<const char_type &>);
             CATCH_CHECK(fly::StandardCharacter<char_type const &>);
         }
 
         CATCH_SECTION("C-string types")
         {
             CATCH_CHECK_FALSE(fly::StandardCharacter<char_type *>);
-            CATCH_CHECK_FALSE(fly::StandardCharacter<const char_type *>);
             CATCH_CHECK_FALSE(fly::StandardCharacter<char_type const *>);
         }
 
         CATCH_SECTION("C++-string types")
         {
             CATCH_CHECK_FALSE(fly::StandardCharacter<string_type>);
-            CATCH_CHECK_FALSE(fly::StandardCharacter<const string_type>);
             CATCH_CHECK_FALSE(fly::StandardCharacter<string_type const>);
 
             CATCH_CHECK_FALSE(fly::StandardString<view_type>);
-            CATCH_CHECK_FALSE(fly::StandardString<const view_type>);
             CATCH_CHECK_FALSE(fly::StandardString<view_type const>);
         }
 
         CATCH_SECTION("C++-string type references")
         {
             CATCH_CHECK_FALSE(fly::StandardCharacter<string_type &>);
-            CATCH_CHECK_FALSE(fly::StandardCharacter<const string_type &>);
             CATCH_CHECK_FALSE(fly::StandardCharacter<string_type const &>);
 
             CATCH_CHECK_FALSE(fly::StandardString<view_type &>);
-            CATCH_CHECK_FALSE(fly::StandardString<const view_type &>);
             CATCH_CHECK_FALSE(fly::StandardString<view_type const &>);
         }
 
         CATCH_SECTION("C++-string type pointers")
         {
             CATCH_CHECK_FALSE(fly::StandardCharacter<string_type *>);
-            CATCH_CHECK_FALSE(fly::StandardCharacter<const string_type *>);
             CATCH_CHECK_FALSE(fly::StandardCharacter<string_type const *>);
 
             CATCH_CHECK_FALSE(fly::StandardString<view_type *>);
-            CATCH_CHECK_FALSE(fly::StandardString<const view_type *>);
             CATCH_CHECK_FALSE(fly::StandardString<view_type const *>);
         }
     }
@@ -182,67 +162,54 @@ CATCH_TEMPLATE_TEST_CASE(
         CATCH_SECTION("Plain data types")
         {
             CATCH_CHECK_FALSE(fly::StandardStringLike<int>);
-            CATCH_CHECK_FALSE(fly::StandardStringLike<const int>);
             CATCH_CHECK_FALSE(fly::StandardStringLike<int const>);
 
             CATCH_CHECK_FALSE(fly::StandardStringLike<char_type>);
-            CATCH_CHECK_FALSE(fly::StandardStringLike<const char_type>);
             CATCH_CHECK_FALSE(fly::StandardStringLike<char_type const>);
 
             CATCH_CHECK_FALSE(fly::StandardStringLike<char_type &>);
-            CATCH_CHECK_FALSE(fly::StandardStringLike<const char_type &>);
             CATCH_CHECK_FALSE(fly::StandardStringLike<char_type const &>);
         }
 
         CATCH_SECTION("C-string types")
         {
             CATCH_CHECK(fly::StandardStringLike<char_type *>);
-            CATCH_CHECK(fly::StandardStringLike<const char_type *>);
             CATCH_CHECK(fly::StandardStringLike<char_type const *>);
 
             CATCH_CHECK(fly::SameAs<fly::StandardStringType<char_type *>, string_type>);
-            CATCH_CHECK(fly::SameAs<fly::StandardStringType<const char_type *>, string_type>);
             CATCH_CHECK(fly::SameAs<fly::StandardStringType<char_type const *>, string_type>);
         }
 
         CATCH_SECTION("C++-string types")
         {
             CATCH_CHECK(fly::StandardStringLike<string_type>);
-            CATCH_CHECK(fly::StandardStringLike<const string_type>);
             CATCH_CHECK(fly::StandardStringLike<string_type const>);
 
             CATCH_CHECK(fly::SameAs<fly::StandardStringType<string_type>, string_type>);
-            CATCH_CHECK(fly::SameAs<fly::StandardStringType<const string_type>, string_type>);
             CATCH_CHECK(fly::SameAs<fly::StandardStringType<string_type const>, string_type>);
 
             CATCH_CHECK(fly::StandardStringLike<view_type>);
-            CATCH_CHECK(fly::StandardStringLike<const view_type>);
             CATCH_CHECK(fly::StandardStringLike<view_type const>);
         }
 
         CATCH_SECTION("C++-string type references")
         {
             CATCH_CHECK(fly::StandardStringLike<string_type &>);
-            CATCH_CHECK(fly::StandardStringLike<const string_type &>);
             CATCH_CHECK(fly::StandardStringLike<string_type const &>);
 
             CATCH_CHECK(fly::SameAs<fly::StandardStringType<string_type &>, string_type>);
-            CATCH_CHECK(fly::SameAs<fly::StandardStringType<const string_type &>, string_type>);
             CATCH_CHECK(fly::SameAs<fly::StandardStringType<string_type const &>, string_type>);
 
             CATCH_CHECK(fly::StandardStringLike<view_type &>);
-            CATCH_CHECK(fly::StandardStringLike<const view_type &>);
             CATCH_CHECK(fly::StandardStringLike<view_type const &>);
         }
 
         CATCH_SECTION("C++-string type pointers")
         {
             CATCH_CHECK_FALSE(fly::StandardStringLike<string_type *>);
-            CATCH_CHECK_FALSE(fly::StandardStringLike<const string_type *>);
             CATCH_CHECK_FALSE(fly::StandardStringLike<string_type const *>);
 
             CATCH_CHECK_FALSE(fly::StandardStringLike<view_type *>);
-            CATCH_CHECK_FALSE(fly::StandardStringLike<const view_type *>);
             CATCH_CHECK_FALSE(fly::StandardStringLike<view_type const *>);
         }
     }

--- a/test/types/string/unicode.cpp
+++ b/test/types/string/unicode.cpp
@@ -36,7 +36,7 @@ CATCH_TEMPLATE_TEST_CASE("BasicUnicode", "[string]", char, wchar_t, char8_t, cha
         CATCH_CAPTURE(line);
 
         auto begin = test.cbegin();
-        const auto end = test.cend();
+        auto const end = test.cend();
 
         CATCH_CHECK_FALSE(BasicString::validate(test));
         CATCH_CHECK_FALSE(BasicString::escape_codepoint(begin, end));
@@ -53,7 +53,7 @@ CATCH_TEMPLATE_TEST_CASE("BasicUnicode", "[string]", char, wchar_t, char8_t, cha
         CATCH_CAPTURE(line);
 
         auto begin = test.cbegin();
-        const auto end = test.cend();
+        auto const end = test.cend();
 
         CATCH_CHECK_FALSE(BasicString::unescape_codepoint(begin, end));
 
@@ -69,7 +69,7 @@ CATCH_TEMPLATE_TEST_CASE("BasicUnicode", "[string]", char, wchar_t, char8_t, cha
         std::optional<string_type> actual;
 
         auto begin = test.cbegin();
-        const auto end = test.cend();
+        auto const end = test.cend();
 
         CATCH_CHECK(BasicString::validate(test));
         CATCH_CHECK_FALSE(BasicString::decode_codepoint(begin, end));
@@ -92,7 +92,7 @@ CATCH_TEMPLATE_TEST_CASE("BasicUnicode", "[string]", char, wchar_t, char8_t, cha
         string_type test;
 
         auto begin = test.cend();
-        const auto end = test.cend();
+        auto const end = test.cend();
 
         CATCH_CHECK_FALSE(BasicString::decode_codepoint(begin, end));
         CATCH_CHECK_FALSE(BasicString::escape_codepoint(begin, end));
@@ -122,7 +122,7 @@ CATCH_TEMPLATE_TEST_CASE("BasicUnicode", "[string]", char, wchar_t, char8_t, cha
             // UTF-32 encoding really only fails if there is no data.
             string_type test;
             auto begin = test.cend();
-            const auto end = test.cend();
+            auto const end = test.cend();
 
             CATCH_CHECK_FALSE(BasicString::escape_codepoint(begin, end));
         }
@@ -159,7 +159,7 @@ CATCH_TEMPLATE_TEST_CASE("BasicUnicode", "[string]", char, wchar_t, char8_t, cha
                 string_type test = make_string({0xff});
 
                 auto begin = test.cbegin();
-                const auto end = test.cend();
+                auto const end = test.cend();
 
                 CATCH_CHECK_FALSE(BasicString::validate(test));
                 CATCH_CHECK_FALSE(BasicString::escape_codepoint(begin, end));
@@ -295,7 +295,7 @@ CATCH_TEMPLATE_TEST_CASE("BasicUnicode", "[string]", char, wchar_t, char8_t, cha
         auto encoded_to = [&](codepoint_type ch, string_type &&expected) {
             CATCH_CAPTURE(ch);
 
-            const string_type test = make_string({ch});
+            string_type const test = make_string({ch});
             std::optional<string_type> actual;
 
             CATCH_CHECK(BasicString::validate(test));
@@ -305,7 +305,7 @@ CATCH_TEMPLATE_TEST_CASE("BasicUnicode", "[string]", char, wchar_t, char8_t, cha
 
             {
                 auto begin = test.cbegin();
-                const auto end = test.cend();
+                auto const end = test.cend();
 
                 actual = BasicString::template escape_codepoint<'u'>(begin, end);
                 CATCH_CHECK(actual == expected);
@@ -315,7 +315,7 @@ CATCH_TEMPLATE_TEST_CASE("BasicUnicode", "[string]", char, wchar_t, char8_t, cha
             }
             {
                 auto begin = test.cbegin();
-                const auto end = test.cend();
+                auto const end = test.cend();
 
                 actual = BasicString::template escape_codepoint<'U'>(begin, end);
                 CATCH_CHECK(actual == expected);
@@ -356,7 +356,7 @@ CATCH_TEMPLATE_TEST_CASE("BasicUnicode", "[string]", char, wchar_t, char8_t, cha
                 CATCH_CHECK(BasicString::validate(expected));
 
                 auto begin = test.cbegin();
-                const auto end = test.cend();
+                auto const end = test.cend();
                 CATCH_CAPTURE(std::distance(begin, end));
 
                 std::optional<string_type> actual;
@@ -481,7 +481,7 @@ CATCH_TEMPLATE_TEST_CASE("BasicUnicode", "[string]", char, wchar_t, char8_t, cha
             CATCH_CHECK(BasicString::validate(expected));
 
             auto begin = test.cbegin();
-            const auto end = test.cend();
+            auto const end = test.cend();
 
             std::optional<string_type> actual;
 
@@ -564,7 +564,7 @@ CATCH_TEMPLATE_TEST_CASE("BasicUnicode", "[string]", char, wchar_t, char8_t, cha
                     CATCH_CHECK(BasicString::validate(test));
 
                     auto it = test.cbegin();
-                    const auto end = test.cend();
+                    auto const end = test.cend();
 
                     std::optional<codepoint_type> actual = BasicString::decode_codepoint(it, end);
                     CATCH_CHECK(actual == expected);
@@ -581,7 +581,7 @@ CATCH_TEMPLATE_TEST_CASE("BasicUnicode", "[string]", char, wchar_t, char8_t, cha
                 std::size_t index = 0;
 
                 auto it = test.cbegin();
-                const auto end = test.cend();
+                auto const end = test.cend();
 
                 for (; (it != end) && (index < expected.size()); ++index)
                 {
@@ -600,7 +600,7 @@ CATCH_TEMPLATE_TEST_CASE("BasicUnicode", "[string]", char, wchar_t, char8_t, cha
 
                     CATCH_CHECK_FALSE(BasicString::validate(test));
 
-                    const auto end = test.cend();
+                    auto const end = test.cend();
                     std::size_t actual = 0;
 
                     for (auto it = test.cbegin(); it != end;)

--- a/test/util/path_util.cpp
+++ b/test/util/path_util.cpp
@@ -39,7 +39,7 @@ std::filesystem::path PathUtil::ScopedTempDirectory::file() const
 }
 
 //==================================================================================================
-bool PathUtil::write_file(const std::filesystem::path &path, const std::string &contents)
+bool PathUtil::write_file(std::filesystem::path const &path, std::string const &contents)
 {
     std::ofstream stream(path, std::ios::out);
 
@@ -52,7 +52,7 @@ bool PathUtil::write_file(const std::filesystem::path &path, const std::string &
 }
 
 //==================================================================================================
-std::string PathUtil::read_file(const std::filesystem::path &path)
+std::string PathUtil::read_file(std::filesystem::path const &path)
 {
     std::ifstream stream(path, std::ios::in);
     std::stringstream sstream;
@@ -66,7 +66,7 @@ std::string PathUtil::read_file(const std::filesystem::path &path)
 }
 
 //==================================================================================================
-bool PathUtil::compare_files(const std::filesystem::path &path1, const std::filesystem::path &path2)
+bool PathUtil::compare_files(std::filesystem::path const &path1, std::filesystem::path const &path2)
 {
     if (std::filesystem::file_size(path1) != std::filesystem::file_size(path2))
     {

--- a/test/util/path_util.hpp
+++ b/test/util/path_util.hpp
@@ -43,8 +43,8 @@ public:
         std::filesystem::path file() const;
 
     private:
-        ScopedTempDirectory(const ScopedTempDirectory &) = delete;
-        ScopedTempDirectory &operator=(const ScopedTempDirectory &) = delete;
+        ScopedTempDirectory(ScopedTempDirectory const &) = delete;
+        ScopedTempDirectory &operator=(ScopedTempDirectory const &) = delete;
 
         std::filesystem::path m_directory;
     };
@@ -58,7 +58,7 @@ public:
      *
      * @return True if the file was correctly created.
      */
-    static bool write_file(const std::filesystem::path &path, const std::string &contents);
+    static bool write_file(std::filesystem::path const &path, std::string const &contents);
 
     /**
      * Read the contents of a file.
@@ -67,7 +67,7 @@ public:
      *
      * @return Contents of the file.
      */
-    static std::string read_file(const std::filesystem::path &path);
+    static std::string read_file(std::filesystem::path const &path);
 
     /**
      * Compare two files for equality. Two files are equal if they have the same size and the same
@@ -79,7 +79,7 @@ public:
      * @return True if the given files are equal.
      */
     static bool
-    compare_files(const std::filesystem::path &path1, const std::filesystem::path &path2);
+    compare_files(std::filesystem::path const &path1, std::filesystem::path const &path2);
 };
 
 } // namespace fly::test

--- a/test/util/task_manager.cpp
+++ b/test/util/task_manager.cpp
@@ -32,7 +32,8 @@ namespace {
         }
 
     private:
-        ScopedTaskManager() : m_task_manager(fly::task::TaskManager::create(s_num_workers))
+        ScopedTaskManager() :
+            m_task_manager(fly::task::TaskManager::create(s_num_workers))
         {
             CATCH_REQUIRE(m_task_manager);
         }
@@ -40,7 +41,7 @@ namespace {
         ~ScopedTaskManager()
         {
             // Cannot wrap with CATCH_REQUIRE because the Catch2 framework will have been torn down.
-            const bool stopped = m_task_manager->stop();
+            bool const stopped = m_task_manager->stop();
 
 #if defined(NDEBUG)
             FLY_UNUSED(stopped);

--- a/test/util/waitable_task_runner.cpp
+++ b/test/util/waitable_task_runner.cpp
@@ -11,7 +11,7 @@ void WaitableTaskRunner::task_complete(fly::task::TaskLocation &&location)
 }
 
 //==================================================================================================
-void WaitableTaskRunner::wait_for_task_to_complete(const std::string &location)
+void WaitableTaskRunner::wait_for_task_to_complete(std::string const &location)
 {
     std::string completed_location;
 

--- a/test/util/waitable_task_runner.hpp
+++ b/test/util/waitable_task_runner.hpp
@@ -35,7 +35,7 @@ public:
      *
      * @param location The location to wait upon.
      */
-    void wait_for_task_to_complete(const std::string &location);
+    void wait_for_task_to_complete(std::string const &location);
 
 protected:
     /**


### PR DESCRIPTION
Namely:
1. All constructor initializers are on their own line always.
2. Switch to using east-const.

There are likely instances of (2) which aren't caught here as
clang-format isn't perfect with this option yet. Many of these were
manual.