### PR TITLE
Remove usage of std::find_if from string formatting

### DIFF
--- a/fly/types/string/detail/format_specifier.hpp
+++ b/fly/types/string/detail/format_specifier.hpp
@@ -925,16 +925,15 @@ BasicFormatSpecifier<CharType>::resolve_parameter_type(FormatParseContext &conte
 template <fly::StandardCharacter CharType>
 constexpr auto BasicFormatSpecifier<CharType>::type_of(CharType ch) -> std::optional<Type>
 {
-    auto it = std::find_if(s_type_map.begin(), s_type_map.end(), [&ch](auto const &item) {
-        return item.first == ch;
-    });
-
-    if (it == s_type_map.end())
+    for (auto it = s_type_map.begin(); it != s_type_map.end(); ++it)
     {
-        return std::nullopt;
+        if (it->first == ch)
+        {
+            return it->second;
+        }
     }
 
-    return it->second;
+    return std::nullopt;
 }
 
 //==================================================================================================

--- a/fly/types/string/detail/unicode.hpp
+++ b/fly/types/string/detail/unicode.hpp
@@ -604,12 +604,15 @@ auto BasicUnicode<CharType>::codepoint_from_string(IteratorType &it, IteratorTyp
     codepoint_type const leading_byte = next_encoded_byte(it, end);
 
     // First find the codepoint length by finding which leading byte matches the first encoded byte.
-    auto utf8_it = std::find_if(
-        s_utf8_leading_bytes.begin(),
-        s_utf8_leading_bytes.end(),
-        [&leading_byte](auto const &candidate) {
-            return (leading_byte & candidate.m_encoding_mask) == candidate.m_leading_byte;
-        });
+    auto utf8_it = s_utf8_leading_bytes.begin();
+
+    for (; utf8_it != s_utf8_leading_bytes.end(); ++utf8_it)
+    {
+        if ((leading_byte & utf8_it->m_encoding_mask) == utf8_it->m_leading_byte)
+        {
+            break;
+        }
+    }
 
     if (utf8_it == s_utf8_leading_bytes.end())
     {


### PR DESCRIPTION
Recent clang builds fail due to a missing `#include <algorithm>` before
usage of std::find_if. Rather than introducing this heavy header for
string formatting, replace those usages with plain for-loops.