### PR TITLE
Update flymake to 1.11.0

### DIFF
--- a/build/ci/Dockerfile
+++ b/build/ci/Dockerfile
@@ -43,7 +43,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
         llvm-$CLANG_VERSION \
     && \
     \
-    for tool in clang clang++ lld llvm-ar llvm-cov llvm-profdata llvm-strip; \
+    for tool in clang clang++ ld.lld lld llvm-ar llvm-cov llvm-profdata llvm-strip; \
     do \
         update-alternatives --install \
             /usr/bin/$tool $tool /usr/bin/$tool-$CLANG_VERSION 1; \


### PR DESCRIPTION
Switches to using the LLVM linker by default on Linux, which is up to 3x
faster than gold.